### PR TITLE
docs: reconcile spec, backlog, and status with the AI-agent product roadmap

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,16 +1,73 @@
-# Jotter — Backlog (v1 and v2 Feature Roadmap)
+# Jotter — Backlog
 
-## v1 Roadmap (Next Cycle)
+Sequenced from `docs/20260727-jotter-roadmap-ai-agent.md` (product roadmap) within the constraints of `docs/jotter-initial-spec-and-build-plan.md` §14. Where the two disagree, the spec's §8 security constraints, §4 shared-hosting constraints, and §1 Markdown-on-disk invariant win, and the item sits in **Needs a decision** below until resolved.
 
-- [ ] **SabreDAV WebDAV Integration**: Direct sync endpoint for Obsidian Mobile / Desktop native syncing.
-- [ ] **Static Site Publishing**: Export workspace notes as a static HTML website with navigation.
-- [ ] **AI-KB Layer 1 & MCP Server**: `llms.txt` generation and Model Context Protocol (MCP) server for AI agent integration.
-- [ ] **Daily Notes & Templates**: Automatic daily note generator and Markdown template support.
-- [ ] **Broken Link Report**: Workspace-wide report of unresolved `[[wikilinks]]`.
+Roadmap priorities 1–5 (search, nested folders, tags, backlinks, attachments) are **already delivered** — see spec §14.3. The roadmap's gap analysis lists them as missing because its baseline describes a different product; do not re-plan them.
 
-## v2 Roadmap (Future)
+---
 
