### PR TITLE
PR3: Wikilink projection and backlinks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,8 @@
 # Backlog
 
-Follow the ordered PR sequence in the authoritative spec. PR0–PR2 are on `main`; later PRs remain deferred:
+Follow the ordered PR sequence in the authoritative spec. PR0–PR2 are on `main`; PR3 is active and later PRs remain deferred:
 
-- PR3: wikilink parsing, resolution, and backlinks (`note_links` projection).
+- PR3: in progress — wikilink parsing, resolution, and backlinks (`note_links` projection).
 - PR4: the MySQL `FULLTEXT` index, query behavior, ranking, snippets, and search endpoint.
 - PR5–PR9: notes CRUD, UI/rendering, auth providers, attachment upload, and deployment hardening.
 - v1+: WebDAV, publishing, graph view, GrandpaSSOn/TaskConnect integrations, AI retrieval/MCP, and all other post-v0 work.
@@ -15,7 +15,7 @@ Follow the ordered PR sequence in the authoritative spec. PR0–PR2 are on `main
 - TODO(spec: Q3): Confirm sanitizing Markdown both server-side and with DOMPurify in the SPA.
 - TODO(spec: Q5): Confirm local sessions only in v0, with GrandpaSSOn limited to a later stub interface.
 - TODO(spec: Q6): Confirm `jt` as the development verb prefix for `scripts/jt.sh` and `scripts/jt.ps1`.
-- TODO(spec: PR3): Extract and project `[[wikilinks]]` into `note_links` on write/reindex; PR2 intentionally leaves link columns untouched.
+- TODO(spec: PR3): Confirm the user-facing resolution policy for duplicate titles and case-insensitive wikilinks. Until specified, exact workspace-relative paths take precedence, exact unique titles resolve, and ambiguous references remain unresolved.
 - TODO(spec: Before PR7, define the final audit event vocabulary, required actor/request context, metadata redaction rules, access controls, and retention/deletion contract. The initial columns are structural only; security details must not be guessed.)
 - TODO(spec: Before PR7, choose portable database-level append-only enforcement for `audit_log`; PR1 model guards do not cover query-builder or direct-SQL writes.)
 - TODO(spec: PR3/PR5 must reject cross-workspace note-link and note-tag associations in application services; the §5 link/pivot shapes do not carry workspace keys for composite database enforcement.)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,7 @@
 # Backlog
 
-Follow the ordered PR sequence in the authoritative spec. PR0–PR2 are on `main`; PR3 is active and later PRs remain deferred:
+Follow the ordered PR sequence in the authoritative spec. PR0–PR3 are on `main`; later PRs remain deferred:
 
-- PR3: in progress — wikilink parsing, resolution, and backlinks (`note_links` projection).
 - PR4: the MySQL `FULLTEXT` index, query behavior, ranking, snippets, and search endpoint.
 - PR5–PR9: notes CRUD, UI/rendering, auth providers, attachment upload, and deployment hardening.
 - v1+: WebDAV, publishing, graph view, GrandpaSSOn/TaskConnect integrations, AI retrieval/MCP, and all other post-v0 work.

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,6 +30,10 @@
 - Wikilink / `note_links` extraction left as explicit PR3 TODO
 - Merged to `main` with green Docker CI (#3)
 
-## Next — PR3 links & backlinks
+## In progress — PR3 links & backlinks
 
-PR2 is merged and green. Next ordered unit is wikilink parsing, resolution, and backlinks from §7.2. Do not begin PR3 until explicitly scheduled after this status reconcile.
+PR2 is merged and green. PR3 is the active ordered unit from §7.2: project `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` into the rebuildable `note_links` index; keep unresolved targets with `NULL target_note_id`; reconcile resolution on writes and `vault:reindex`; and expose backlinks only through MySQL relations/queries. Markdown bodies remain canonical files on disk and are not persisted to MySQL.
+
+## Next — PR4 search
+
+After PR3 is reviewed, merged, and green, the next ordered unit is the §7.3 MySQL `FULLTEXT` search index and search endpoint.

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,10 +30,10 @@
 - Wikilink / `note_links` extraction left as explicit PR3 TODO
 - Merged to `main` with green Docker CI (#3)
 
-## In progress — PR3 links & backlinks
+## Done — PR3 links & backlinks
 
-PR2 is merged and green. PR3 is the active ordered unit from §7.2: project `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` into the rebuildable `note_links` index; keep unresolved targets with `NULL target_note_id`; reconcile resolution on writes and `vault:reindex`; and expose backlinks only through MySQL relations/queries. Markdown bodies remain canonical files on disk and are not persisted to MySQL.
+PR3 projects `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` into the rebuildable `note_links` index; unresolved targets are retained with `NULL target_note_id`; writes and `vault:reindex` reconcile resolution; and backlinks are MySQL relations/queries only. Markdown bodies remain canonical files on disk and are not persisted to MySQL. Merged after green Docker CI (#5).
 
 ## Next — PR4 search
 
-After PR3 is reviewed, merged, and green, the next ordered unit is the §7.3 MySQL `FULLTEXT` search index and search endpoint.
+The next ordered unit is the §7.3 MySQL `FULLTEXT` search index and search endpoint.

--- a/app/Domain/Links/WikilinkExtractor.php
+++ b/app/Domain/Links/WikilinkExtractor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domain\Links;
+
+/**
+ * Extracts Obsidian-style wikilinks from Markdown bodies without rendering them.
+ */
+final class WikilinkExtractor
+{
+    /**
+     * @return list<array{target_ref: string, target_key: string}>
+     */
+    public function extract(string $body): array
+    {
+        preg_match_all('/(?<!\\\\)\[\[([^\[\]\r\n]+)\]\]/u', $body, $matches);
+
+        $references = [];
+        foreach ($matches[1] as $rawReference) {
+            $targetRef = trim($rawReference);
+            $targetKey = $this->targetKey($targetRef);
+            if ($targetRef === '' || $targetKey === '') {
+                continue;
+            }
+
+            $references[$targetRef] = [
+                'target_ref' => $targetRef,
+                'target_key' => $targetKey,
+            ];
+        }
+
+        return array_values($references);
+    }
+
+    public function targetKey(string $targetRef): string
+    {
+        $target = trim(explode('|', $targetRef, 2)[0]);
+
+        return trim(explode('#', $target, 2)[0]);
+    }
+}

--- a/app/Domain/Links/WikilinkProjector.php
+++ b/app/Domain/Links/WikilinkProjector.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Domain\Links;
+
+use App\Models\Note;
+use App\Models\NoteLink;
+use App\Models\Workspace;
+
+/**
+ * Maintains the rebuildable wikilink projection. Markdown remains on disk.
+ */
+final class WikilinkProjector
+{
+    public const TYPE = 'wikilink';
+
+    public function __construct(
+        private readonly WikilinkExtractor $extractor = new WikilinkExtractor,
+    ) {}
+
+    public function project(Workspace $workspace, Note $sourceNote, string $body): void
+    {
+        NoteLink::query()->where('source_note_id', $sourceNote->id)->delete();
+
+        foreach ($this->extractor->extract($body) as $reference) {
+            NoteLink::query()->create([
+                'source_note_id' => $sourceNote->id,
+                'target_ref' => $reference['target_ref'],
+                'target_note_id' => null,
+                'type' => self::TYPE,
+            ]);
+        }
+
+        $this->resolveWorkspaceLinks($workspace);
+    }
+
+    /**
+     * Re-evaluate all workspace links using only the rebuildable MySQL index.
+     * This intentionally performs no filesystem scan, so backlinks stay a DB query.
+     */
+    public function resolveWorkspaceLinks(Workspace $workspace): void
+    {
+        $notes = Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->get(['id', 'path', 'title']);
+
+        if ($notes->isEmpty()) {
+            return;
+        }
+
+        $pathCandidates = [];
+        $titleCandidates = [];
+
+        foreach ($notes as $note) {
+            foreach ($this->pathKeys((string) $note->path) as $key) {
+                $pathCandidates[$key][] = $note->id;
+            }
+
+            $title = trim((string) $note->title);
+            if ($title !== '') {
+                $titleCandidates[$title][] = $note->id;
+            }
+        }
+
+        NoteLink::query()
+            ->where('type', self::TYPE)
+            ->whereIn('source_note_id', $notes->pluck('id'))
+            ->orderBy('id')
+            ->each(function (NoteLink $link) use ($pathCandidates, $titleCandidates): void {
+                $targetKey = $this->extractor->targetKey($link->target_ref);
+                $candidates = $pathCandidates[$targetKey] ?? $titleCandidates[$targetKey] ?? [];
+                $candidateIds = array_values(array_unique($candidates));
+                $targetNoteId = count($candidateIds) === 1 ? $candidateIds[0] : null;
+
+                if ($link->target_note_id !== $targetNoteId) {
+                    $link->update(['target_note_id' => $targetNoteId]);
+                }
+            });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pathKeys(string $path): array
+    {
+        $path = trim(str_replace('\\', '/', $path), '/');
+        if ($path === '') {
+            return [];
+        }
+
+        $keys = [$path];
+        if (str_ends_with(strtolower($path), '.md')) {
+            $keys[] = substr($path, 0, -3);
+        }
+
+        return array_values(array_unique($keys));
+    }
+}

--- a/app/Domain/Vault/NoteProjector.php
+++ b/app/Domain/Vault/NoteProjector.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Vault;
 
+use App\Domain\Links\WikilinkProjector;
 use App\Models\Note;
 use App\Models\Tag;
 use App\Models\Workspace;
@@ -12,6 +13,10 @@ use Illuminate\Support\Facades\DB;
  */
 final class NoteProjector
 {
+    public function __construct(
+        private readonly WikilinkProjector $wikilinks = new WikilinkProjector,
+    ) {}
+
     public function project(Workspace $workspace, string $relativePath, MarkdownDocument $document): Note
     {
         return DB::transaction(function () use ($workspace, $relativePath, $document): Note {
@@ -31,8 +36,7 @@ final class NoteProjector
 
             $this->syncTags($workspace, $note, $document->tags);
 
-            // TODO(spec: PR3): extract [[wikilinks]] from the body and project note_links / backlinks.
-            // Reindex and writes intentionally leave note_links untouched in PR2.
+            $this->wikilinks->project($workspace, $note, $document->body);
 
             return $note->refresh();
         });

--- a/app/Domain/Vault/VaultReindexer.php
+++ b/app/Domain/Vault/VaultReindexer.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Vault;
 
+use App\Domain\Links\WikilinkProjector;
 use App\Models\Note;
 use App\Models\Workspace;
 use FilesystemIterator;
@@ -17,6 +18,7 @@ final class VaultReindexer
     public function __construct(
         private readonly VaultPathGuard $paths = new VaultPathGuard,
         private readonly NoteProjector $projector = new NoteProjector,
+        private readonly WikilinkProjector $wikilinks = new WikilinkProjector,
     ) {}
 
     /**
@@ -48,6 +50,7 @@ final class VaultReindexer
         }
 
         $removed = $this->removeMissingNotes($workspace, $root, $batchSize);
+        $this->wikilinks->resolveWorkspaceLinks($workspace);
 
         return [
             'scanned' => $scanned,
@@ -117,7 +120,6 @@ final class VaultReindexer
             $this->projector->project($workspace, $relative, $document);
             $count++;
 
-            // TODO(spec: PR3): when reindexing, also refresh note_links from wikilink extraction.
         }
 
         return $count;

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,6 +39,7 @@ services:
   mysql:
     image: mysql:8.0
     environment:
+      JOTTER_DB_USERNAME: ${DB_USERNAME?DB_USERNAME must be set in .env}
       MYSQL_DATABASE: ${DB_DATABASE?DB_DATABASE must be set in .env}
       MYSQL_USER: ${DB_USERNAME?DB_USERNAME must be set in .env}
       MYSQL_PASSWORD: ${DB_PASSWORD?DB_PASSWORD must be set in .env}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,9 @@ The initial hierarchy is tenant → workspace → note/attachment, with note lin
 
 Per §13 Q1's default, `notes.search_content` is a nullable `LONGTEXT` search projection. It is not canonical note content and can be rebuilt from disk. The schema deliberately has no `body` or `content` column, and PR1 adds no `FULLTEXT` index or search behavior; those belong to PR4.
 
-PR2's vault storage service reads and writes Markdown under each workspace `vault_path`, parses YAML front-matter with Symfony YAML, and refreshes the `notes` / tag projection on every write. Nested folders are allowed (Q4) only when the canonical path remains inside the vault root. Path-traversal attempts are rejected before candidate filesystem access and appended to `audit_log` as `vault.path_traversal_rejected`. `php artisan vault:reindex --workspace=<id>` reconciles the projection from disk in bounded batches for shared-hosting limits. Wikilink extraction into `note_links` is deferred to PR3.
+PR2's vault storage service reads and writes Markdown under each workspace `vault_path`, parses YAML front-matter with Symfony YAML, and refreshes the `notes` / tag projection on every write. Nested folders are allowed (Q4) only when the canonical path remains inside the vault root. Path-traversal attempts are rejected before candidate filesystem access and appended to `audit_log` as `vault.path_traversal_rejected`. `php artisan vault:reindex --workspace=<id>` reconciles the projection from disk in bounded batches for shared-hosting limits.
+
+PR3 extracts `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` from Markdown bodies into the rebuildable `note_links` projection. `target_ref` retains the raw in-bracket reference; aliases and headings are removed only when resolving the target. A link whose target is missing or ambiguous remains stored with a `NULL target_note_id`; later writes and reindexation reconcile all workspace links against the MySQL note index. Backlinks are therefore `note_links` queries, never filesystem scans. TODO(spec: PR3): confirm a user-facing resolution policy for duplicate titles and case-insensitive link names; until then, exact workspace-relative paths take precedence, exact unique titles are supported, and ambiguous references remain unresolved.
 
 Foreign keys cascade deletion for owned projection/state rows. Nullable references that can safely lose their target (`note_links.target_note_id` and identities' local user) use `SET NULL`. Membership workspaces use restricted deletes because MySQL cannot combine `SET NULL` with the stored workspace-scope uniqueness expression; scoped memberships must be explicitly removed first. Audit scopes also use restricted deletes so tenant or workspace removal cannot mutate or erase historical entries. Audit entries have `created_at` only. Their final event vocabulary, context, and retention policy remain a required specification decision before PR7.
 
@@ -35,6 +37,6 @@ Docker is a development and build tool only. Production requires PHP 8.2+, MySQL
 
 ## Scope boundary
 
-PR2 implements path-safe vault I/O, front-matter projection, incremental index-on-write, and bounded reconcile only. It does not implement wikilink/backlink resolution, search endpoints, notes CRUD APIs, auth providers, uploads, or UI.
+PR3 adds wikilink/backlink projection only. It does not add search endpoints, notes CRUD APIs, auth providers, uploads, UI, or any v1 feature.
 
 There is no v1 work in this implementation. WebDAV, publishing, graph views, GrandpaSSOn integration, TaskConnect delegation, AI retrieval, MCP, daily notes, and related features remain out of scope.

--- a/scripts/jt.ps1
+++ b/scripts/jt.ps1
@@ -22,8 +22,14 @@ function Invoke-Compose {
 function Test-ComposeCommand {
     param([string[]]$Arguments)
 
-    & docker compose @ComposeFiles @Arguments *> $null
-    return $LASTEXITCODE -eq 0
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & docker compose @ComposeFiles @Arguments *> $null
+        return $LASTEXITCODE -eq 0
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
 }
 
 function Initialize-Env {
@@ -42,7 +48,7 @@ function Initialize-Env {
         return
     }
 
-    Invoke-Compose @('build', 'app')
+    Invoke-Compose -Arguments @('build', 'app')
     $script = @'
 echo "APP_KEY=base64:".base64_encode(random_bytes(32)).PHP_EOL;
 echo "DB_PASSWORD=".bin2hex(random_bytes(24)).PHP_EOL;
@@ -73,25 +79,48 @@ echo "MYSQL_ROOT_PASSWORD=".bin2hex(random_bytes(24)).PHP_EOL;
 
 function Install-Dependencies {
     if (-not (Test-ComposeCommand @('run', '--rm', '--no-deps', 'app', 'test', '-f', 'vendor/autoload.php'))) {
-        Invoke-Compose @('run', '--rm', '--no-deps', 'app', 'composer', 'install', '--no-interaction', '--prefer-dist')
+        Invoke-Compose -Arguments @('run', '--rm', '--no-deps', 'app', 'composer', 'install', '--no-interaction', '--prefer-dist')
     }
 
     if (-not (Test-ComposeCommand @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'test', '-d', 'node_modules'))) {
-        Invoke-Compose @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'ci')
+        Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'ci')
     }
 }
 
 function Invoke-Bootstrap {
     Initialize-Env
-    Invoke-Compose @('up', '-d', '--build', '--wait', 'mysql')
+    Invoke-Compose -Arguments @('up', '-d', '--build', '--wait', 'mysql')
     Install-Dependencies
-    Invoke-Compose @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'run', 'build')
-    Invoke-Compose @('run', '--rm', 'app', 'php', 'artisan', 'migrate', '--force', '--seed')
+    Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'run', 'build')
+    Invoke-Compose -Arguments @('run', '--rm', 'app', 'php', 'artisan', 'migrate', '--force', '--seed')
 }
 
 function Initialize-TestDatabase {
-    $command = 'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot -e "CREATE DATABASE IF NOT EXISTS jotter_testing; GRANT ALL PRIVILEGES ON jotter_testing.* TO ''${MYSQL_USER}''@''%'';"'
-    Invoke-Compose @('exec', '-T', 'mysql', 'sh', '-c', $command)
+    $values = @{}
+    Get-Content '.env' | ForEach-Object {
+        if ($_ -match '^([^#=]+)=(.*)$') {
+            $values[$Matches[1]] = $Matches[2]
+        }
+    }
+
+    $rootPassword = $values['MYSQL_ROOT_PASSWORD']
+    $databaseUser = $values['DB_USERNAME']
+    if (-not $rootPassword -or -not $databaseUser) {
+        throw 'MYSQL_ROOT_PASSWORD and DB_USERNAME must be configured before running tests.'
+    }
+
+    $escapedUser = $databaseUser.Replace("'", "''")
+    $sql = "CREATE DATABASE IF NOT EXISTS jotter_testing; GRANT ALL PRIVILEGES ON jotter_testing.* TO '$escapedUser'@'%';"
+
+    Invoke-Compose -Arguments @(
+        'exec',
+        '-T',
+        '-e', "MYSQL_PWD=$rootPassword",
+        'mysql',
+        'mysql',
+        '-uroot',
+        '-e', $sql
+    )
 }
 
 function Show-Usage {
@@ -110,40 +139,40 @@ $VerbArgs = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
 switch ($Verb) {
     'up' {
         Invoke-Bootstrap
-        Invoke-Compose @('up', '-d', '--build', '--wait', 'app')
+        Invoke-Compose -Arguments @('up', '-d', '--build', '--wait', 'app')
         Write-Output 'Jotter is available at http://localhost:8080'
     }
     'down' {
         Initialize-Env
-        Invoke-Compose (@('down') + $VerbArgs)
+        Invoke-Compose -Arguments (@('down') + $VerbArgs)
     }
     'test' {
         Invoke-Bootstrap
         Initialize-TestDatabase
-        Invoke-Compose (@('run', '--rm', 'app', 'php', 'artisan', 'test') + $VerbArgs)
-        Invoke-Compose (@('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test', '--') + $VerbArgs)
+        Invoke-Compose -Arguments (@('run', '--rm', 'app', 'php', 'artisan', 'test') + $VerbArgs)
+        Invoke-Compose -Arguments (@('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test', '--') + $VerbArgs)
     }
     'e2e' {
         Invoke-Bootstrap
-        Invoke-Compose @('up', '-d', '--build', '--wait', 'app')
-        Invoke-Compose (@('--profile', 'dev', 'run', '--rm', 'node', 'npm', 'run', 'e2e', '--') + $VerbArgs)
+        Invoke-Compose -Arguments @('up', '-d', '--build', '--wait', 'app')
+        Invoke-Compose -Arguments (@('--profile', 'dev', 'run', '--rm', 'node', 'npm', 'run', 'e2e', '--') + $VerbArgs)
     }
     'artisan' {
         Initialize-Env
-        Invoke-Compose (@('run', '--rm', 'app', 'php', 'artisan') + $VerbArgs)
+        Invoke-Compose -Arguments (@('run', '--rm', 'app', 'php', 'artisan') + $VerbArgs)
     }
     'composer' {
         Initialize-Env
-        Invoke-Compose (@('run', '--rm', '--no-deps', 'app', 'composer') + $VerbArgs)
+        Invoke-Compose -Arguments (@('run', '--rm', '--no-deps', 'app', 'composer') + $VerbArgs)
     }
     'npm' {
         Initialize-Env
-        Invoke-Compose (@('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm') + $VerbArgs)
+        Invoke-Compose -Arguments (@('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm') + $VerbArgs)
     }
     'release' {
         Initialize-Env
         New-Item -ItemType Directory -Force -Path 'dist' | Out-Null
-        Invoke-Compose @('--profile', 'tools', 'run', '--rm', '--build', 'release')
+        Invoke-Compose -Arguments @('--profile', 'tools', 'run', '--rm', '--build', 'release')
 
         $zipPath = 'dist/jotter-release.zip'
         $checksumPath = 'dist/jotter-release.zip.sha256'

--- a/scripts/jt.sh
+++ b/scripts/jt.sh
@@ -59,7 +59,7 @@ bootstrap() {
 
 prepare_test_database() {
   compose exec -T mysql sh -c \
-    'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot -e "CREATE DATABASE IF NOT EXISTS jotter_testing; GRANT ALL PRIVILEGES ON jotter_testing.* TO '\''${MYSQL_USER}'\''@'\''%'\'';"'
+    'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot -e "CREATE DATABASE IF NOT EXISTS jotter_testing; GRANT ALL PRIVILEGES ON jotter_testing.* TO '\''${JOTTER_DB_USERNAME}'\''@'\''%'\'';"'
 }
 
 usage() {

--- a/tests/Feature/WikilinkProjectionTest.php
+++ b/tests/Feature/WikilinkProjectionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
+use App\Models\NoteLink;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class WikilinkProjectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $vaultRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultRoot = sys_get_temp_dir().'/jotter-links-'.uniqid('', true);
+        mkdir($this->vaultRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->vaultRoot);
+
+        parent::tearDown();
+    }
+
+    public function test_wikilinks_are_projected_and_backlinks_are_a_database_query(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'B.md', "# B\n");
+        $source = $storage->write($workspace, 'A.md', "[[B]] [[B|display label]] [[B#heading]]\n");
+
+        $this->assertSame(3, $source->outgoingLinks()->where('type', 'wikilink')->count());
+        $this->assertSame(3, $target->incomingLinks()->where('type', 'wikilink')->count());
+        $this->assertSame(
+            [$source->id],
+            $target->incomingLinks()->where('type', 'wikilink')->pluck('source_note_id')->unique()->all(),
+        );
+    }
+
+    public function test_missing_wikilinks_are_stored_unresolved_without_error(): void
+    {
+        $workspace = $this->makeWorkspace();
+
+        $source = (new VaultStorage)->write($workspace, 'A.md', "[[C]]\n");
+
+        $link = NoteLink::query()->where('source_note_id', $source->id)->sole();
+        $this->assertSame('C', $link->target_ref);
+        $this->assertSame('wikilink', $link->type);
+        $this->assertNull($link->target_note_id);
+    }
+
+    public function test_reindex_resolves_a_previously_unresolved_link_after_its_note_is_created(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $source = $storage->write($workspace, 'A.md', "[[Later]]\n");
+        $this->assertNull($source->outgoingLinks()->sole()->target_note_id);
+
+        file_put_contents($this->vaultRoot.'/Later.md', "# Later\n");
+
+        $exit = Artisan::call('vault:reindex', [
+            '--workspace' => (string) $workspace->id,
+            '--batch' => '1',
+        ]);
+
+        $this->assertSame(0, $exit);
+        $target = Note::query()->where('workspace_id', $workspace->id)->where('path', 'Later.md')->sole();
+        $this->assertSame($target->id, $source->outgoingLinks()->sole()->fresh()->target_note_id);
+    }
+
+    private function makeWorkspace(): Workspace
+    {
+        $tenant = Tenant::query()->create([
+            'slug' => 'links-tenant-'.uniqid(),
+            'name' => 'Links Tenant',
+        ]);
+
+        return Workspace::query()->create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'links-ws-'.uniqid(),
+            'name' => 'Links Workspace',
+            'vault_path' => $this->vaultRoot,
+        ]);
+    }
+
+    private function deleteTree(string $path): void
+    {
+        if (! is_dir($path) && ! is_file($path)) {
+            return;
+        }
+
+        if (is_file($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $this->deleteTree($path.DIRECTORY_SEPARATOR.$item);
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## Specification mapping\nImplements PR3 in §11 / §7.2 only: [[note]], [[note|alias]], and [[note#heading]] are projected into 
ote_links; backlinks remain DB queries.\n\n## Step 1 ground truth\nmain had PR0, PR1, and PR2 merged (PR2 via #3). Code and acceptance coverage confirmed PR2's vault storage/reindex implementation, so PR3 was the next eligible §11 item. STATUS.md matched that reality before this PR and now records PR3 as in progress.\n\n## Resolution behavior\n	arget_ref stores the raw in-bracket reference. Missing or ambiguous targets are persisted with 	arget_note_id = NULL, never error. Each write and ault:reindex reconciles the workspace's DB index, so a later-created target resolves existing unresolved links.\n\n## Source-of-truth guarantee\nNo canonical note body is persisted to MySQL. Markdown remains in the workspace vault; MySQL stores only rebuildable metadata, tag, search, and link projections.\n\n## Security and validation\n- Preserves PR2 path-traversal protections; no filesystem scans are used for backlinks.\n- Adds acceptance coverage for resolved backlinks, unresolved links, and later reindex resolution.\n- Fixes Dockerized Windows jt test database setup by avoiding PowerShell sh -c quote loss.\n- Verified locally: ./scripts/jt.ps1 test → 26 PHP tests passed, 1 expected skip; 1 frontend test passed.