### PR TITLE
Blocks: callouts, toggles, tables, and dividers rendering and editing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,7 @@
   - Admin Local User Management (`GET/POST /api/admin/users`, deactivate, reactivate, password reset, self-service change password, provider gating)
   - Admin Administration UI (`frontend/src/components/AdminPanel.vue`, Workspaces/Members/Users tabs, modal & Vitest test suite)
   - Declarative Block Registry (`app/Domain/Vault/BlockRegistry.php`, `frontend/src/services/blockRegistry.ts`, PHPUnit `BlockRegistryTest` & Vitest `blockRegistry.spec.ts`)
+  - Callouts, Toggles, Tables, and Dividers Dual-Path Rendering (`MarkdownServerRenderer.php` with TableExtension & callout regex, `markdown.ts` callout renderer)
 
 ---
 

--- a/app/Domain/Vault/MarkdownServerRenderer.php
+++ b/app/Domain/Vault/MarkdownServerRenderer.php
@@ -2,18 +2,25 @@
 
 namespace App\Domain\Vault;
 
-use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\MarkdownConverter;
 
 final class MarkdownServerRenderer
 {
-    private readonly CommonMarkConverter $converter;
+    private readonly MarkdownConverter $converter;
 
     public function __construct()
     {
-        $this->converter = new CommonMarkConverter([
+        $environment = new Environment([
             'html_input' => 'escape',
             'allow_unsafe_links' => false,
         ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new TableExtension());
+
+        $this->converter = new MarkdownConverter($environment);
     }
 
     public function render(string $markdown): string
@@ -34,7 +41,25 @@ final class MarkdownServerRenderer
             $markdown
         );
 
+        // Convert Callouts > [!NOTE] content into styled div block
+        $processed = preg_replace_callback(
+            '/>\s*\[!([A-Z]+)\]\s*(.*?)(?=\n\n|\n$|$)/s',
+            function (array $matches): string {
+                $type = strtolower(trim($matches[1]));
+                $content = htmlspecialchars(trim($matches[2]), ENT_QUOTES, 'UTF-8');
+                return sprintf('<div class="callout" data-callout-type="%s"><p>%s</p></div>', $type, $content);
+            },
+            $processed ?? $markdown
+        );
+
         $html = (string) $this->converter->convert($processed ?? $markdown);
+
+        // Unescape safe html details and summary tags
+        $html = str_replace(
+            ['&lt;details&gt;', '&lt;/details&gt;', '&lt;summary&gt;', '&lt;/summary&gt;'],
+            ['<details>', '</details>', '<summary>', '</summary>'],
+            $html
+        );
 
         // Server-side XSS sanitization pass
         return $this->sanitizeHtml($html);

--- a/frontend/src/markdown.spec.ts
+++ b/frontend/src/markdown.spec.ts
@@ -36,4 +36,16 @@ describe('Markdown rendering & XSS security', () => {
     expect(html).not.toContain('onerror')
     expect(html).not.toContain('href="javascript:')
   })
+
+  it('renders callouts, toggles, tables, and dividers', () => {
+    const md = '> [!NOTE] Callout body\n\n<details><summary>Summary</summary>Body</details>\n\n| H1 | H2 |\n| --- | --- |\n| C1 | C2 |\n\n---'
+    const html = renderMarkdown(md)
+
+    expect(html).toContain('class="callout"')
+    expect(html).toContain('data-callout-type="note"')
+    expect(html).toContain('<details>')
+    expect(html).toContain('<summary>')
+    expect(html).toContain('<table>')
+    expect(html).toContain('<hr')
+  })
 })

--- a/frontend/src/services/markdown.ts
+++ b/frontend/src/services/markdown.ts
@@ -30,29 +30,39 @@ function wrapCodeBlocks(html: string): string {
   })
 }
 
+import { getClientAllowedAttributes, getClientAllowedTags } from './blockRegistry'
+
 /**
- * Parses markdown to HTML, processes wikilinks, code block wrappers, and sanitizes output.
+ * Transforms callouts like > [!NOTE] content into styled div containers.
+ */
+export function renderCallouts(text: string): string {
+  return text.replace(/>\s*\[!([A-Z]+)\]\s*(.*?)(?=\n\n|\n$|$)/gs, (_match, type, content) => {
+    const cleanType = type.toLowerCase().trim()
+    const cleanContent = DOMPurify.sanitize(content.trim())
+    return `<div class="callout" data-callout-type="${cleanType}"><p>${cleanContent}</p></div>`
+  })
+}
+
+/**
+ * Parses markdown to HTML, processes wikilinks, callouts, code block wrappers, and sanitizes output.
  */
 export function renderMarkdown(markdownText: string): string {
   if (!markdownText) return ''
   
-  // First convert wikilinks to custom anchor tokens
+  // Convert wikilinks and callouts
   const withWikilinks = renderWikilinks(markdownText)
+  const withCallouts = renderCallouts(withWikilinks)
   
   // Convert markdown to HTML
-  let rawHtml = marked.parse(withWikilinks, { async: false }) as string
+  let rawHtml = marked.parse(withCallouts, { async: false }) as string
 
   // Wrap code blocks
   rawHtml = wrapCodeBlocks(rawHtml)
 
-  // Sanitize with DOMPurify ensuring required tags and attributes are allowed
+  // Sanitize with DOMPurify ensuring derived tags and attributes from block registry are allowed
   return DOMPurify.sanitize(rawHtml, {
-    ADD_ATTR: ['data-target', 'type', 'checked', 'class'],
-    ALLOWED_TAGS: [
-      'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'ul', 'ol', 'li', 'code', 'pre',
-      'blockquote', 'strong', 'em', 'del', 'hr', 'br', 'table', 'thead', 'tbody',
-      'tr', 'th', 'td', 'img', 'span', 'div', 'input', 'button'
-    ],
-    ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'data-target', 'type', 'checked']
+    ADD_ATTR: getClientAllowedAttributes(),
+    ALLOWED_TAGS: getClientAllowedTags(),
+    ALLOWED_ATTR: getClientAllowedAttributes(),
   })
 }

--- a/tests/Feature/MarkdownServerRendererTest.php
+++ b/tests/Feature/MarkdownServerRendererTest.php
@@ -19,4 +19,19 @@ final class MarkdownServerRendererTest extends TestCase
         $this->assertStringContainsString('class="wikilink"', $cleanHtml);
         $this->assertStringContainsString('Target Note', $cleanHtml);
     }
+
+    public function test_renders_callouts_toggles_tables_and_dividers(): void
+    {
+        $renderer = new MarkdownServerRenderer();
+
+        $markdown = "> [!NOTE] Callout body\n\n<details><summary>Summary</summary>Details body</details>\n\n| H1 | H2 |\n| --- | --- |\n| C1 | C2 |\n\n---";
+        $html = $renderer->render($markdown);
+
+        $this->assertStringContainsString('class="callout"', $html);
+        $this->assertStringContainsString('data-callout-type="note"', $html);
+        $this->assertStringContainsString('<details>', $html);
+        $this->assertStringContainsString('<summary>', $html);
+        $this->assertStringContainsString('<table>', $html);
+        $this->assertStringContainsString('<hr', $html);
+    }
 }


### PR DESCRIPTION
Implements Issue #87 with dual-path rendering for callouts, toggles, tables, and dividers. Closes #87