-- [ ] **Document Parsing**: PDF / DOCX / PPTX conversion to Markdown via TaskConnect.
-- [ ] **Web Crawler**: Web page capture to Markdown notes.
-- [ ] **Embeddings & RAG**: Vector store index for semantic note search.
-- [ ] **Visual Canvas & Mind Map**: Node canvas editor for notes.
+## Delivered (not backlog — recorded so the roadmap is not re-planned against it)
+
+- Full-text search, nested vault folders, tags + front-matter projection, backlinks, attachments — v0 §7.
+- Command palette, note graph view, tag cloud, task lists, code-copy — post-v0 UI.
+- WebDAV sync endpoint, workspace ZIP export, static-site publishing, `llms.txt` (AI-KB Layer 1), audit-log query, server-side CommonMark rendering + sanitization, `JobDispatcher` seam.
+
+> **Correction:** the WebDAV adapter is a hand-rolled Laravel route handler (`app/Http/Controllers/WebDavController.php`). `sabre/dav` is **not** a dependency, despite "SabreDAV" appearing in the commit message and earlier status notes. Adopting SabreDAV proper is a separate, unplanned decision.
+
+---
+
+## Milestone A — knowledge foundations (near-term)
+
+The only Phase 1 items the product does not already have.
+
+- [ ] **Version history** — roadmap priority 6; promoted from v2 to v1 (spec §6). Revision snapshots with restore. **Storage design is constrained:** no per-revision files in the vault (spec §14.5 C6, §4 inode quotas). Decide DB-stored deltas vs. bounded snapshot retention first.
+- [ ] **Search filters** — roadmap priority 1 asks for filters by title, tags, and modified date. Current search is unfiltered natural-language `FULLTEXT` matching only.
+- [ ] **Markdown / JSON import** — export ships; the inbound half does not. Must route through `VaultPathGuard` and the reindex path.
+
+## Milestone B — connected knowledge
+
+- [ ] **Daily notes and templates** — roadmap priority 7; already scoped as v1.
+- [ ] **Broken-link report** — workspace-wide report of unresolved `[[wikilinks]]`. The unresolved rows already exist in `note_links`; this is the reporting surface.
+- [ ] **Typed note properties** — roadmap priority 3's missing half. Front-matter is parsed and projected, but there is no typed property layer. Gates the metadata table view.
+- [ ] **Richer block / slash-command surface** — callouts, toggles, tables, dividers, embeds.
+- [ ] **MCP server** — the second half of AI-KB Layer 1; `llms.txt` retrieval already ships.
+
+## Milestone C — team collaboration
+
+- [ ] **GrandpaSSOn identity adapter** — consume tenancy claims and RBAC. The stub and the `IdentityProvider` seam already exist.
+- [ ] **Workspace administration UI** — `tenants` / `workspaces` / `memberships` with roles exist and are enforced; there is no surface for managing them.
+- [ ] **Comments and mentions** — roadmap priority 9. Needs new §5 schema and §8 S5 authorization. Asynchronous only (see C1).
+- [ ] **Notification / event bus** — should reuse the audit-log event infrastructure per the roadmap's dependency map.
+
+## Milestone D — structured work
+
+Blocked on decision **C2**. Do not begin without it.
+
+- [ ] **Metadata table view** — roadmap priority 11.
+- [ ] **Board / calendar views** — roadmap priority 12.
+- [ ] **Relations and linked records.**
+
+## v2 — later
+
+- [ ] **Document parsing** — PDF / DOCX / PPTX → Markdown, delegated to TaskConnect.
+- [ ] **Web crawler** — web page capture to Markdown.
+- [ ] **Embeddings and RAG** — semantic search over the vault.
+
+---
+
+## Needs a decision (spec §14.5)
+
+These block the roadmap items above. Until each is answered, the constraint wins.
+
+- **C1 — Collaboration model.** Roadmap Phase 3 lists presence indicators; its baseline assumes realtime collaboration. Spec §3 N1 and §4 exclude both — no websockets on shared hosting. `TODO(spec): confirm collaboration stays asynchronous — comments and mentions yes, presence and live cursors no.`
+- **C2 — Structured collections.** Roadmap Phase 4 wants database-like collections over note metadata. Spec §1 says MySQL is only an index. `TODO(spec): decide whether collections project from front-matter on disk, or whether the Markdown-on-disk invariant is being amended.`
+- **C3 — Synced blocks.** Roadmap priority 8. Transclusion that does not degrade to readable Markdown breaks Obsidian compatibility. `TODO(spec): choose a plain-Markdown-safe syntax, or drop the item.`
+- **C5 — Offline / mobile-first.** Roadmap Phase 5 differentiators contradict §2's deliberate local-first inversion. `TODO(spec): confirm WebDAV + Obsidian is the mobile and offline answer.`
+- **C6 — History storage.** See Milestone A. `TODO(spec): DB deltas or bounded snapshots; no per-revision files in the vault.`
+- **Roadmap baseline provenance.** `TODO(spec): confirm whether the roadmap's gap analysis was drawn from a different product of the same name. Until confirmed, spec §14.3 governs what counts as delivered.`
+
+## Not adopted
+
+- **Visual canvas / whiteboard** — spec §3 N3; the roadmap itself lists whiteboard parity as a non-goal for the next cycle.
+- **Chat-and-files parity, full database-view breadth** — named as non-goals by the roadmap.
+- **Realtime multi-user editing** — spec §3 N1, permanently out on shared hosting.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,41 +1,55 @@
 # Jotter — Project Status
 
-- **Current Version:** v0.9.0-prod (v0 Spec Complete & Verified + v1 Enhancements)
-- **Last Updated:** 2026-07-27
+- **Current Version:** v0.9.0 (v0 spec contracts complete; v1 work in progress)
+- **Last Updated:** 2026-07-28
 - **Repo:** https://github.com/suporterfid/jotter
 - **Production Site:** https://hub.taskconnect.com.br/
-- **CI Status:** 🟢 100% Green (`59/59 PHPUnit`, `7/7 Vitest`)
+- **CI Status:** 🔴 Red on `main` — PHPUnit and Vitest pass; one Playwright spec fails (see §3)
+- **Planning authority:** `docs/jotter-initial-spec-and-build-plan.md` §14 sequences post-v0 work from `docs/20260727-jotter-roadmap-ai-agent.md`
 
 ---
 
-## 1. Accomplished (v0 Spec & Beyond)
+## 1. Accomplished (v0 spec and beyond)
 
 - **PR0 — Scaffold & CI**: Laravel 12 + Vue 3 SPA + Vite + Docker dev + `jt` scripts + release target.
