### PR TITLE
docs: reconcile STATUS after PR1/PR2 merges

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-Follow the ordered PR sequence in the authoritative spec. PR2 delivers vault storage only; later PRs remain deferred:
+Follow the ordered PR sequence in the authoritative spec. PR0–PR2 are on `main`; later PRs remain deferred:
 
 - PR3: wikilink parsing, resolution, and backlinks (`note_links` projection).
 - PR4: the MySQL `FULLTEXT` index, query behavior, ranking, snippets, and search endpoint.

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,9 +18,9 @@
 - Configured, repeat-safe default tenant/workspace seeding without users or credentials
 - Data-model, scoping, relationship, and seeder feature tests
 - Schema/projection documentation
-- Merged to `main` with green Docker CI
+- Merged to `main` with green Docker CI (#2)
 
-## In progress — PR2 vault storage
+## Done — PR2 vault storage
 
 - Path-safe vault Markdown read/write rooted at each workspace `vault_path`
 - Symfony YAML front-matter parsing into the rebuildable `notes` projection
@@ -28,7 +28,8 @@
 - Bounded `vault:reindex --workspace=<id>` reconcile for out-of-band disk edits
 - Path-traversal rejection with audit coverage (§7.1 / §8 S2)
 - Wikilink / `note_links` extraction left as explicit PR3 TODO
+- Merged to `main` with green Docker CI (#3)
 
 ## Next — PR3 links & backlinks
 
-After PR2 is reviewed, merged, and green, implement wikilink parsing, resolution, and backlinks from §7.2. Do not begin PR3 as part of PR2.
+PR2 is merged and green. Next ordered unit is wikilink parsing, resolution, and backlinks from §7.2. Do not begin PR3 until explicitly scheduled after this status reconcile.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only reconcile after verifying `main` against the build plan.

### STEP 1 findings

| Unit | On `main`? | CI | `STATUS.md` before this PR |
|------|------------|----|----------------------------|
| PR0 scaffold (#1) | Yes | Green | Done |
| PR1 data model (#2) | Yes | Green | Already **Done** (no flip needed) |
| PR2 vault storage (#3) | Yes | Green (post-merge) | Stale **In progress** |

No missing PR1 acceptance criteria — schema, models, idempotent seed, and scoping/relationship/seeder tests are present on `main`.

### This PR

- Move **PR2 → Done** in `STATUS.md` (merged #3, green CI)
- Note PR3 as next ordered unit, **not started**
- Align `BACKLOG.md` intro with PR0–PR2 on `main`

No application code changes.

### STEP 2 / PR2 checkpoint (already shipped)

PR2 was already implemented and merged as [#3](https://github.com/suporterfid/jotter/pull/3). Not re-opened or re-implemented. Do **not** begin PR3.

**Vault-root resolution/canonicalization approach** (`VaultPathGuard`):
1. Validate the relative path string first (reject `..`, absolute/UNC/drive paths, null bytes) **before** any access to the candidate path
2. `realpath()` the workspace `vault_path` as the canonical root
3. Join + re-check the resolved path (and symlink targets / parents) stays under that root
4. On rejection: append `audit_log` event `vault.path_traversal_rejected`, throw `PathTraversalRejected`

**§7.1 acceptance tests on `main`** (`tests/Feature/VaultStorageTest.php`):
- (a) `test_path_traversal_is_rejected_before_filesystem_access_and_audited` — includes `../../etc/passwd`
- (b) `test_vault_reindex_picks_up_out_of_band_disk_edits` — title/front-matter/tags/`search_content` refreshed; wikilink/`note_links` deferred to PR3 per prior stop line

Post-merge `main` CI for #3 was green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-516f52a9-f575-45e8-8e63-c7b5bc09a01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-516f52a9-f575-45e8-8e63-c7b5bc09a01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

