### PR TITLE
PR2: Path-safe vault storage service and bounded reindex

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,9 +1,8 @@
 # Backlog
 
-Follow the ordered PR sequence in the authoritative spec. PR1 deliberately defers all behavior built on top of the data model:
+Follow the ordered PR sequence in the authoritative spec. PR2 delivers vault storage only; later PRs remain deferred:
 
-- PR2: path-safe vault reads/writes, front-matter handling, incremental projection updates, and reconcile.
-- PR3: wikilink parsing, resolution, and backlinks.
+- PR3: wikilink parsing, resolution, and backlinks (`note_links` projection).
 - PR4: the MySQL `FULLTEXT` index, query behavior, ranking, snippets, and search endpoint.
 - PR5–PR9: notes CRUD, UI/rendering, auth providers, attachment upload, and deployment hardening.
 - v1+: WebDAV, publishing, graph view, GrandpaSSOn/TaskConnect integrations, AI retrieval/MCP, and all other post-v0 work.
@@ -11,11 +10,12 @@ Follow the ordered PR sequence in the authoritative spec. PR1 deliberately defer
 ## Specification decisions and open items
 
 - Q1 default adopted: nullable `notes.search_content` is a rebuildable search projection; disk Markdown remains canonical. Creating its `FULLTEXT` index and implementing search remain deferred to PR4.
+- Q4 default adopted: nested folders are allowed within each workspace vault; every path is canonicalized and must resolve inside the workspace root before filesystem access.
 - TODO(spec: Q2): Confirm `league/commonmark` plus a custom `[[ ]]` inline parser.
 - TODO(spec: Q3): Confirm sanitizing Markdown both server-side and with DOMPurify in the SPA.
-- TODO(spec: Q4): Confirm nested folders within each workspace vault, guarded by canonical path validation.
 - TODO(spec: Q5): Confirm local sessions only in v0, with GrandpaSSOn limited to a later stub interface.
 - TODO(spec: Q6): Confirm `jt` as the development verb prefix for `scripts/jt.sh` and `scripts/jt.ps1`.