-- **PR1 — Data Model & Migrations**: Idempotent schema (`tenants`, `workspaces`, `notes`, `note_links`, `tags`, `note_tags`, `attachments`, `users`, `audit_log`).
-- **PR2 — Vault Storage Service**: Plain `.md` files on disk, frontmatter parsing, `VaultPathGuard` path traversal protection, `vault:reindex` Artisan command.
-- **PR3 — Links & Backlinks**: `[[wikilinks]]` parsed into `note_links` table, real-time incoming link resolution.
-- **PR4 — Full-Text Search**: MySQL `FULLTEXT` indexing over note title and content (`GET /api/workspaces/{id}/search`).
-- **PR5 — Workspace Notes CRUD API**: Scoped notes endpoints with authorization enforcement.
-- **PR6 — Frontend Vue 3 SPA**: Glassmorphism UI, Markdown editor, `[[` wikilink autocomplete, backlinks panel.
-- **PR7 — Auth Abstraction**: `IdentityProvider` domain seam with `LocalIdentityProvider` and live `GrandpaSSOnIdentityProvider` adapter.
-- **PR8 — Attachment Management**: File uploads to vault `_resources/` with 20MB type/size allowlist and streaming endpoints.
-- **PR9 — Deployment Hardening**: Hostinger shared hosting combo deployment, AutoSSL, production `.env` configuration.
-- **PR10 to PR40 — Post-v0 Enhancements**:
-  - Global Command Palette (`Cmd+K` / `Ctrl+K`)
-  - Drag & Drop Uploads & Status Bar
-  - Interactive GFM Task Lists & Code Block Copy Button
-  - Sidebar Tag Cloud Explorer & Multi-Criteria Sorting
-  - Interactive Note Relationship Graph View (`GraphView.vue`)
-  - WebDAV / REST Sync Endpoint (`GET /api/workspaces/{id}/sync`)
-  - Workspace Vault ZIP Archive Export (`GET /api/workspaces/{id}/export`)
-  - Audit Log & Revision Query Endpoint (`GET /api/workspaces/{id}/audit-logs`)
-  - Server-Side CommonMark Renderer & XSS Sanitizer (`MarkdownServerRenderer.php`)
-  - Background Job Dispatcher Seam (`JobDispatcher` + `LocalJobDispatcher`)
+- **PR1 — Data Model & Migrations**: Idempotent schema (`tenants`, `workspaces`, `notes`, `note_links`, `tags`, `note_tags`, `attachments`, `users`, `memberships`, `audit_log`).
+- **PR2 — Vault Storage Service**: Plain `.md` files on disk, front-matter parsing, `VaultPathGuard` traversal protection, `vault:reindex` Artisan command.
+- **PR3 — Links & Backlinks**: `[[wikilinks]]` projected into `note_links`, resolved and unresolved refs retained.
+- **PR4 — Full-Text Search**: MySQL `FULLTEXT` over title and content (`GET /api/workspaces/{id}/search`).
+- **PR5 — Workspace Notes CRUD API**: Workspace-scoped notes endpoints.
+- **PR6 — Frontend Vue 3 SPA**: Glassmorphism UI, Markdown editor, `[[` autocomplete, backlinks panel.
+- **PR7 — Auth Abstraction**: `IdentityProvider` seam with `LocalIdentityProvider` and a `GrandpaSSOnIdentityProvider` adapter; `AuthorizeWorkspaceAccess` replaced the fail-closed placeholder.
+- **PR8 — Attachment Management**: Uploads to vault `_resources/` with a 20 MB type/size allowlist and streaming endpoints.
+- **PR9 — Deployment Hardening**: Shared-hosting deployment, AutoSSL, production `.env` configuration.
+- **Post-v0 enhancements**: command palette, drag & drop uploads, GFM task lists, code-block copy, tag cloud + sorting, note graph view, sync endpoint, ZIP export, audit-log query, server-side CommonMark rendering + XSS sanitization, `JobDispatcher` seam, WebDAV endpoint, static-site publishing, `llms.txt` (AI-KB Layer 1).
 
 ---
 
-## 2. Next Milestones (v1 Roadmap)
+## 2. Position against the product roadmap
 
