### PR TITLE
MCP: transport and machine-token authentication over the IdentityProvider seam

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -39,6 +39,7 @@
   - Declarative Block Registry (`app/Domain/Vault/BlockRegistry.php`, `frontend/src/services/blockRegistry.ts`, PHPUnit `BlockRegistryTest` & Vitest `blockRegistry.spec.ts`)
   - Callouts, Toggles, Tables, and Dividers Dual-Path Rendering (`MarkdownServerRenderer.php` with TableExtension & callout regex, `markdown.ts` callout renderer)
   - Slash-Command Insertion Menu (`SlashMenu.vue` component driven by `blockRegistry.ts`, filter/navigation & `SlashMenu.spec.ts`)
+  - MCP HTTP Transport & Machine-Token Auth (`POST /api/mcp`, `machine_tokens` table, SHA-256 tokens via `IdentityProvider` seam, `McpTransportAuthTest`)
 
 ---
 

--- a/app/Domain/Audit/AuditEvent.php
+++ b/app/Domain/Audit/AuditEvent.php
@@ -23,6 +23,10 @@ enum AuditEvent: string
     case USER_REACTIVATED = 'user.reactivated';
     case USER_PASSWORD_RESET = 'user.password_reset';
 
+    case MCP_CONNECTED = 'mcp.connected';
+    case MCP_METHOD_CALLED = 'mcp.method_called';
+    case MCP_AUTH_FAILED = 'mcp.auth_failed';
+
     case ATTACHMENT_CREATED = 'attachment.created';
     case ATTACHMENT_DELETED = 'attachment.deleted';
 

--- a/app/Domain/Auth/Providers/LocalIdentityProvider.php
+++ b/app/Domain/Auth/Providers/LocalIdentityProvider.php
@@ -17,6 +17,31 @@ final class LocalIdentityProvider implements IdentityProvider
 {
     public function resolveIdentity(Request $request): ?AuthenticatedSubject
     {
+        // 1. Check Bearer MachineToken header
+        $bearerToken = $request->bearerToken();
+        if ($bearerToken) {
+            $hash = \App\Models\MachineToken::hashToken($bearerToken);
+            $tokenRecord = \App\Models\MachineToken::query()
+                ->where('token_hash', $hash)
+                ->whereNull('revoked_at')
+                ->first();
+
+            if ($tokenRecord) {
+                /** @var User|null $user */
+                $user = User::find($tokenRecord->subject_id);
+                if ($user && $user->is_active !== false) {
+                    return new AuthenticatedSubject(
+                        subjectId: (string) $user->id,
+                        email: $user->email,
+                        name: $user->name,
+                        isAdmin: (bool) $user->is_admin,
+                        user: $user,
+                    );
+                }
+            }
+        }
+
+        // 2. Check Session User
         /** @var User|null $user */
         $user = Auth::guard('web')->user() ?? Auth::user();
 

--- a/app/Http/Controllers/McpController.php
+++ b/app/Http/Controllers/McpController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Domain\Auth\Contracts\IdentityProvider;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class McpController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider,
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+    ) {}
+
+    public function handle(Request $request): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+
+        if (! $subject) {
+            $this->auditRecorder->record(
+                event: AuditEvent::MCP_AUTH_FAILED,
+                metadata: ['ip' => $request->ip()]
+            );
+
+            return response()->json([
+                'jsonrpc' => '2.0',
+                'error' => ['code' => -32001, 'message' => 'Unauthorized machine token'],
+                'id' => $request->input('id'),
+            ], 401);
+        }
+
+        $method = (string) $request->input('method', '');
+        $id = $request->input('id');
+
+        $this->auditRecorder->record(
+            event: AuditEvent::MCP_METHOD_CALLED,
+            actorId: $subject->subjectId,
+            metadata: ['method' => $method]
+        );
+
+        if ($method === 'initialize') {
+            return response()->json([
+                'jsonrpc' => '2.0',
+                'result' => [
+                    'protocolVersion' => '2024-11-05',
+                    'capabilities' => ['tools' => new \stdClass, 'resources' => new \stdClass],
+                    'serverInfo' => ['name' => 'Jotter MCP Server', 'version' => '1.0.0'],
+                ],
+                'id' => $id,
+            ]);
+        }
+
+        if ($method === 'tools/list') {
+            return response()->json([
+                'jsonrpc' => '2.0',
+                'result' => [
+                    'tools' => [
+                        ['name' => 'list_notes', 'description' => 'List workspace notes'],
+                        ['name' => 'read_note', 'description' => 'Read note content'],
+                        ['name' => 'search_notes', 'description' => 'Search notes'],
+                        ['name' => 'get_backlinks', 'description' => 'Get note backlinks'],
+                    ],
+                ],
+                'id' => $id,
+            ]);
+        }
+
+        return response()->json([
+            'jsonrpc' => '2.0',
+            'error' => ['code' => -32601, 'message' => 'Method not found'],
+            'id' => $id,
+        ], 404);
+    }
+}

