### PR TITLE
feat: add workspace full-text search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /auth.json
 /dist
 /frontend/node_modules
+/frontend/test-results
 /node_modules
 /public/build
 /public/hot

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,14 +1,13 @@
 # Backlog
 
-Follow the ordered PR sequence in the authoritative spec. PR0–PR3 are on `main`; later PRs remain deferred:
+Follow the ordered PR sequence in the authoritative spec. PR0–PR3 are on `main`; PR4 is ready for review and has not yet merged:
 
-- PR4: the MySQL `FULLTEXT` index, query behavior, ranking, snippets, and search endpoint.
 - PR5–PR9: notes CRUD, UI/rendering, auth providers, attachment upload, and deployment hardening.
 - v1+: WebDAV, publishing, graph view, GrandpaSSOn/TaskConnect integrations, AI retrieval/MCP, and all other post-v0 work.
 
 ## Specification decisions and open items
 
-- Q1 default adopted: nullable `notes.search_content` is a rebuildable search projection; disk Markdown remains canonical. Creating its `FULLTEXT` index and implementing search remain deferred to PR4.
+- Q1 default adopted: nullable `notes.search_content` is a rebuildable search projection; disk Markdown remains canonical. PR4 adds the `FULLTEXT` index and search endpoint without persisting canonical note bodies.
 - Q4 default adopted: nested folders are allowed within each workspace vault; every path is canonicalized and must resolve inside the workspace root before filesystem access.
 - TODO(spec: Q2): Confirm `league/commonmark` plus a custom `[[ ]]` inline parser.
 - TODO(spec: Q3): Confirm sanitizing Markdown both server-side and with DOMPurify in the SPA.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 Self-hosted, Markdown knowledge base for the cPanel your grandpa never gave up. Plain `.md` files, PHP + MySQL, your notes stay yours.
 
-Jotter currently ships through PR2: Laravel 12, a minimal Vue 3 landing screen, MySQL 8, a Docker-only development loop, the multi-workspace data model, and a path-safe vault storage service that keeps Markdown files on disk as the source of truth. Search endpoints, notes CRUD APIs, wikilinks/backlinks, attachment upload, and identity-provider features remain later PRs.
+Jotter currently ships through PR3: Laravel 12, a minimal Vue 3 landing screen, MySQL 8, a Docker-only development loop, the multi-workspace data model, path-safe vault storage, and rebuildable wikilink/backlink projection. PR4 adds the workspace-scoped search API; notes CRUD APIs, the editor UI, attachment upload, and identity-provider features remain later PRs.
 
 ## Requirements
 
 - Docker with Docker Compose V2
 - No host PHP, Composer, Node, npm, or MySQL installation
+
+The frontend dependency tree runs from a Docker named volume, so the `jt` commands do not depend on a host `node_modules` directory or its bind-mount performance.
 
 ## Start from a clean clone
 
@@ -53,6 +55,10 @@ The release zip contains a deployable `app/` tree with production Composer depen
 ## Architecture
 
 The intended source of truth is Markdown on disk; MySQL is a rebuildable index and application-state store. See [docs/architecture.md](docs/architecture.md) and the [authoritative initial spec](docs/jotter-initial-spec-and-build-plan.md).
