### PR TITLE
docs: record the visual identity workstream in BACKLOG and STATUS

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,6 +55,19 @@ Blocked on decision **C2**. Do not begin without it.
 
 ---
 
+## Visual identity (cross-cutting)
+
+Not a roadmap item and not blocked on any §14.5 decision. Adopts a shared dark/purple design system — semantic tokens, Open Sans, WCAG 2.2 AA — across the SPA, the Laravel shell, and the published static site. Presentation layer only: no API contract, no change to the Markdown-on-disk invariant (spec §1), no change to §8 security requirements.
+
+Tracked in **#96**. Today the product ships four unrelated visual treatments (SPA glassmorphism, a light-serif landing stylesheet, the stock Laravel welcome page, and an unstyled published site), three sub-AA color pairs, six `outline: none` sites with no replacement focus indicator, and no `prefers-reduced-motion` handling.
+
+- [ ] Foundation — #97 spec + asset structure, #98 token layer, #99 self-hosted Open Sans.
+- [ ] Application — #100 component migration, #101 typography, #102 spacing/shape/elevation, #103 controls and focus, #104 motion.
+- [ ] Other surfaces — #105 theme reconciliation, #106 published static site, #107 app-shell metadata, #108 project mark.
+- [ ] Verification — #109 WCAG 2.2 AA audit (acceptance gate), #110 CI token guard (lands last).
+
+---
+
 ## Needs a decision (spec §14.5)
 
 These block the roadmap items above. Until each is answered, the constraint wins.

--- a/STATUS.md
+++ b/STATUS.md
@@ -58,3 +58,4 @@ Six roadmap items conflict with hard constraints and are parked pending decision
 1. Fix the failing Playwright spec and restore green CI; add branch protection so §0.3 is enforced rather than conventional.
 2. Resolve the §14.5 decisions that block planning — C1, C2, and C6 gate the nearest work.
 3. Then Milestone A's remainder: version history (once C6 is decided), search filters, import.
+4. **Visual identity (#96)** — cross-cutting presentation workstream adopting a shared dark/purple design system with semantic tokens, Open Sans, and WCAG 2.2 AA across the SPA, the Laravel shell, and the published static site. Sequenced independently of Milestones A–D and blocked on none of the §14.5 decisions, but gated behind item 1 like every other PR. See `BACKLOG.md`.


### PR DESCRIPTION
Planning-document update accompanying the visual identity epic (#96) and its fourteen implementation issues (#97–#110).

`CLAUDE.md` requires `STATUS.md` and `BACKLOG.md` be updated when scope changes. Adopting a shared visual identity specification across every rendering surface is a scope change, so this records it.

## Changes

**`BACKLOG.md`** — adds a cross-cutting **Visual identity** section between *v2 — later* and *Needs a decision*, tracking #96 and grouping its children as foundation / application / other surfaces / verification. It is placed outside the Milestone A–D sequence deliberately: it is not a roadmap item, it is not blocked on any spec §14.5 decision, and it does not compete with those milestones for sequencing.

**`STATUS.md`** — adds item 4 to §4 *Next*, noting the workstream is still gated behind restoring green CI (#49) like every other PR, per spec §0.3.

## What this PR does not do

No code. No file under `frontend/`, `resources/`, `app/`, or `public/` is touched — the actual implementation is sequenced across #97–#110, one merged-and-green PR at a time per `AGENTS.md`.

## Context recorded in the epic

The audit behind #96 found, in the current tree:

- Four unrelated visual treatments across the SPA (`App.vue`), the Vite landing stylesheet (`style.css`), the Laravel welcome page, and the published static site.
- Three sub-AA contrast pairs, including `#ffffff` on `#6366f1` at **4.47:1** — every primary button.
- Six `outline: none` declarations with no replacement focus indicator.
- 23 transition/animation declarations and zero `prefers-reduced-motion` handling.
- Three font sources across three shells, with the **production** shell (`app.blade.php`) loading none — so shipped typography already differs from intended.

## Verification

Documentation-only. `./scripts/jt.sh test` is unaffected; no UI surface is touched, so spec §0.3 does not require a Playwright run for this PR.

Note that CI is red on `main` (#49) independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFqHsyJ8uWgtJRS4ckoABp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFqHsyJ8uWgtJRS4ckoABp)_