### PR TITLE
Notes API: support rename and move of a note path

### DIFF
--- a/app/Domain/Vault/VaultStorage.php
+++ b/app/Domain/Vault/VaultStorage.php
@@ -94,6 +94,33 @@ final class VaultStorage
             ->delete();
     }
 
+    public function move(Workspace $workspace, string $oldPath, string $newPath): Note
+    {
+        $oldAbsolute = $this->paths->resolve($workspace, $oldPath, mustExist: true);
+        $newAbsolute = $this->paths->resolve($workspace, $newPath, mustExist: false);
+        $newRelative = $this->paths->toRelative($workspace, $newAbsolute);
+
+        $this->ensureParentDirectory($workspace, $newAbsolute);
+
+        if (! rename($oldAbsolute, $newAbsolute)) {
+            throw new \RuntimeException("Unable to move vault note from [{$oldPath}] to [{$newPath}].");
+        }
+
+        $note = Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->where('path', $oldPath)
+            ->first();
+
+        $contents = file_get_contents($newAbsolute) ?: '';
+        $document = MarkdownDocument::parse($contents, $this->fallbackTitle($newRelative));
+
+        if ($note) {
+            $note->delete();
+        }
+
+        return $this->projector->project($workspace, $newRelative, $document);
+    }
+
     private function ensureParentDirectory(Workspace $workspace, string $absolute): void
     {
         $root = $this->paths->ensureVaultRoot($workspace);

--- a/app/Http/Controllers/WorkspaceNoteController.php
+++ b/app/Http/Controllers/WorkspaceNoteController.php
@@ -98,6 +98,25 @@ final class WorkspaceNoteController extends Controller
         return response()->json(status: 204);
     }
 
+    public function move(Request $request, Workspace $workspace, int $note, VaultStorage $storage): JsonResponse
+    {
+        $validated = $request->validate([
+            'new_path' => ['required', 'string', 'max:700'],
+        ]);
+
+        $note = $this->scopedNote($workspace, $note);
+
+        try {
+            $movedNote = $storage->move($workspace, $note->path, $validated['new_path']);
+        } catch (PathTraversalRejected $exception) {
+            throw ValidationException::withMessages(['new_path' => [$exception->getMessage()]]);
+        }
+
+        return response()->json([
+            'data' => $this->metadata($movedNote),
+        ]);
+    }
+
     private function scopedNote(Workspace $workspace, int $noteId): Note
     {
         return $workspace->notes()->findOrFail($noteId);

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::post('/workspaces/{workspace}/notes', [WorkspaceNoteController::class, 'store']);
     Route::get('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'show']);
     Route::put('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'update']);
+    Route::post('/workspaces/{workspace}/notes/{note}/move', [WorkspaceNoteController::class, 'move']);
     Route::delete('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'destroy']);
 
     Route::get('/workspaces/{workspace}/attachments', [AttachmentController::class, 'index']);

--- a/tests/Feature/WorkspaceNotesApiTest.php
+++ b/tests/Feature/WorkspaceNotesApiTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Domain\Vault\VaultPathGuard;
-use App\Http\Middleware\WorkspaceAuthorizationPlaceholder;
 use App\Models\Note;
 use App\Models\Tenant;
 use App\Models\Workspace;
@@ -36,7 +35,6 @@ class WorkspaceNotesApiTest extends TestCase
 
     public function test_create_and_list_keep_markdown_on_disk_and_return_only_note_metadata(): void
     {
-        $this->withoutMiddleware(WorkspaceAuthorizationPlaceholder::class);
         $workspace = $this->makeWorkspace('primary');
         $markdown = "---\ntitle: API Note\ntags: [api]\n---\nCanonical body.\n";
 
@@ -190,6 +188,23 @@ class WorkspaceNotesApiTest extends TestCase
             ->assertCreated();
 
         return Note::query()->findOrFail($response->json('data.id'));
+    }
+
+    public function test_note_rename_and_move_endpoint(): void
+    {
+        $workspace = $this->makeWorkspace('move_test');
+        $storage = app(\App\Domain\Vault\VaultStorage::class);
+        $note = $storage->write($workspace, 'original.md', "# Original\n");
+
+        $response = $this->postJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/move", [
+            'new_path' => 'archived/renamed.md',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.path', 'archived/renamed.md');
+
+        $this->assertFileExists($this->vaultRoot.'/move_test/archived/renamed.md');
+        $this->assertFileDoesNotExist($this->vaultRoot.'/move_test/original.md');
     }
 
     private function makeWorkspace(string $suffix): Workspace


### PR DESCRIPTION
Implements Issue #74 with VaultStorage move method and POST /api/workspaces/{w}/notes/{n}/move endpoint. Closes #74