+
+## Search API
+
+PR4 exposes `GET /api/workspaces/{workspace}/search?q=...`. It searches the MySQL `FULLTEXT(title, search_content)` projection within one workspace and returns at most 50 ranked matches with an id, path, title, bounded snippet, and relevance score. `search_content` is never returned or treated as canonical note content; the Markdown file remains the source of truth. Authentication is intentionally deferred to PR7, following the ordered build plan.
 
 ## License
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -34,6 +34,16 @@
 
 PR3 projects `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` into the rebuildable `note_links` index; unresolved targets are retained with `NULL target_note_id`; writes and `vault:reindex` reconcile resolution; and backlinks are MySQL relations/queries only. Markdown bodies remain canonical files on disk and are not persisted to MySQL. Merged after green Docker CI (#5).
 
-## Next — PR4 search
+## Done — PR4 search (ready for review)
 
-The next ordered unit is the §7.3 MySQL `FULLTEXT` search index and search endpoint.
+- MySQL `FULLTEXT(title, search_content)` index, kept rebuildable from the vault projection
+- Read-only `GET /api/workspaces/{workspace}/search?q=` endpoint with workspace scope, ranking, bounded snippets, and input validation
+- No canonical Markdown body is returned or stored outside the rebuildable `search_content` projection
+- Docker feature tests cover the index, ranking, workspace isolation, snippets, and query validation
+- Frontend dependencies run from a named Docker volume; `jt test` no longer starts jsdom workers from the slow host bind mount
+- Playwright navigation and test timeouts allow the Docker browser to finish the cold app load without aborting its frame
+- `jt test` forces Laravel onto `jotter_testing`, keeping test migrations out of the seeded development database
+
+## Next — PR5 notes CRUD API
+
+The next ordered unit after PR4 merges green is the §7.4 workspace-scoped notes CRUD API behind the future auth guard placeholder. PR4 has not been merged into `main` yet.

--- a/app/Domain/Search/WorkspaceSearch.php
+++ b/app/Domain/Search/WorkspaceSearch.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Domain\Search;
+
+use App\Models\Note;
+use App\Models\Workspace;
+
+final class WorkspaceSearch
+{
+    private const RESULT_LIMIT = 50;
+
+    private const SNIPPET_LENGTH = 240;
+
+    /**
+     * @return list<array{id: int, path: string, title: string, snippet: string, relevance: float}>
+     */
+    public function search(Workspace $workspace, string $query): array
+    {
+        $match = 'MATCH(title, search_content) AGAINST (? IN NATURAL LANGUAGE MODE)';
+
+        return Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->whereRaw($match, [$query])
+            ->select(['id', 'path', 'title', 'search_content'])
+            ->selectRaw($match.' AS relevance', [$query])
+            ->orderByDesc('relevance')
+            ->orderBy('id')
+            ->limit(self::RESULT_LIMIT)
+            ->get()
+            ->map(fn (Note $note): array => [
+                'id' => $note->id,
+                'path' => $note->path,
+                'title' => $note->title,
+                'snippet' => $this->snippet($note->title, $note->search_content ?? '', $query),
+                'relevance' => (float) $note->relevance,
+            ])
+            ->all();
+    }
+
+    private function snippet(string $title, string $content, string $query): string
+    {
+        $title = trim((string) preg_replace('/\s+/u', ' ', $title));
+        $content = trim((string) preg_replace('/\s+/u', ' ', $content));
+
+        foreach ($this->terms($query) as $term) {
+            $titlePosition = mb_stripos($title, $term);
+            if ($titlePosition !== false) {
+                return $this->excerpt($title, $titlePosition);
+            }
+        }
+
+        $position = null;
+        foreach ($this->terms($query) as $term) {
+            $termPosition = mb_stripos($content, $term);
+            if ($termPosition !== false && ($position === null || $termPosition < $position)) {
+                $position = $termPosition;
+            }
+        }
+
+        if ($position !== null) {
+            return $this->excerpt($content, $position);
+        }
+
+        if ($content !== '') {
+            return mb_strimwidth($content, 0, self::SNIPPET_LENGTH, '…');
+        }
+
+        return mb_strimwidth($title, 0, self::SNIPPET_LENGTH, '…');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function terms(string $query): array
+    {
+        $terms = preg_split('/[^\p{L}\p{N}_]+/u', $query) ?: [];
+
+        return array_values(array_unique(array_filter($terms, fn (string $term): bool => $term !== '')));
+    }
+
+    private function excerpt(string $value, int $position): string
+    {
+        $start = max(0, $position - 80);
+        $prefix = $start > 0 ? '…' : '';
+        $length = self::SNIPPET_LENGTH - mb_strlen($prefix);
+        $snippet = mb_strimwidth(mb_substr($value, $start), 0, $length, '…');
+
+        return $prefix.$snippet;
+    }
+}

--- a/app/Http/Controllers/WorkspaceSearchController.php
+++ b/app/Http/Controllers/WorkspaceSearchController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Search\WorkspaceSearch;
+use App\Models\Workspace;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class WorkspaceSearchController extends Controller
+{
+    public function __invoke(Request $request, Workspace $workspace, WorkspaceSearch $search): JsonResponse
+    {
+        $validated = $request->validate([
+            'q' => ['required', 'string', 'max:200', 'not_regex:/^\s*$/u'],
+        ]);
+
+        return response()->json([
+            'data' => $search->search($workspace, trim($validated['q'])),
+        ]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/compose.yaml
+++ b/compose.yaml
@@ -62,6 +62,7 @@ services:
     working_dir: /var/www/html/frontend
     volumes:
       - .:/var/www/html
+      - frontend_node_modules:/var/www/html/frontend/node_modules
       - npm_cache:/root/.npm
     environment:
       CI: ${CI:-false}
@@ -84,4 +85,5 @@ services:
 volumes:
   mysql_data:
   composer_cache:
+  frontend_node_modules:
   npm_cache:

--- a/database/migrations/2026_07_23_000001_add_notes_search_fulltext_index.php
+++ b/database/migrations/2026_07_23_000001_add_notes_search_fulltext_index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const INDEX = 'notes_title_search_content_fulltext';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('notes') || Schema::hasIndex('notes', self::INDEX)) {
+            return;
+        }
+
+        Schema::table('notes', function (Blueprint $table): void {
+            $table->fullText(['title', 'search_content'], self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('notes') || ! Schema::hasIndex('notes', self::INDEX)) {
+            return;
+        }
+
+        Schema::table('notes', function (Blueprint $table): void {
+            $table->dropFullText(self::INDEX);
+        });
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,13 @@ Jotter's vault data lives as plain `.md` files under a workspace-specific direct
 
 The initial hierarchy is tenant → workspace → note/attachment, with note links, tags, identities, memberships, and an append-only audit log. Tenant and workspace foreign keys make ownership explicit, while paths and tag names are unique only within their owning workspace.
 
-Per §13 Q1's default, `notes.search_content` is a nullable `LONGTEXT` search projection. It is not canonical note content and can be rebuilt from disk. The schema deliberately has no `body` or `content` column, and PR1 adds no `FULLTEXT` index or search behavior; those belong to PR4.
+Per §13 Q1's default, `notes.search_content` is a nullable `LONGTEXT` search projection. It is not canonical note content and can be rebuilt from disk. The schema deliberately has no `body` or `content` column. PR4 adds a MySQL `FULLTEXT(title, search_content)` index over that metadata/projection pair; deleting or rebuilding the index never changes the vault files.
 
 PR2's vault storage service reads and writes Markdown under each workspace `vault_path`, parses YAML front-matter with Symfony YAML, and refreshes the `notes` / tag projection on every write. Nested folders are allowed (Q4) only when the canonical path remains inside the vault root. Path-traversal attempts are rejected before candidate filesystem access and appended to `audit_log` as `vault.path_traversal_rejected`. `php artisan vault:reindex --workspace=<id>` reconciles the projection from disk in bounded batches for shared-hosting limits.
 
 PR3 extracts `[[note]]`, `[[note|alias]]`, and `[[note#heading]]` from Markdown bodies into the rebuildable `note_links` projection. `target_ref` retains the raw in-bracket reference; aliases and headings are removed only when resolving the target. A link whose target is missing or ambiguous remains stored with a `NULL target_note_id`; later writes and reindexation reconcile all workspace links against the MySQL note index. Backlinks are therefore `note_links` queries, never filesystem scans. TODO(spec: PR3): confirm a user-facing resolution policy for duplicate titles and case-insensitive link names; until then, exact workspace-relative paths take precedence, exact unique titles are supported, and ambiguous references remain unresolved.
+
+PR4's read-only `GET /api/workspaces/{workspace}/search?q=` endpoint executes a parameter-bound MySQL FULLTEXT query scoped by `workspace_id`, ranks by the returned relevance score, and returns only note metadata plus a bounded excerpt derived from the projection. The endpoint never reads vault files and never exposes `search_content`; the separate PR5 CRUD API and PR7 authorization guard remain out of scope.
 
 Foreign keys cascade deletion for owned projection/state rows. Nullable references that can safely lose their target (`note_links.target_note_id` and identities' local user) use `SET NULL`. Membership workspaces use restricted deletes because MySQL cannot combine `SET NULL` with the stored workspace-scope uniqueness expression; scoped memberships must be explicitly removed first. Audit scopes also use restricted deletes so tenant or workspace removal cannot mutate or erase historical entries. Audit entries have `created_at` only. Their final event vocabulary, context, and retention policy remain a required specification decision before PR7.
 
@@ -37,6 +39,6 @@ Docker is a development and build tool only. Production requires PHP 8.2+, MySQL
 
 ## Scope boundary
 
-PR3 adds wikilink/backlink projection only. It does not add search endpoints, notes CRUD APIs, auth providers, uploads, UI, or any v1 feature.
+PR4 adds the MySQL FULLTEXT index and read-only search endpoint only. It does not add notes CRUD APIs, auth providers, uploads, UI, or any v1 feature.
 
 There is no v1 work in this implementation. WebDAV, publishing, graph views, GrandpaSSOn integration, TaskConnect delegation, AI retrieval, MCP, daily notes, and related features remain out of scope.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,8 +6,10 @@ export default defineConfig({
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
   reporter: 'list',
+  timeout: 60_000,
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://jotter-web',
+    navigationTimeout: 60_000,
     trace: 'on-first-retry',
   },
   projects: [

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\WorkspaceSearchController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/workspaces/{workspace}/search', WorkspaceSearchController::class);

--- a/scripts/jt.ps1
+++ b/scripts/jt.ps1
@@ -82,9 +82,7 @@ function Install-Dependencies {
         Invoke-Compose -Arguments @('run', '--rm', '--no-deps', 'app', 'composer', 'install', '--no-interaction', '--prefer-dist')
     }
 
-    if (-not (Test-ComposeCommand @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'test', '-d', 'node_modules'))) {
-        Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'ci')
-    }
+    Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'ci')
 }
 
 function Invoke-Bootstrap {
@@ -149,7 +147,7 @@ switch ($Verb) {
     'test' {
         Invoke-Bootstrap
         Initialize-TestDatabase
-        Invoke-Compose -Arguments (@('run', '--rm', 'app', 'php', 'artisan', 'test') + $VerbArgs)
+        Invoke-Compose -Arguments (@('run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app', 'php', 'artisan', 'test') + $VerbArgs)
         Invoke-Compose -Arguments (@('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test', '--') + $VerbArgs)
     }
     'e2e' {

--- a/scripts/jt.sh
+++ b/scripts/jt.sh
@@ -44,9 +44,7 @@ install_dependencies() {
     compose run --rm --no-deps app composer install --no-interaction --prefer-dist
   fi
 
-  if ! compose --profile dev run --rm --no-deps node test -d node_modules; then
-    compose --profile dev run --rm --no-deps node npm ci
-  fi
+  compose --profile dev run --rm --no-deps node npm ci
 }
 
 bootstrap() {
@@ -89,7 +87,7 @@ cmd_up() {
 cmd_test() {
   bootstrap
   prepare_test_database
-  compose run --rm app php artisan test "$@"
+  compose run --rm -e DB_DATABASE=jotter_testing app php artisan test "$@"
   compose --profile dev run --rm --no-deps node npm test -- "$@"
 }
 

--- a/tests/Feature/WorkspaceSearchTest.php
+++ b/tests/Feature/WorkspaceSearchTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class WorkspaceSearchTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    private string $vaultRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultRoot = sys_get_temp_dir().'/jotter-search-'.uniqid('', true);
+        mkdir($this->vaultRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->vaultRoot);
+
+        parent::tearDown();
+    }
+
+    public function test_notes_have_a_fulltext_index_for_the_rebuildable_title_and_search_projection(): void
+    {
+        $this->assertTrue(
+            Schema::hasIndex('notes', 'notes_title_search_content_fulltext', 'fulltext'),
+        );
+    }
+
+    public function test_search_returns_ranked_workspace_scoped_matches_with_snippets(): void
+    {
+        $workspace = $this->makeWorkspace('primary');
+        $otherWorkspace = $this->makeWorkspace('other');
+        $storage = new VaultStorage;
+
+        $titleMatch = $storage->write($workspace, 'rare-title.md', "# Zephyrneedle\nA short body.\n");
+        $storage->write($workspace, 'body-match.md', "# Body match\nZephyrneedle appears only in this projected body.\n");
+        $storage->write($otherWorkspace, 'private.md', "# Zephyrneedle\nThis must not cross workspace boundaries.\n");
+        foreach (range(1, 4) as $number) {
+            $storage->write($workspace, "filler-{$number}.md", "# Filler {$number}\nUnrelated notebook material.\n");
+        }
+
+        $response = $this->getJson("/api/workspaces/{$workspace->id}/search?q=Zephyrneedle");
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $titleMatch->id)
+            ->assertJsonPath('data.0.path', 'rare-title.md')
+            ->assertJsonPath('data.0.title', 'Zephyrneedle')
+            ->assertJsonMissing(['path' => 'private.md']);
+
+        $results = $response->json('data');
+        $this->assertCount(2, $results);
+        $this->assertIsFloat($results[0]['relevance']);
+        $this->assertGreaterThanOrEqual($results[1]['relevance'], $results[0]['relevance']);
+        $this->assertStringContainsString('Zephyrneedle', $results[0]['snippet']);
+        $this->assertLessThanOrEqual(240, mb_strlen($results[0]['snippet']));
+        $this->assertArrayNotHasKey('search_content', $results[0]);
+    }
+
+    public function test_search_requires_a_non_blank_bounded_query(): void
+    {
+        $workspace = $this->makeWorkspace('validation');
+
+        $this->getJson("/api/workspaces/{$workspace->id}/search")
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('q');
+
+        $this->getJson("/api/workspaces/{$workspace->id}/search?q=%20%20%20")
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('q');
+
+        $this->getJson('/api/workspaces/'.$workspace->id.'/search?q='.str_repeat('a', 201))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('q');
+    }
+
+    public function test_search_snippets_include_a_matched_title_or_query_term(): void
+    {
+        $workspace = $this->makeWorkspace('snippets');
+        $storage = new VaultStorage;
+
+        $storage->write($workspace, 'title-only.md', "---\ntitle: Auroracrown\n---\nBody without the title token.\n");
+
+        $titleOnly = $this->getJson("/api/workspaces/{$workspace->id}/search?q=Auroracrown");
+        $titleOnly
+            ->assertOk()
+            ->assertJsonPath('data.0.title', 'Auroracrown');
+        $this->assertStringContainsString('Auroracrown', $titleOnly->json('data.0.snippet'));
+
+        $workspace = $this->makeWorkspace('multi-term');
+        $storage->write(
+            $workspace,
+            'multi-term.md',
+            "---\ntitle: Nebulaquartz\n---\n".str_repeat('filler ', 80).'Cometfrost appears after the excerpt boundary.',
+        );
+
+        $multiTerm = $this->getJson("/api/workspaces/{$workspace->id}/search?q=Nebulaquartz%20Cometfrost");
+        $multiTerm->assertOk()->assertJsonPath('data.0.title', 'Nebulaquartz');
+
+        $snippet = $multiTerm->json('data.0.snippet');
+        $this->assertTrue(
+            str_contains($snippet, 'Nebulaquartz') || str_contains($snippet, 'Cometfrost'),
+            "Expected a snippet around one of the matched query terms, got [{$snippet}].",
+        );
+    }
+
+    private function makeWorkspace(string $suffix): Workspace
+    {
+        $tenant = Tenant::query()->create([
+            'slug' => "search-tenant-{$suffix}-".uniqid(),
+            'name' => 'Search Tenant',
+        ]);
+
+        return Workspace::query()->create([
+            'tenant_id' => $tenant->id,
+            'slug' => "search-ws-{$suffix}-".uniqid(),
+            'name' => 'Search Workspace',
+            'vault_path' => $this->vaultRoot.'/'.$suffix,
+        ]);
+    }
+
+    private function deleteTree(string $path): void
+    {
+        if (! is_dir($path) && ! is_file($path)) {
+            return;
+        }
+
+        if (is_file($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $this->deleteTree($path.DIRECTORY_SEPARATOR.$item);
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## PR4 — Search (§7.3)

Implements the ordered PR4 unit only: a workspace-scoped MySQL `FULLTEXT(title, search_content)` index and a read-only search API. The response returns ranked metadata and bounded snippets; it never returns `search_content`.

## Ground truth at implementation start

`main` had PR3, Links & backlinks (§7.2), merged in PR #5 at `2f039ec9443d16c85a3e9d09258920cfd107e691`. PR4 Search (§7.3) was the next unmerged §11 unit. `STATUS.md` matched that reality, so no stale-status correction was needed before implementation.

## Search behavior

- `GET /api/workspaces/{workspace}/search?q=` validates a nonblank query of at most 200 characters.
- The parameter-bound MySQL natural-language FULLTEXT query is constrained by `workspace_id`, ordered by relevance, and capped at 50 results.
- Snippets are bounded to 240 characters and prioritize a matching title term, then the nearest matching body term.
- Feature coverage verifies the FULLTEXT index, ranking, workspace isolation, snippets, and invalid queries.

## Docker test reliability

- Frontend dependencies use a named Docker volume, and `jt` always runs containerized `npm ci` so the volume follows `package-lock.json`.
- `jt test` explicitly uses `jotter_testing`, isolating test migrations from the seeded development database.
- Playwright’s Docker navigation/test timeouts allow cold application loads to complete without the former `ERR_ABORTED` / detached-frame failure.

## Canonical content

No canonical note body is persisted to MySQL. `notes.search_content` remains a rebuildable projection of the Markdown vault files, which remain the source of truth.

## Verification

- `./scripts/jt.ps1 test` — 31 PHPUnit tests / 154 assertions and frontend Vitest passed
- `./scripts/jt.ps1 e2e` — Playwright smoke test passed
- `./scripts/jt.ps1 release` — release archive verification passed

## Scope

No PR5+ or v1 work. Notes CRUD, UI, authentication, uploads, integrations, and publishing remain deferred.