+- TODO(spec: PR3): Extract and project `[[wikilinks]]` into `note_links` on write/reindex; PR2 intentionally leaves link columns untouched.
 - TODO(spec: Before PR7, define the final audit event vocabulary, required actor/request context, metadata redaction rules, access controls, and retention/deletion contract. The initial columns are structural only; security details must not be guessed.)
 - TODO(spec: Before PR7, choose portable database-level append-only enforcement for `audit_log`; PR1 model guards do not cover query-builder or direct-SQL writes.)
 - TODO(spec: PR3/PR5 must reject cross-workspace note-link and note-tag associations in application services; the §5 link/pivot shapes do not carry workspace keys for composite database enforcement.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ All notable changes to Jotter will be documented here.
 - Multi-workspace tenant, workspace, note-index, link, tag, attachment, identity, membership, and audit data model
 - Idempotent default tenant/workspace seeding with a configured on-disk vault path
 - Rebuildable note search projection while Markdown files remain canonical
+- Path-safe workspace vault storage service for Markdown read/write
+- YAML front-matter parsing into the notes projection with incremental tag updates
+- Bounded `vault:reindex` Artisan reconcile command for out-of-band disk edits
+- Production Composer dependency on `symfony/yaml` for front-matter handling

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Self-hosted, Markdown knowledge base for the cPanel your grandpa never gave up. Plain `.md` files, PHP + MySQL, your notes stay yours.
 
-Jotter currently contains the PR0 application scaffold: Laravel 12, a minimal Vue 3 landing screen, MySQL 8, a Docker-only development loop, tests, and shared-hosting release packaging. Note, vault, search, attachment, and identity-provider features are intentionally not part of this scaffold.
+Jotter currently ships through PR2: Laravel 12, a minimal Vue 3 landing screen, MySQL 8, a Docker-only development loop, the multi-workspace data model, and a path-safe vault storage service that keeps Markdown files on disk as the source of truth. Search endpoints, notes CRUD APIs, wikilinks/backlinks, attachment upload, and identity-provider features remain later PRs.
 
 ## Requirements
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,16 +11,24 @@
 - Shared-hosting release zip, checksum, and artifact secret test
 - CI workflow and baseline documentation
 
-## In progress — PR1 data model
+## Done — PR1 data model
 
 - Idempotent initial tenant/workspace projection and state schema
 - Focused Eloquent models and relationships
 - Configured, repeat-safe default tenant/workspace seeding without users or credentials
 - Data-model, scoping, relationship, and seeder feature tests
 - Schema/projection documentation
+- Merged to `main` with green Docker CI
 
-Docker CI is green for the MySQL 8 migration and model tests, frontend tests, Playwright smoke path, release build/checksum, and release secret scan.
+## In progress — PR2 vault storage
 
-## Next — PR2 vault storage
+- Path-safe vault Markdown read/write rooted at each workspace `vault_path`
+- Symfony YAML front-matter parsing into the rebuildable `notes` projection
+- Incremental projection updates on write (path, title, frontmatter, content_hash, search_content, tags)
+- Bounded `vault:reindex --workspace=<id>` reconcile for out-of-band disk edits
+- Path-traversal rejection with audit coverage (§7.1 / §8 S2)
+- Wikilink / `note_links` extraction left as explicit PR3 TODO
 
-After PR1 is reviewed, merged, and green, implement the path-safe disk Markdown storage service and incremental projection updates from §7.1. Do not begin PR2 as part of PR1.
+## Next — PR3 links & backlinks
+
+After PR2 is reviewed, merged, and green, implement wikilink parsing, resolution, and backlinks from §7.2. Do not begin PR3 as part of PR2.

--- a/app/Console/Commands/VaultReindexCommand.php
+++ b/app/Console/Commands/VaultReindexCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Vault\VaultReindexer;
+use App\Models\Workspace;
+use Illuminate\Console\Command;
+
+class VaultReindexCommand extends Command
+{
+    protected $signature = 'vault:reindex
+                            {--workspace= : Workspace id to reconcile}
+                            {--batch= : Optional batch size override for shared-hosting limits}';
+
+    protected $description = 'Rebuild the notes projection for a workspace from on-disk Markdown (bounded/batched)';
+
+    public function handle(VaultReindexer $reindexer): int
+    {
+        $workspaceId = $this->option('workspace');
+        if ($workspaceId === null || $workspaceId === '') {
+            $this->error('The --workspace option is required.');
+
+            return self::FAILURE;
+        }
+
+        if (! ctype_digit((string) $workspaceId)) {
+            $this->error('The --workspace option must be a positive integer id.');
+
+            return self::FAILURE;
+        }
+
+        $workspace = Workspace::query()->find((int) $workspaceId);
+        if ($workspace === null) {
+            $this->error("Workspace [{$workspaceId}] was not found.");
+
+            return self::FAILURE;
+        }
+
+        $batchOption = $this->option('batch');
+        $batchSize = null;
+        if ($batchOption !== null && $batchOption !== '') {
+            if (! ctype_digit((string) $batchOption) || (int) $batchOption < 1) {
+                $this->error('The --batch option must be a positive integer.');
+
+                return self::FAILURE;
+            }
+            $batchSize = (int) $batchOption;
+        }
+
+        $result = $reindexer->reindex($workspace, $batchSize);
+
+        $this->info(sprintf(
+            'Reindexed workspace %d (%s): scanned %d, upserted %d, removed %d.',
+            $workspace->id,
+            $workspace->slug,
+            $result['scanned'],
+            $result['upserted'],
+            $result['removed'],
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Vault/Exceptions/PathTraversalRejected.php
+++ b/app/Domain/Vault/Exceptions/PathTraversalRejected.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Vault\Exceptions;
+
+use RuntimeException;
+
+final class PathTraversalRejected extends RuntimeException
+{
+    public function __construct(
+        public readonly int $workspaceId,
+        public readonly string $attemptedPath,
+        string $message = 'Path resolves outside the workspace vault root.',
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/app/Domain/Vault/MarkdownDocument.php
+++ b/app/Domain/Vault/MarkdownDocument.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Parses Obsidian-style Markdown with optional YAML front-matter.
+ */
+final class MarkdownDocument
+{
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     * @param  list<string>  $tags
+     */
+    public function __construct(
+        public readonly string $raw,
+        public readonly array $frontmatter,
+        public readonly string $body,
+        public readonly string $title,
+        public readonly array $tags,
+        public readonly string $contentHash,
+        public readonly string $searchContent,
+    ) {}
+
+    public static function parse(string $raw, string $fallbackTitle): self
+    {
+        [$frontmatter, $body] = self::splitFrontMatter($raw);
+        $title = self::resolveTitle($frontmatter, $body, $fallbackTitle);
+        $tags = self::extractTags($frontmatter);
+
+        return new self(
+            raw: $raw,
+            frontmatter: $frontmatter,
+            body: $body,
+            title: $title,
+            tags: $tags,
+            contentHash: hash('sha256', $raw),
+            searchContent: self::buildSearchContent($body),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     */
+    public static function compose(array $frontmatter, string $body): string
+    {
+        $body = self::normalizeNewlines($body);
+
+        if ($frontmatter === []) {
+            return $body;
+        }
+
+        $yaml = Yaml::dump($frontmatter, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $yaml = rtrim($yaml, "\n");
+
+        return "---\n{$yaml}\n---\n".$body;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private static function splitFrontMatter(string $raw): array
+    {
+        $normalized = self::normalizeNewlines($raw);
+
+        if (! str_starts_with($normalized, "---\n") && $normalized !== '---') {
+            return [[], $normalized];
+        }
+
+        $offset = 4; // after opening ---\n
+        $closing = strpos($normalized, "\n---", $offset);
+
+        if ($closing === false) {
+            return [[], $normalized];
+        }
+
+        $yamlBlock = substr($normalized, $offset, $closing - $offset);
+        $rest = substr($normalized, $closing + 4); // past \n---
+        if (str_starts_with($rest, "\n")) {
+            $rest = substr($rest, 1);
+        }
+
+        try {
+            $parsed = Yaml::parse($yamlBlock);
+        } catch (ParseException) {
+            return [[], $normalized];
+        }
+
+        if (! is_array($parsed)) {
+            return [[], $normalized];
+        }
+
+        /** @var array<string, mixed> $parsed */
+        return [$parsed, $rest];
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     */
+    private static function resolveTitle(array $frontmatter, string $body, string $fallbackTitle): string
+    {
+        $fromMatter = $frontmatter['title'] ?? null;
+        if (is_string($fromMatter) && trim($fromMatter) !== '') {
+            return trim($fromMatter);
+        }
+
+        if (preg_match('/^#\s+(.+)$/m', $body, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        return $fallbackTitle;
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     * @return list<string>
+     */
+    private static function extractTags(array $frontmatter): array
+    {
+        if (! array_key_exists('tags', $frontmatter)) {
+            return [];
+        }
+
+        $rawTags = $frontmatter['tags'];
+        $tags = [];
+
+        if (is_string($rawTags)) {
+            $parts = preg_split('/\s*,\s*/', $rawTags) ?: [];
+            foreach ($parts as $part) {
+                $tags[] = $part;
+            }
+        } elseif (is_array($rawTags)) {
+            foreach ($rawTags as $part) {
+                if (is_string($part) || is_numeric($part)) {
+                    $tags[] = (string) $part;
+                }
+            }
+        }
+
+        $normalized = [];
+        foreach ($tags as $tag) {
+            $tag = trim($tag);
+            $tag = ltrim($tag, '#');
+            if ($tag === '') {
+                continue;
+            }
+            $normalized[$tag] = $tag;
+        }
+
+        return array_values($normalized);
+    }
+
+    private static function buildSearchContent(string $body): string
+    {
+        // Q1 default: rebuildable FULLTEXT projection of note body text only (not canonical).
+        return trim($body);
+    }
+
+    private static function normalizeNewlines(string $value): string
+    {
+        return str_replace(["\r\n", "\r"], "\n", $value);
+    }
+}

--- a/app/Domain/Vault/NoteProjector.php
+++ b/app/Domain/Vault/NoteProjector.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use App\Models\Note;
+use App\Models\Tag;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Maintains the rebuildable MySQL projection for a vault Markdown document.
+ */
+final class NoteProjector
+{
+    public function project(Workspace $workspace, string $relativePath, MarkdownDocument $document): Note
+    {
+        return DB::transaction(function () use ($workspace, $relativePath, $document): Note {
+            /** @var Note $note */
+            $note = Note::query()->updateOrCreate(
+                [
+                    'workspace_id' => $workspace->id,
+                    'path' => $relativePath,
+                ],
+                [
+                    'title' => $document->title,
+                    'frontmatter' => $document->frontmatter === [] ? null : $document->frontmatter,
+                    'content_hash' => $document->contentHash,
+                    'search_content' => $document->searchContent === '' ? null : $document->searchContent,
+                ],
+            );
+
+            $this->syncTags($workspace, $note, $document->tags);
+
+            // TODO(spec: PR3): extract [[wikilinks]] from the body and project note_links / backlinks.
+            // Reindex and writes intentionally leave note_links untouched in PR2.
+
+            return $note->refresh();
+        });
+    }
+
+    /**
+     * @param  list<string>  $tagNames
+     */
+    private function syncTags(Workspace $workspace, Note $note, array $tagNames): void
+    {
+        $tagIds = [];
+
+        foreach ($tagNames as $name) {
+            $tag = Tag::query()->firstOrCreate(
+                [
+                    'workspace_id' => $workspace->id,
+                    'name' => $name,
+                ],
+            );
+            $tagIds[] = $tag->id;
+        }
+
+        $note->tags()->sync($tagIds);
+    }
+}

--- a/app/Domain/Vault/VaultPathGuard.php
+++ b/app/Domain/Vault/VaultPathGuard.php
@@ -27,13 +27,13 @@ final class VaultPathGuard
         $root = $this->canonicalVaultRoot($workspace);
         $absolute = $this->join($root, $relative);
 
-        if (! $this->isInsideRoot($root, $absolute)) {
+        if (! $this->isUnderVaultRoot($root, $absolute)) {
             $this->reject($workspace, $relativePath);
         }
 
         if ($mustExist) {
             $real = realpath($absolute);
-            if ($real === false || ! $this->isInsideRoot($root, $real)) {
+            if ($real === false || ! $this->isUnderVaultRoot($root, $real)) {
                 $this->reject($workspace, $relativePath);
             }
 
@@ -42,7 +42,7 @@ final class VaultPathGuard
 
         if (is_link($absolute) || file_exists($absolute)) {
             $real = realpath($absolute);
-            if ($real === false || ! $this->isInsideRoot($root, $real)) {
+            if ($real === false || ! $this->isUnderVaultRoot($root, $real)) {
                 $this->reject($workspace, $relativePath);
             }
 
@@ -52,7 +52,8 @@ final class VaultPathGuard
         $parent = dirname($absolute);
         if (is_dir($parent) || is_link($parent)) {
             $realParent = realpath($parent);
-            if ($realParent === false || ! $this->isInsideRoot($root, $realParent)) {
+            // Parent may be the vault root itself for root-level notes.
+            if ($realParent === false || ! $this->isUnderVaultRoot($root, $realParent, allowRoot: true)) {
                 $this->reject($workspace, $relativePath);
             }
 
@@ -89,11 +90,11 @@ final class VaultPathGuard
         $absolute = str_replace('\\', '/', $absolutePath);
         $rootNormalized = str_replace('\\', '/', $root);
 
-        if (! $this->isInsideRoot($rootNormalized, $absolute)) {
+        if (! $this->isUnderVaultRoot($rootNormalized, $absolute)) {
             $this->reject($workspace, $absolutePath);
         }
 
-        $relative = substr($absolute, strlen($rootNormalized));
+        $relative = substr($absolute, strlen(rtrim($rootNormalized, '/')));
         $relative = ltrim(str_replace('\\', '/', $relative), '/');
 
         return $this->assertSafeRelativePath($workspace, $relative);
@@ -168,13 +169,17 @@ final class VaultPathGuard
         return rtrim($root, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $relative);
     }
 
-    private function isInsideRoot(string $root, string $absolute): bool
+    /**
+     * True when $absolute is inside the vault root. When $allowRoot is true, the root
+     * directory itself is accepted (needed for parent-dir checks of root-level notes).
+     */
+    private function isUnderVaultRoot(string $root, string $absolute, bool $allowRoot = false): bool
     {
         $root = rtrim(str_replace('\\', '/', $root), '/');
-        $absolute = str_replace('\\', '/', $absolute);
+        $absolute = rtrim(str_replace('\\', '/', $absolute), '/');
 
         if ($absolute === $root) {
-            return false;
+            return $allowRoot;
         }
 
         return str_starts_with($absolute, $root.'/');

--- a/app/Domain/Vault/VaultPathGuard.php
+++ b/app/Domain/Vault/VaultPathGuard.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use App\Domain\Vault\Exceptions\PathTraversalRejected;
+use App\Models\AuditLog;
+use App\Models\Workspace;
+
+/**
+ * Canonicalizes in-vault note paths and rejects anything that escapes the workspace root (§8/S2).
+ */
+final class VaultPathGuard
+{
+    public const AUDIT_EVENT = 'vault.path_traversal_rejected';
+
+    /**
+     * Resolve a relative in-vault path to an absolute filesystem path under the workspace vault root.
+     *
+     * Traversal attempts are rejected using path-string rules before any access to the candidate path.
+     *
+     * @throws PathTraversalRejected
+     */
+    public function resolve(Workspace $workspace, string $relativePath, bool $mustExist = false): string
+    {
+        // Validate the candidate path string before any filesystem access (§7.1 / §8 S2).
+        $relative = $this->assertSafeRelativePath($workspace, $relativePath);
+        $root = $this->canonicalVaultRoot($workspace);
+        $absolute = $this->join($root, $relative);
+
+        if (! $this->isInsideRoot($root, $absolute)) {
+            $this->reject($workspace, $relativePath);
+        }
+
+        if ($mustExist) {
+            $real = realpath($absolute);
+            if ($real === false || ! $this->isInsideRoot($root, $real)) {
+                $this->reject($workspace, $relativePath);
+            }
+
+            return $real;
+        }
+
+        if (is_link($absolute) || file_exists($absolute)) {
+            $real = realpath($absolute);
+            if ($real === false || ! $this->isInsideRoot($root, $real)) {
+                $this->reject($workspace, $relativePath);
+            }
+
+            return $real;
+        }
+
+        $parent = dirname($absolute);
+        if (is_dir($parent) || is_link($parent)) {
+            $realParent = realpath($parent);
+            if ($realParent === false || ! $this->isInsideRoot($root, $realParent)) {
+                $this->reject($workspace, $relativePath);
+            }
+
+            return $realParent.DIRECTORY_SEPARATOR.basename($absolute);
+        }
+
+        return $absolute;
+    }
+
+    /**
+     * Ensure the vault root exists on disk and return its canonical absolute path.
+     */
+    public function ensureVaultRoot(Workspace $workspace): string
+    {
+        $configured = $this->normalizeConfiguredRoot((string) $workspace->vault_path);
+
+        if (! is_dir($configured) && ! file_exists($configured)) {
+            if (! mkdir($configured, 0755, true) && ! is_dir($configured)) {
+                throw new \RuntimeException("Unable to create vault root [{$configured}].");
+            }
+        }
+
+        $real = realpath($configured);
+        if ($real === false || ! is_dir($real)) {
+            throw new \RuntimeException("Vault root [{$configured}] is not a usable directory.");
+        }
+
+        return $real;
+    }
+
+    public function toRelative(Workspace $workspace, string $absolutePath): string
+    {
+        $root = $this->canonicalVaultRoot($workspace);
+        $absolute = str_replace('\\', '/', $absolutePath);
+        $rootNormalized = str_replace('\\', '/', $root);
+
+        if (! $this->isInsideRoot($rootNormalized, $absolute)) {
+            $this->reject($workspace, $absolutePath);
+        }
+
+        $relative = substr($absolute, strlen($rootNormalized));
+        $relative = ltrim(str_replace('\\', '/', $relative), '/');
+
+        return $this->assertSafeRelativePath($workspace, $relative);
+    }
+
+    private function canonicalVaultRoot(Workspace $workspace): string
+    {
+        return $this->ensureVaultRoot($workspace);
+    }
+
+    private function assertSafeRelativePath(Workspace $workspace, string $relativePath): string
+    {
+        $path = str_replace('\\', '/', $relativePath);
+        $path = trim($path);
+
+        if ($path === '' || str_contains($path, "\0")) {
+            $this->reject($workspace, $relativePath);
+        }
+
+        if ($this->looksAbsolute($path)) {
+            $this->reject($workspace, $relativePath);
+        }
+
+        $segments = explode('/', $path);
+        $normalized = [];
+
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.') {
+                $this->reject($workspace, $relativePath);
+            }
+
+            if ($segment === '..') {
+                $this->reject($workspace, $relativePath);
+            }
+
+            if (str_contains($segment, ':')) {
+                $this->reject($workspace, $relativePath);
+            }
+
+            $normalized[] = $segment;
+        }
+
+        $normalizedPath = implode('/', $normalized);
+
+        if (! str_ends_with(strtolower($normalizedPath), '.md')) {
+            $this->reject($workspace, $relativePath, 'Vault note paths must end with .md.');
+        }
+
+        return $normalizedPath;
+    }
+
+    private function looksAbsolute(string $path): bool
+    {
+        if (str_starts_with($path, '/')) {
+            return true;
+        }
+
+        if (str_starts_with($path, '~')) {
+            return true;
+        }
+
+        // Windows drive or UNC
+        if (preg_match('#^[a-zA-Z]:#', $path) === 1) {
+            return true;
+        }
+
+        return str_starts_with($path, '//');
+    }
+
+    private function join(string $root, string $relative): string
+    {
+        return rtrim($root, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $relative);
+    }
+
+    private function isInsideRoot(string $root, string $absolute): bool
+    {
+        $root = rtrim(str_replace('\\', '/', $root), '/');
+        $absolute = str_replace('\\', '/', $absolute);
+
+        if ($absolute === $root) {
+            return false;
+        }
+
+        return str_starts_with($absolute, $root.'/');
+    }
+
+    private function normalizeConfiguredRoot(string $vaultPath): string
+    {
+        $path = str_replace('\\', '/', trim($vaultPath));
+
+        if ($path === '' || str_contains($path, "\0")) {
+            throw new \InvalidArgumentException('Workspace vault_path is empty or invalid.');
+        }
+
+        if (! $this->looksAbsolute($path) && ! str_starts_with($vaultPath, DIRECTORY_SEPARATOR)) {
+            // Relative configured roots are resolved from the application base path.
+            $path = base_path($path);
+        }
+
+        return $path;
+    }
+
+    private function reject(Workspace $workspace, string $attemptedPath, ?string $message = null): never
+    {
+        AuditLog::query()->create([
+            'tenant_id' => $workspace->tenant_id,
+            'workspace_id' => $workspace->id,
+            'actor_subject_id' => null,
+            'event' => self::AUDIT_EVENT,
+            'metadata' => [
+                // TODO(spec: Before PR7, finalize audit event vocabulary and metadata redaction.)
+                'attempted_path' => $attemptedPath,
+            ],
+            'ip_address' => null,
+        ]);
+
+        throw new PathTraversalRejected(
+            (int) $workspace->id,
+            $attemptedPath,
+            $message ?? 'Path resolves outside the workspace vault root.',
+        );
+    }
+}

--- a/app/Domain/Vault/VaultReindexer.php
+++ b/app/Domain/Vault/VaultReindexer.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use App\Models\Note;
+use App\Models\Workspace;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Bounded reconcile of the notes projection from on-disk Markdown (cron-safe).
+ */
+final class VaultReindexer
+{
+    public function __construct(
+        private readonly VaultPathGuard $paths = new VaultPathGuard,
+        private readonly NoteProjector $projector = new NoteProjector,
+    ) {}
+
+    /**
+     * @return array{scanned: int, upserted: int, removed: int}
+     */
+    public function reindex(Workspace $workspace, ?int $batchSize = null): array
+    {
+        $batchSize = max(1, $batchSize ?? (int) config('jotter.vault.reindex_batch_size', 50));
+        $root = $this->paths->ensureVaultRoot($workspace);
+
+        $scanned = 0;
+        $upserted = 0;
+        $batch = [];
+
+        foreach ($this->iterateMarkdownFiles($root) as $file) {
+            $absolute = $file->getPathname();
+            $relative = $this->paths->toRelative($workspace, $absolute);
+            $batch[] = [$absolute, $relative];
+            $scanned++;
+
+            if (count($batch) >= $batchSize) {
+                $upserted += $this->projectBatch($workspace, $batch);
+                $batch = [];
+            }
+        }
+
+        if ($batch !== []) {
+            $upserted += $this->projectBatch($workspace, $batch);
+        }
+
+        $removed = $this->removeMissingNotes($workspace, $root, $batchSize);
+
+        return [
+            'scanned' => $scanned,
+            'upserted' => $upserted,
+            'removed' => $removed,
+        ];
+    }
+
+    /**
+     * @return \Generator<int, SplFileInfo>
+     */
+    private function iterateMarkdownFiles(string $root): \Generator
+    {
+        if (! is_dir($root)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $root,
+                FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO,
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $name = $file->getFilename();
+            if (! str_ends_with(strtolower($name), '.md')) {
+                continue;
+            }
+
+            // Skip symlink escapes: only yield files whose realpath stays inside root.
+            $real = realpath($file->getPathname());
+            if ($real === false) {
+                continue;
+            }
+
+            $rootNormalized = rtrim(str_replace('\\', '/', $root), '/');
+            $realNormalized = str_replace('\\', '/', $real);
+            if (! str_starts_with($realNormalized, $rootNormalized.'/')) {
+                continue;
+            }
+
+            yield $file;
+        }
+    }
+
+    /**
+     * @param  list<array{0: string, 1: string}>  $batch
+     */
+    private function projectBatch(Workspace $workspace, array $batch): int
+    {
+        $count = 0;
+
+        foreach ($batch as [$absolute, $relative]) {
+            $raw = file_get_contents($absolute);
+            if ($raw === false) {
+                continue;
+            }
+
+            $document = MarkdownDocument::parse($raw, $this->fallbackTitle($relative));
+            $this->projector->project($workspace, $relative, $document);
+            $count++;
+
+            // TODO(spec: PR3): when reindexing, also refresh note_links from wikilink extraction.
+        }
+
+        return $count;
+    }
+
+    private function removeMissingNotes(Workspace $workspace, string $root, int $batchSize): int
+    {
+        $removed = 0;
+        $rootNormalized = rtrim(str_replace('\\', '/', $root), '/');
+
+        Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->orderBy('id')
+            ->chunkById($batchSize, function ($notes) use ($workspace, $rootNormalized, &$removed): void {
+                foreach ($notes as $note) {
+                    try {
+                        $absolute = $this->paths->resolve($workspace, (string) $note->path, mustExist: false);
+                    } catch (\Throwable) {
+                        $note->delete();
+                        $removed++;
+
+                        continue;
+                    }
+
+                    $absoluteNormalized = str_replace('\\', '/', $absolute);
+                    if (! is_file($absolute) || ! str_starts_with($absoluteNormalized, $rootNormalized.'/')) {
+                        $note->delete();
+                        $removed++;
+                    }
+                }
+            });
+
+        return $removed;
+    }
+
+    private function fallbackTitle(string $relativePath): string
+    {
+        $base = basename(str_replace('\\', '/', $relativePath));
+        if (str_ends_with(strtolower($base), '.md')) {
+            $base = substr($base, 0, -3);
+        }
+
+        return $base === '' ? 'Untitled' : $base;
+    }
+}

--- a/app/Domain/Vault/VaultStorage.php
+++ b/app/Domain/Vault/VaultStorage.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use App\Models\Note;
+use App\Models\Workspace;
+
+/**
+ * Path-safe read/write for workspace Markdown vaults. Disk files are source of truth;
+ * MySQL is updated as a rebuildable projection on every successful write.
+ */
+final class VaultStorage
+{
+    public function __construct(
+        private readonly VaultPathGuard $paths = new VaultPathGuard,
+        private readonly NoteProjector $projector = new NoteProjector,
+    ) {}
+
+    public function read(Workspace $workspace, string $relativePath): MarkdownDocument
+    {
+        $absolute = $this->paths->resolve($workspace, $relativePath, mustExist: true);
+
+        $raw = file_get_contents($absolute);
+        if ($raw === false) {
+            throw new \RuntimeException("Unable to read vault note [{$relativePath}].");
+        }
+
+        return MarkdownDocument::parse($raw, $this->fallbackTitle($relativePath));
+    }
+
+    public function write(Workspace $workspace, string $relativePath, string $contents): Note
+    {
+        $absolute = $this->paths->resolve($workspace, $relativePath, mustExist: false);
+        $relative = $this->paths->toRelative($workspace, $absolute);
+
+        $this->ensureParentDirectory($workspace, $absolute);
+
+        // Re-resolve after parents exist so symlink escapes are caught before write.
+        $absolute = $this->paths->resolve($workspace, $relative, mustExist: false);
+
+        $written = file_put_contents($absolute, $contents, LOCK_EX);
+        if ($written === false) {
+            throw new \RuntimeException("Unable to write vault note [{$relative}].");
+        }
+
+        $document = MarkdownDocument::parse($contents, $this->fallbackTitle($relative));
+
+        return $this->projector->project($workspace, $relative, $document);
+    }
+
+    /**
+     * @param  array<string, mixed>  $frontmatter
+     */
+    public function writeDocument(Workspace $workspace, string $relativePath, array $frontmatter, string $body): Note
+    {
+        return $this->write(
+            $workspace,
+            $relativePath,
+            MarkdownDocument::compose($frontmatter, $body),
+        );
+    }
+
+    public function exists(Workspace $workspace, string $relativePath): bool
+    {
+        try {
+            $absolute = $this->paths->resolve($workspace, $relativePath, mustExist: false);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        return is_file($absolute);
+    }
+
+    private function ensureParentDirectory(Workspace $workspace, string $absolute): void
+    {
+        $root = $this->paths->ensureVaultRoot($workspace);
+        $parent = dirname($absolute);
+
+        $rootNormalized = rtrim(str_replace('\\', '/', $root), '/');
+        $parentNormalized = rtrim(str_replace('\\', '/', $parent), '/');
+
+        if ($parentNormalized !== $rootNormalized && ! str_starts_with($parentNormalized, $rootNormalized.'/')) {
+            throw new \RuntimeException('Refusing to create directories outside the vault root.');
+        }
+
+        if (is_dir($parent)) {
+            $realParent = realpath($parent);
+            if ($realParent === false) {
+                throw new \RuntimeException('Vault parent directory could not be canonicalized.');
+            }
+
+            $realNormalized = str_replace('\\', '/', $realParent);
+            if ($realNormalized !== $rootNormalized && ! str_starts_with($realNormalized, $rootNormalized.'/')) {
+                throw new \RuntimeException('Refusing to use a vault parent outside the workspace root.');
+            }
+
+            return;
+        }
+
+        $relativeParent = trim(substr($parentNormalized, strlen($rootNormalized)), '/');
+        if ($relativeParent !== '') {
+            foreach (explode('/', $relativeParent) as $segment) {
+                if ($segment === '' || $segment === '.' || $segment === '..' || str_contains($segment, ':')) {
+                    throw new \RuntimeException('Refusing to create unsafe vault directories.');
+                }
+            }
+        }
+
+        if (! mkdir($parent, 0755, true) && ! is_dir($parent)) {
+            throw new \RuntimeException("Unable to create vault directory for [{$absolute}].");
+        }
+
+        $realParent = realpath($parent);
+        if ($realParent === false) {
+            throw new \RuntimeException('Vault parent directory could not be canonicalized.');
+        }
+
+        $realNormalized = str_replace('\\', '/', $realParent);
+        if ($realNormalized !== $rootNormalized && ! str_starts_with($realNormalized, $rootNormalized.'/')) {
+            throw new \RuntimeException('Refusing to use a vault parent outside the workspace root.');
+        }
+    }
+
+    private function fallbackTitle(string $relativePath): string
+    {
+        $base = basename(str_replace('\\', '/', $relativePath));
+        if (str_ends_with(strtolower($base), '.md')) {
+            $base = substr($base, 0, -3);
+        }
+
+        return $base === '' ? 'Untitled' : $base;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.3",
         "laravel/tinker": "^2.10.1",
-        "symfony/uid": "^7.4"
+        "symfony/uid": "^7.4",
+        "symfony/yaml": "^7.4"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76845629693455c63209eeae7155480b",
+    "content-hash": "3b3bf8ce4fd475731826c3bf4a11a10b",
     "packages": [
         {
             "name": "brick/math",
@@ -5842,6 +5842,82 @@
             "time": "2026-06-08T20:24:16+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-08T20:24:16+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.4.0",
             "source": {
@@ -8287,82 +8363,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.4.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
-                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -8,4 +8,9 @@ return [
         'workspace_slug' => env('JOTTER_WORKSPACE_SLUG', 'default'),
         'vault_path' => env('JOTTER_VAULT_PATH') ?: storage_path('app/vaults/default'),
     ],
+
+    'vault' => [
+        // Bounded reconcile batch size for shared-hosting PHP memory/time limits.
+        'reindex_batch_size' => (int) env('JOTTER_VAULT_REINDEX_BATCH', 50),
+    ],
 ];

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,8 @@ The initial hierarchy is tenant → workspace → note/attachment, with note lin
 
 Per §13 Q1's default, `notes.search_content` is a nullable `LONGTEXT` search projection. It is not canonical note content and can be rebuilt from disk. The schema deliberately has no `body` or `content` column, and PR1 adds no `FULLTEXT` index or search behavior; those belong to PR4.
 
+PR2's vault storage service reads and writes Markdown under each workspace `vault_path`, parses YAML front-matter with Symfony YAML, and refreshes the `notes` / tag projection on every write. Nested folders are allowed (Q4) only when the canonical path remains inside the vault root. Path-traversal attempts are rejected before candidate filesystem access and appended to `audit_log` as `vault.path_traversal_rejected`. `php artisan vault:reindex --workspace=<id>` reconciles the projection from disk in bounded batches for shared-hosting limits. Wikilink extraction into `note_links` is deferred to PR3.
+
 Foreign keys cascade deletion for owned projection/state rows. Nullable references that can safely lose their target (`note_links.target_note_id` and identities' local user) use `SET NULL`. Membership workspaces use restricted deletes because MySQL cannot combine `SET NULL` with the stored workspace-scope uniqueness expression; scoped memberships must be explicitly removed first. Audit scopes also use restricted deletes so tenant or workspace removal cannot mutate or erase historical entries. Audit entries have `created_at` only. Their final event vocabulary, context, and retention policy remain a required specification decision before PR7.
 
 Membership uniqueness uses a generated workspace scope key so MySQL also rejects duplicate tenant-level memberships when `workspace_id` is `NULL`. A composite tenant/workspace foreign key prevents memberships from crossing tenant boundaries.
@@ -24,7 +26,7 @@ Only local providers may perform work in v0. Jotter must remain fully useful wit
 
 - The deployable web root is `public/`; vault content must never be placed there.
 - Requests cannot rely on daemons, workers, websockets, or long-lived processes.
-- Cron-invoked, bounded Artisan commands are the future scheduling boundary.
+- Cron-invoked, bounded Artisan commands are the scheduling boundary (`vault:reindex` in PR2).
 - Application code must not call `exec`, `shell_exec`, `proc_open`, or external command-line tools.
 - Work must fit ordinary PHP execution, memory, upload, inode, and disk quotas.
 - Deployment is a zip containing `vendor/` and built public assets, followed by migrations.
@@ -33,6 +35,6 @@ Docker is a development and build tool only. Production requires PHP 8.2+, MySQL
 
 ## Scope boundary
 
-PR1 defines schema, models, seed configuration, and projection boundaries only. It does not create vault directories or implement filesystem access, indexing, parsing, search, CRUD APIs, providers, uploads, or UI.
+PR2 implements path-safe vault I/O, front-matter projection, incremental index-on-write, and bounded reconcile only. It does not implement wikilink/backlink resolution, search endpoints, notes CRUD APIs, auth providers, uploads, or UI.
 
 There is no v1 work in this implementation. WebDAV, publishing, graph views, GrandpaSSOn integration, TaskConnect delegation, AI retrieval, MCP, daily notes, and related features remain out of scope.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,4 +26,10 @@ The command writes `dist/jotter-release.zip` and `dist/jotter-release.zip.sha256
 
 The artifact includes production `vendor/` dependencies and compiled `public/build/` assets. It excludes tests, frontend sources, container files, development tooling, and secrets.
 
-The bounded `vault:reindex` cron entry described by the product spec will be documented when that command is implemented in its later PR. PR0 does not provide a placeholder command.
+Schedule a bounded reconcile for each workspace vault (adjust the id and frequency to the host):
+
+```sh
+php artisan vault:reindex --workspace=1
+```
+
+Keep vault directories outside the web root. Notes are never served as static files from `public/`.

--- a/tests/Feature/VaultStorageTest.php
+++ b/tests/Feature/VaultStorageTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\Exceptions\PathTraversalRejected;
+use App\Domain\Vault\MarkdownDocument;
+use App\Domain\Vault\VaultPathGuard;
+use App\Domain\Vault\VaultStorage;
+use App\Models\AuditLog;
+use App\Models\Note;
+use App\Models\Tag;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class VaultStorageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $vaultRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultRoot = sys_get_temp_dir().'/jotter-vault-'.uniqid('', true);
+        mkdir($this->vaultRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->vaultRoot);
+
+        parent::tearDown();
+    }
+
+    public function test_path_traversal_is_rejected_before_filesystem_access_and_audited(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $outsideDir = sys_get_temp_dir().'/jotter-outside-'.uniqid('', true);
+        mkdir($outsideDir, 0755, true);
+        $sentinel = $outsideDir.'/sentinel.md';
+        file_put_contents($sentinel, "safe\n");
+        $before = file_get_contents($sentinel);
+        $mtimeBefore = filemtime($sentinel);
+
+        // Spec §7.1 acceptance example (no .md suffix).
+        try {
+            $storage->write($workspace, '../../etc/passwd', "pwned\n");
+            $this->fail('Expected path traversal to be rejected.');
+        } catch (PathTraversalRejected $exception) {
+            $this->assertSame($workspace->id, $exception->workspaceId);
+            $this->assertSame('../../etc/passwd', $exception->attemptedPath);
+        }
+
+        $this->assertSame($before, file_get_contents($sentinel));
+        $this->assertSame($mtimeBefore, filemtime($sentinel));
+
+        $audit = AuditLog::query()->where('event', VaultPathGuard::AUDIT_EVENT)->sole();
+        $this->assertSame($workspace->tenant_id, $audit->tenant_id);
+        $this->assertSame($workspace->id, $audit->workspace_id);
+        $this->assertSame('../../etc/passwd', $audit->metadata['attempted_path']);
+
+        try {
+            $storage->read($workspace, '/etc/passwd.md');
+            $this->fail('Expected absolute path to be rejected.');
+        } catch (PathTraversalRejected) {
+            // expected
+        }
+
+        try {
+            $storage->write($workspace, 'notes/../../outside.md', "nope\n");
+            $this->fail('Expected nested traversal to be rejected.');
+        } catch (PathTraversalRejected) {
+            // expected
+        }
+
+        $this->assertSame(3, AuditLog::query()->where('event', VaultPathGuard::AUDIT_EVENT)->count());
+
+        $this->deleteTree($outsideDir);
+    }
+
+    public function test_front_matter_is_parsed_into_the_projection(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $raw = <<<'MD'
+---
+title: Parsed Title
+tags:
+  - alpha
+  - beta
+status: draft
+---
+Body for search projection.
+MD;
+
+        $note = $storage->write($workspace, 'inbox/parsed.md', $raw);
+
+        $this->assertSame('inbox/parsed.md', $note->path);
+        $this->assertSame('Parsed Title', $note->title);
+        $this->assertSame('draft', $note->frontmatter['status']);
+        $this->assertSame(['alpha', 'beta'], $note->frontmatter['tags']);
+        $this->assertSame(hash('sha256', $raw), $note->content_hash);
+        $this->assertSame('Body for search projection.', $note->search_content);
+        $this->assertEqualsCanonicalizing(['alpha', 'beta'], $note->tags()->pluck('name')->all());
+        $this->assertFileExists($this->vaultRoot.'/inbox/parsed.md');
+        $this->assertSame($raw, file_get_contents($this->vaultRoot.'/inbox/parsed.md'));
+    }
+
+    public function test_write_incrementally_updates_title_front_matter_and_tags(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $storage->writeDocument($workspace, 'daily.md', [
+            'title' => 'Day One',
+            'tags' => ['one'],
+        ], "First body\n");
+
+        $updated = $storage->writeDocument($workspace, 'daily.md', [
+            'title' => 'Day Two',
+            'tags' => ['two', 'shared'],
+        ], "Second body\n");
+
+        $this->assertSame(1, Note::query()->count());
+        $this->assertSame('Day Two', $updated->title);
+        $this->assertSame(['two', 'shared'], $updated->frontmatter['tags']);
+        $this->assertSame('Second body', $updated->search_content);
+        $this->assertEqualsCanonicalizing(['two', 'shared'], $updated->tags()->pluck('name')->all());
+        $this->assertTrue(Tag::query()->where('name', 'one')->exists());
+    }
+
+    public function test_vault_reindex_picks_up_out_of_band_disk_edits(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $storage->writeDocument($workspace, 'oob.md', [
+            'title' => 'Before',
+            'tags' => ['old'],
+        ], "Original\n");
+
+        $oob = <<<'MD'
+---
+title: After OOB Edit
+tags:
+  - fresh
+---
+Edited directly on disk.
+MD;
+        file_put_contents($this->vaultRoot.'/oob.md', $oob);
+
+        $exit = Artisan::call('vault:reindex', [
+            '--workspace' => (string) $workspace->id,
+            '--batch' => '10',
+        ]);
+
+        $this->assertSame(0, $exit);
+
+        $note = Note::query()->where('path', 'oob.md')->sole();
+        $this->assertSame('After OOB Edit', $note->title);
+        $this->assertSame(['fresh'], $note->frontmatter['tags']);
+        $this->assertSame('Edited directly on disk.', $note->search_content);
+        $this->assertEqualsCanonicalizing(['fresh'], $note->tags()->pluck('name')->all());
+        $this->assertSame(hash('sha256', $oob), $note->content_hash);
+    }
+
+    public function test_nested_folder_paths_are_allowed_with_root_validation(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $note = $storage->write($workspace, 'projects/alpha/readme.md', "# Nested\n");
+
+        $this->assertSame('projects/alpha/readme.md', $note->path);
+        $this->assertSame('Nested', $note->title);
+        $this->assertFileExists($this->vaultRoot.'/projects/alpha/readme.md');
+    }
+
+    public function test_reindex_removes_stale_note_rows_missing_on_disk(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $storage->write($workspace, 'keep.md', "# Keep\n");
+        $storage->write($workspace, 'gone.md', "# Gone\n");
+        unlink($this->vaultRoot.'/gone.md');
+
+        Artisan::call('vault:reindex', ['--workspace' => (string) $workspace->id]);
+
+        $this->assertTrue(Note::query()->where('path', 'keep.md')->exists());
+        $this->assertFalse(Note::query()->where('path', 'gone.md')->exists());
+    }
+
+    public function test_markdown_document_parse_round_trip_helpers(): void
+    {
+        $composed = MarkdownDocument::compose([
+            'title' => 'Compose',
+            'tags' => ['x'],
+        ], "Hello\n");
+
+        $parsed = MarkdownDocument::parse($composed, 'fallback');
+
+        $this->assertSame('Compose', $parsed->title);
+        $this->assertSame(['x'], $parsed->tags);
+        $this->assertSame('Hello', $parsed->searchContent);
+    }
+
+    private function makeWorkspace(): Workspace
+    {
+        $tenant = Tenant::query()->create([
+            'slug' => 'vault-tenant-'.uniqid(),
+            'name' => 'Vault Tenant',
+        ]);
+
+        return Workspace::query()->create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'vault-ws-'.uniqid(),
+            'name' => 'Vault Workspace',
+            'vault_path' => $this->vaultRoot,
+        ]);
+    }
+
+    private function deleteTree(string $path): void
+    {
+        if (! is_dir($path) && ! is_file($path)) {
+            return;
+        }
+
+        if (is_file($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $this->deleteTree($path.DIRECTORY_SEPARATOR.$item);
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR2 — Vault storage service** per spec §7.1 / §11.

- Path-safe read/write of workspace `.md` files rooted at each workspace `vault_path`
- Symfony YAML front-matter → `notes.frontmatter` projection
- Incremental projection on write: `path`, `title`, `frontmatter`, `content_hash`, `search_content` (Q1), and front-matter tags
- Bounded `php artisan vault:reindex --workspace=<id>` reconcile for out-of-band disk edits (batched; drops stale note rows)
- Path-traversal guard (§8/S2): canonicalize; reject before candidate filesystem access; audit as `vault.path_traversal_rejected`
- Nested folders allowed (Q4) with root validation
- Wikilink / `note_links` left as explicit `TODO(spec: PR3)` — not half-built

Disk Markdown remains the source of truth; MySQL stays a rebuildable projection (no canonical note bodies in the DB).

## Spec mapping

| Contract | Coverage |
|----------|----------|
| §7.1 read/write `.md` + YAML front-matter | `VaultStorage`, `MarkdownDocument` |
| §7.1 / §8 S2 path-traversal rejection + audit | `VaultPathGuard` + feature test |
| §7.1 incremental index-on-write | `NoteProjector` |
| §7.1 `vault:reindex` OOB reconcile | `VaultReindexer` + `vault:reindex` |
| §13 Q1 search projection | `notes.search_content` only |
| §13 Q4 nested folders | allowed with root validation |

## Tests

- Path traversal (`../../etc/passwd`) rejected + audited
- Front-matter parsed into projection
- Incremental write updates title / front-matter / tags
- `vault:reindex` picks up out-of-band disk edit
- Nested paths allowed; stale note rows removed on reindex
- Root-level notes resolve with the vault root as parent (regression covered)

## Out of scope (stop line)

Does **not** start PR3 (wikilinks/backlinks), PR4 (search API), PR5 (notes CRUD), or identity work.

## Docs

`STATUS.md` (PR2 in progress, PR3 next), `BACKLOG.md`, `CHANGELOG.md`, `docs/architecture.md`, `docs/deployment.md` updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-516f52a9-f575-45e8-8e63-c7b5bc09a01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-516f52a9-f575-45e8-8e63-c7b5bc09a01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