--- a/app/Models/MachineToken.php
+++ b/app/Models/MachineToken.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MachineToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'subject_id',
+        'name',
+        'token_hash',
+        'revoked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'tenant_id' => 'integer',
+            'revoked_at' => 'datetime',
+        ];
+    }
+
+    public static function hashToken(string $plainToken): string
+    {
+        return hash('sha256', $plainToken);
+    }
+}

--- a/database/migrations/2026_07_28_000002_create_machine_tokens_table.php
+++ b/database/migrations/2026_07_28_000002_create_machine_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('machine_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->string('subject_id', 191);
+            $table->string('name', 191);
+            $table->string('token_hash', 64)->unique();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('machine_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ Route::post('/auth/login', [AuthController::class, 'login']);
 Route::post('/auth/logout', [AuthController::class, 'logout']);
 Route::get('/auth/me', [AuthController::class, 'me']);
 Route::post('/auth/change-password', [\App\Http\Controllers\AdminUserController::class, 'changePassword']);
+Route::post('/mcp', [\App\Http\Controllers\McpController::class, 'handle']);
 
 Route::middleware('workspace.authorization')->group(function (): void {
     Route::get('/admin/users', [\App\Http\Controllers\AdminUserController::class, 'index']);

--- a/tests/Feature/McpTransportAuthTest.php
+++ b/tests/Feature/McpTransportAuthTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MachineToken;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class McpTransportAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['jotter.auth_bypass' => false]);
+        config(['jotter.auth_provider' => 'local']);
+    }
+
+    public function test_unauthenticated_call_is_rejected(): void
+    {
+        $res = $this->postJson('/api/mcp', [
+            'jsonrpc' => '2.0',
+            'method' => 'initialize',
+            'id' => 1,
+        ]);
+
+        $res->assertStatus(401);
+        $this->assertDatabaseHas('audit_log', ['event' => 'mcp.auth_failed']);
+    }
+
+    public function test_valid_machine_token_authenticates_and_completes_handshake(): void
+    {
+        $tenant = Tenant::create(['slug' => 'default', 'name' => 'Default Tenant']);
+        $user = User::factory()->create(['is_admin' => true, 'is_active' => true]);
+
+        $plainToken = 'mcp_test_token_12345';
+        $tokenRecord = MachineToken::create([
+            'tenant_id' => $tenant->id,
+            'subject_id' => (string) $user->id,
+            'name' => 'Test Agent Token',
+            'token_hash' => MachineToken::hashToken($plainToken),
+        ]);
+
+        // Hashed storage assertion
+        $this->assertNotEquals($plainToken, $tokenRecord->token_hash);
+        $this->assertEquals(hash('sha256', $plainToken), $tokenRecord->token_hash);
+
+        // Handshake request
+        $res = $this->withHeader('Authorization', 'Bearer '.$plainToken)
+            ->postJson('/api/mcp', [
+                'jsonrpc' => '2.0',
+                'method' => 'initialize',
+                'id' => 1,
+            ]);
+
+        $res->assertOk();
+        $res->assertJsonPath('result.serverInfo.name', 'Jotter MCP Server');
+        $this->assertDatabaseHas('audit_log', [
+            'event' => 'mcp.method_called',
+            'actor_subject_id' => (string) $user->id,
+        ]);
+    }
+
+    public function test_revoked_token_is_rejected_immediately(): void
+    {
+        $tenant = Tenant::create(['slug' => 'default', 'name' => 'Default Tenant']);
+        $user = User::factory()->create(['is_admin' => true, 'is_active' => true]);
+
+        $plainToken = 'mcp_revoked_token_999';
+        $tokenRecord = MachineToken::create([
+            'tenant_id' => $tenant->id,
+            'subject_id' => (string) $user->id,
+            'name' => 'Revoked Token',
+            'token_hash' => MachineToken::hashToken($plainToken),
+            'revoked_at' => now(),
+        ]);
+
+        $res = $this->withHeader('Authorization', 'Bearer '.$plainToken)
+            ->postJson('/api/mcp', [
+                'jsonrpc' => '2.0',
+                'method' => 'initialize',
+                'id' => 1,
+            ]);
+
+        $res->assertStatus(401);
+    }
+}


### PR DESCRIPTION
Implements Issue #89 with McpController, MachineToken model, and McpTransportAuthTest. Closes #89