-- SabreDAV / WebDAV protocol adapter for Obsidian mobile direct sync.
-- Workspace Publishing as a static site.
-- AI-KB Layer 1 (Retrieval API + `llms.txt`) and MCP Server.
+`docs/20260727-jotter-roadmap-ai-agent.md` ranks twelve near-term priorities. **Five of its top six already ship here** — search, nested folders, tags, backlinks, and attachments. Its gap analysis says otherwise because its baseline describes a different product (offline-first, Material You, realtime collaboration); spec §14.1 records this and §14.3 carries the authoritative delivered-state table.
+
+| Roadmap milestone | State |
+|---|---|
+| A — knowledge foundations | Mostly delivered. Open: version history, search filters, import. |
+| B — connected knowledge | Partial. Command palette and graph view ship; templates, broken-link report, typed properties, MCP server open. |
+| C — team collaboration | Data model and per-request authorization ship. GrandpaSSOn adapter, admin UI, comments, notifications open. |
+| D — structured work | Not started; blocked on decision C2 (spec §14.5). |
+
+Six roadmap items conflict with hard constraints and are parked pending decisions — realtime presence, structured collections, synced blocks, offline/mobile-first, history storage, and the baseline's provenance. `BACKLOG.md` carries them under **Needs a decision**.
+
+---
+
+## 3. Known issues
+
+- **CI is red on `main`.** The workflow has failed on every run since 2026-07-27 22:28, including the latest (`f57003d`). The current failure is narrow: `frontend/e2e/notes.spec.ts:26` times out waiting for `[data-testid="editor-title"]` to contain `e2e-demo` (1 failed, 1 passed). PHPUnit and Vitest pass. §0.3 of the spec requires green CI per PR, so this blocks the next unit.
+- **`WorkspaceAuthorizationPlaceholder` is still present** in `app/Http/Middleware/` but is no longer aliased — `AuthorizeWorkspaceAccess` replaced it. Dead code pending removal.
+- **The WebDAV adapter is hand-rolled, not SabreDAV.** `sabre/dav` is not a dependency despite the commit message and earlier status notes saying so.
+
+---
+
+## 4. Next
+
+1. Fix the failing Playwright spec and restore green CI; add branch protection so §0.3 is enforced rather than conventional.
+2. Resolve the §14.5 decisions that block planning — C1, C2, and C6 gate the nearest work.
+3. Then Milestone A's remainder: version history (once C6 is decided), search filters, import.

--- a/docs/jotter-initial-spec-and-build-plan.md
+++ b/docs/jotter-initial-spec-and-build-plan.md
@@ -9,6 +9,7 @@
 - **Companion specs (siblings, not hard dependencies for v0):**
   - `grandpasson-spec-v1-extension.md` — identity (SSO, tenancy claims, machine tokens)
   - `taskconnect-spec-v1-extension.md` — background jobs (idempotent, workspace-scoped, pipelines)
+- **Post-v0 planning input:** `docs/20260727-jotter-roadmap-ai-agent.md` — product roadmap and competitive gap analysis. It governs *sequencing after* the §12 stop line; this document remains the authority for v0 contracts, §8 security constraints, and the §1–§4 architectural invariants. See §14 for the mapping, the delivered-state reconciliation, and the unresolved conflicts.
 - **One-line description (repo About):** Self-hosted, Markdown knowledge base for the cPanel your grandpa never gave up. Plain `.md` files, PHP + MySQL, your notes stay yours.
 
 ---
@@ -120,10 +121,14 @@ Vault store on disk · index in MySQL · wikilinks + backlinks · full-text sear
 WebDAV endpoint (SabreDAV) for Obsidian sync · graph endpoint · GrandpaSSOn identity adapter (tenancy claims, RBAC) · publishing a workspace as a static site · AI-KB **Layer 1** (retrieval API + `llms.txt`) and **MCP server** · daily notes/templates · orphan/broken-link report · TaskConnect delegation for reconcile/publish.
 
 ### v2 — Later
-Document parsing (PDF/DOCX/PPTX/XLSX → MD) · website crawling → MD · embeddings/RAG · PWA/offline · version history/diffs · plugins · canvas.
+Document parsing (PDF/DOCX/PPTX/XLSX → MD) · website crawling → MD · embeddings/RAG · PWA/offline · plugins · canvas.
+
+> **Re-prioritized by the roadmap (§14):** *version history/diffs* moved from v2 to v1. The roadmap ranks it 6th of 12 near-term priorities and places it in Phase 1 as a durability primitive, alongside hierarchy, search, and attachments — all of which v0 already ships. Its storage design is constrained by §4 (inode/disk quotas); see §14.5 C6.
 
 ### Won't (this iteration)
 Anything in v1/v2, real-time collab, non-MySQL backends.
+
+> The roadmap's Phase 3 lists presence indicators and its baseline assumes realtime collaboration. That remains a **Won't** here — N1 and §4 rule it out on shared hosting. See §14.5 C1.
 
 ---
 
@@ -265,6 +270,8 @@ Each item is one PR. Merge in order; DoD (§0.3) applies to all.
 >
 > **Stop here and request review.** Do not start v1 (WebDAV, publishing, GrandpaSSOn adapter, MCP/AI-KB).
 
+**Status of this stop line (2026-07-28):** the v0 contracts in §7 are implemented and the stop line has been passed — work continued into v1 (WebDAV sync, static-site publishing, `llms.txt`) and into UI work beyond §7.5. Post-v0 sequencing is therefore no longer governed by §11; it is governed by §14 and the roadmap. `STATUS.md` carries the authoritative current state, including CI. This paragraph records what happened; it does not retroactively authorize it.
+
 ---
 
 ## 13. Open questions (resolve before/with implementation)
@@ -280,4 +287,67 @@ Each item is one PR. Merge in order; DoD (§0.3) applies to all.
 
 ---
 
-*Green-field build. Start at PR0, ship the PR sequence in order, keep CI green, and stop at the §12 stop line for review. Jotter must run fully on its own; GrandpaSSOn and TaskConnect are seams, not dependencies.*
+## 14. Product roadmap alignment (post-v0)
+
+`docs/20260727-jotter-roadmap-ai-agent.md` (the "AI-agent roadmap") is the product planning input for cycles after the §12 stop line. Its **sequencing logic, dependency map, and feature definitions are adopted**. Its **assessment of Jotter's current state is not** — see §14.1.
+
+Precedence: where the roadmap and this document disagree, the §8 security constraints, the §4 shared-hosting constraints, and the §1 Markdown-on-disk invariant win. Disagreements are recorded in §14.5 as open decisions rather than resolved silently.
+
+### 14.1 Baseline discrepancy — read this before planning from the roadmap
+
+The roadmap's *Scope and baseline* describes Jotter as "a lightweight notes product with offline-first behavior, rich note taking, Material You styling, Markdown support, keyboard shortcuts, slash commands, code highlighting, and realtime collaboration," and its *Feature gap summary* concludes that Jotter lacks "structured databases, page hierarchy, backlinks, file attachments, granular permissions, wiki spaces, page history, comments, diagrams, or visual canvases."
+
+That baseline does not describe this repository:
+
+- This Jotter is a **self-hosted PHP 8.2 / Laravel 12 + Vue 3 server application for cPanel-style shared hosting** (§2). It is not offline-first, has no Material You surface, and **does not do realtime collaboration** — §3 N1 excludes it and §4 explains why (no websockets, no long-running processes).
+- **Five of the roadmap's top six near-term priorities already shipped in v0**: full-text search, nested folders, tags, backlinks, and attachments. Only version history is genuinely absent. See §14.3.
+
+The offline-first, Material You, and realtime-collaboration signals suggest the gap analysis was drawn from a different product carrying the same name. Plan from §14.3's delivered-state column, not from the roadmap's gap summary.
+
+`TODO(spec): confirm the provenance of the roadmap's baseline. Until confirmed, §14.3 governs what is considered already delivered.`
+
+### 14.2 Product direction
+
+The roadmap's recommended direction — "begin as a notes-first and knowledge-first product, then selectively expand into workspace capabilities after the knowledge model is mature" — is **accepted**, and it is consistent with §1. Its Phase 5 differentiator candidates of *offline-first excellence* and *Android/mobile-first speed* are **not** accepted as stated: §2's local-first inversion is a deliberate architectural position, and the sanctioned answer to mobile and offline use is an Obsidian vault over WebDAV, not a Jotter offline client. See §14.5 C5.
+
+### 14.3 Roadmap near-term priorities vs. delivered state
+
+| # | Roadmap priority | State in this repo | Notes |
+|---|---|---|---|
+| 1 | Full-text search | **Delivered** (v0 PR4) | MySQL `FULLTEXT(title, search_content)`, ranked, snippets. Roadmap also asks for *filters* (title, tags, modified date) — those are **not** built; natural-language match only. |
+| 2 | Nested pages/folders | **Delivered** (v0 PR2, Q4) | Nested folders inside each workspace vault, every path canonicalized against the root. Filesystem hierarchy, not a database page-tree. |
+| 3 | Tags and properties | **Partial** | `tags` / `note_tags` plus YAML front-matter projected into `notes.frontmatter`. No typed or schema'd property layer. |
+| 4 | Backlinks | **Delivered** (v0 PR3) | `note_links` with resolved and unresolved refs; backlinks are a query, never a scan. |
+| 5 | Attachments | **Delivered** (v0 PR8) | Type/size allowlist, stored outside `public/`, streamed through authorized routes (§8 S4/S9). |
+| 6 | Version history | **Not delivered** | The single real gap in Phase 1. Promoted from v2 to v1 in §6. Constrained by §4 — see §14.5 C6. |
+| 7 | Templates | **Not delivered** | Already scoped as v1 ("daily notes/templates"). |
+| 8 | Synced blocks | **Not delivered** | Conflicts with plain-Markdown portability — see §14.5 C3. |
+| 9 | Comments and mentions | **Not delivered** | No data model yet. Needs §8 S5 authorization and §5 schema work. |
+| 10 | Shared workspaces and permissions | **Partial** | `tenants` / `workspaces` / `memberships` with roles exist (§5) and are enforced per request; there is no administration UI, and RBAC-from-claims remains the v1 GrandpaSSOn adapter. |
+| 11 | Metadata table view | **Not delivered** | Gated by the property layer (#3). |
+| 12 | Board/calendar views | **Not delivered** | Gated by §14.5 C2. |
+
+### 14.4 Roadmap phases mapped to this document's releases
+
+| Roadmap | Maps to | Remaining work |
+|---|---|---|
+| Phase 1 / Milestone A — knowledge foundations | v0 (delivered) + v1 | Version history, search filters, Markdown/JSON import. Export already ships. |
+| Phase 2 / Milestone B — connected knowledge | v1 | Templates, broken-link report, richer block/slash-command surface. Command palette and graph view already shipped post-v0. |
+| Phase 3 / Milestone C — team collaboration | v1 (identity/RBAC) + new scope | GrandpaSSOn adapter covers roles/claims. Comments, mentions, and notifications are new scope. **Presence is excluded** (C1). |
+| Phase 4 / Milestone D — structured work | Beyond current v2 | Blocked on C2. Do not begin without that decision. |
+| Phase 5 — differentiators | Partly delivered | AI-KB Layer 1 (`llms.txt`) ships; MCP server is v1. Offline/mobile-first and canvas are not adopted (C4, C5). |
+
+### 14.5 Conflicts to resolve before the affected roadmap items are planned
+
+Each is a decision, not a defect. Until resolved, the constraint wins and the roadmap item stays unplanned.
+
+- **C1 — Realtime collaboration and presence** (roadmap baseline, Phase 3) vs **§3 N1 / §4**. Shared hosting has no websockets or daemons. Any "live" behavior must be polling or deferred. `TODO(spec): confirm collaboration stays asynchronous — comments and mentions yes, presence and live cursors no.`
+- **C2 — Database-like collections and board/calendar views** (Phase 4) vs **§1**. MySQL is an index, not the source of truth. A collections feature is only admissible if it stays a rebuildable projection of front-matter on disk. `TODO(spec): decide whether structured collections project from front-matter, or whether the Markdown-on-disk invariant is being amended.`
+- **C3 — Synced/reusable blocks** (Phase 2) vs **§1 Obsidian compatibility**. Transclusion that does not survive as plain Markdown breaks the "if Jotter disappears, you still have a readable folder of notes" guarantee. `TODO(spec): choose a syntax that degrades to readable Markdown, or drop the item.`
+- **C4 — Visual canvas / whiteboard** (Phase 5) vs **§3 N3 / §6 v2**. The roadmap itself lists whiteboard parity as a non-goal for the next cycle. No action needed unless the product direction changes.
+- **C5 — Offline-first and mobile-first differentiators** (Phase 5) vs **§2**. See §14.2. `TODO(spec): confirm WebDAV + Obsidian is the mobile/offline answer.`
+- **C6 — Page history storage** (Phase 1) vs **§4 inode and disk quotas**. A vault is already thousands of small files; per-note revision files would multiply inode usage. `TODO(spec): choose DB-stored deltas or bounded snapshot retention; do not write per-revision files into the vault.`
+
+---
+
+*Green-field build. Start at PR0, ship the PR sequence in order, keep CI green, and stop at the §12 stop line for review. Jotter must run fully on its own; GrandpaSSOn and TaskConnect are seams, not dependencies. Post-v0, sequence from §14.*


### PR DESCRIPTION
## What changed

Updates the three planning documents to reflect `docs/20260727-jotter-roadmap-ai-agent.md`, added in f57003d.

### `docs/jotter-initial-spec-and-build-plan.md`

- New **§14 — Product roadmap alignment (post-v0)**: registers the roadmap as the post-v0 planning input, sets precedence (§8 security, §4 hosting, §1 Markdown-on-disk win over the roadmap), maps the roadmap's phases and milestones to this document's releases, and records six conflicts as open decisions.
- **§14.3 delivered-state table** — the substantive finding: **five of the roadmap's top six near-term priorities already ship** (full-text search, nested folders, tags, backlinks, attachments). Only version history is genuinely absent.
- **§6** — version history promoted from v2 to v1 per the roadmap's Phase 1 placement; a note that presence and realtime collaboration stay excluded by N1.
- **§12** — records that the stop line has been passed, and that post-v0 sequencing now runs through §14 rather than §11.
- Header — the roadmap listed as a companion planning input.

### `BACKLOG.md`

Resequenced around the roadmap's Milestones A–D. Separates delivered work (so the roadmap is not re-planned against it) from open work, and adds a **Needs a decision** section carrying the six blocking questions.

### `STATUS.md`

Corrects the CI claim, adds roadmap positioning, and records known issues.

## Findings worth reviewer attention

**The roadmap's baseline describes a different product.** It characterises Jotter as having "offline-first behavior, ... Material You styling, ... and realtime collaboration," and concludes the product lacks backlinks, attachments, search, hierarchy, and permissions. This repo is a self-hosted Laravel + Vue server app for cPanel shared hosting that already ships most of that list, and §3 N1 explicitly excludes realtime collaboration. Its *sequencing logic and feature definitions* are useful; its *gap analysis* should not be planned from directly. Recorded as a `TODO(spec)` in §14.1 rather than silently resolved.

**CI is red on `main`, contrary to the previous `STATUS.md`.** It claimed "🟢 100% Green (59/59 PHPUnit, 7/7 Vitest)". The workflow has failed on every run since 2026-07-27 22:28, including the latest on `f57003d`. The current failure is narrow — `frontend/e2e/notes.spec.ts:26` times out waiting for `[data-testid="editor-title"]`; PHPUnit and Vitest do pass, so the unit-test counts were accurate but the overall status was not.

**The WebDAV adapter is not SabreDAV.** `sabre/dav` appears in neither `composer.json` nor `composer.lock`; `WebDavController` is a hand-rolled Laravel route handler. Corrected in both `STATUS.md` and `BACKLOG.md`.

## Six conflicts recorded, not resolved

Each needs a product decision; until then the spec constraint wins and the roadmap item stays unplanned. C1 realtime presence (vs N1/§4) · C2 database-like collections (vs "MySQL is only an index") · C3 synced blocks (vs plain-Markdown portability) · C4 visual canvas (vs N3) · C5 offline/mobile-first (vs §2's local-first inversion) · C6 history storage (vs §4 inode quotas).

C1, C2, and C6 gate the nearest work.

## Scope

Documentation only — no code, schema, or configuration changes. Related to the coverage assessment tracked in #38, several items of which have since been implemented on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012uQJTnEBSMU42MxTiLPiHZ)_