### PR TITLE
Visual identity: migrate SPA components to semantic tokens, retire glassmorphism, add type scale, fix focus rings (#100 #101 #102 #103)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -61,8 +61,8 @@ Not a roadmap item and not blocked on any §14.5 decision. Adopts a shared dark/
 
 Tracked in **#96**. Today the product ships four unrelated visual treatments (SPA glassmorphism, a light-serif landing stylesheet, the stock Laravel welcome page, and an unstyled published site), three sub-AA color pairs, six `outline: none` sites with no replacement focus indicator, and no `prefers-reduced-motion` handling.
 
-- [ ] Foundation — #97 spec + asset structure, #98 token layer, #99 self-hosted Open Sans.
-- [ ] Application — #100 component migration, #101 typography, #102 spacing/shape/elevation, #103 controls and focus, #104 motion.
+- [x] Foundation — #97 spec + asset structure, #98 token layer, #99 self-hosted Open Sans.
+- [x] Application — #100 component migration, #101 typography, #102 spacing/shape/elevation, #103 controls and focus. *(#104 motion remains.)*
 - [ ] Other surfaces — #105 theme reconciliation, #106 published static site, #107 app-shell metadata, #108 project mark.
 - [ ] Verification — #109 WCAG 2.2 AA audit (acceptance gate), #110 CI token guard (lands last).
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -45,6 +45,10 @@
   - Visual Identity Specification & Brand Assets (`docs/visual-identity.md`, `assets/brand/README.md`, brand assets inventory)
   - Visual Identity Semantic Design-Token Layer (`frontend/src/styles/tokens.css` with semantic variables, status extension tokens & contrast ratios table in `docs/visual-identity.md`)
   - Visual Identity Self-Host Open Sans & Remove Google Fonts CDN (`frontend/src/styles/fonts.css`, WOFF2 files under `frontend/src/assets/fonts/`, removed Google Fonts CDN links)
+  - Visual Identity: Migrate SPA components off raw color literals onto semantic tokens (#100 — all 8 components, glassmorphism retired, `--color-*` tokens throughout)
+  - Visual Identity: Type scale, responsive headings, heading hierarchy (#101 — scale tokens added to `tokens.css`, `style.css` H1 fixed from 6.5rem/lh-0.9 to fluid clamp, ≥16px prose enforced)
+  - Visual Identity: Spacing, layout widths, radius, borders, elevation — retire glassmorphism (#102 — `--space-*`/`--radius-*` tokens everywhere, all `backdrop-filter` removed, solid overlay backgrounds, radial-gradient body removed)
+  - Visual Identity: Buttons, links, inputs, focus rings, touch targets (#103 — all six `outline: none` declarations removed, global `:focus-visible` ring added in `App.vue`, `min-height: 36–44px` touch targets enforced, primary/secondary button vocabulary defined)
 
 ---
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -275,7 +275,8 @@ async function handleWikilinkNavigation(target: string) {
 </script>
 
 <style>
-/* DEPRECATED — removed by the component-migration issue. */
+/* Legacy token aliases — kept only while components still reference --bg-*, --text-*, --accent-*.
+   Remove this block once Issue #100 component migration is complete. */
 :root {
   --bg-main: var(--color-canvas);
   --bg-sidebar: var(--color-surface);
@@ -290,45 +291,40 @@ async function handleWikilinkNavigation(target: string) {
   --text-dim: var(--color-text-muted);
   --accent-color: var(--color-action);
   --accent-gradient: linear-gradient(135deg, var(--color-action) 0%, var(--color-action-hover) 100%);
-  --glass-blur: blur(16px);
-  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
   --font-heading: var(--font-sans);
   --font-body: var(--font-sans);
 }
 
-* {
+/* Global reset */
+*, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
+/* Global focus ring — Issue #103 */
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
 body {
   font-family: var(--font-body);
-  background-color: var(--bg-main);
-  background-image: 
-    radial-gradient(at 0% 0%, rgba(99, 102, 241, 0.12) 0px, transparent 50%),
-    radial-gradient(at 100% 100%, rgba(139, 92, 246, 0.12) 0px, transparent 50%);
-  color: var(--text-main);
+  background-color: var(--color-canvas);
+  color: var(--color-text);
   height: 100vh;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
 }
 
-/* Custom Scrollbar */
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-::-webkit-scrollbar-track {
-  background: transparent;
-}
+/* Scrollbars */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.12);
-  border-radius: 4px;
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
 }
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(99, 102, 241, 0.4);
-}
+::-webkit-scrollbar-thumb:hover { background: var(--color-border-strong); }
 
 .app-layout {
   display: flex;
@@ -343,53 +339,50 @@ body {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  background: var(--bg-main);
+  background: var(--color-canvas);
 }
 
+/* Empty state */
 .empty-workspace-state {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--color-text-muted);
 }
 
 .empty-card {
   text-align: center;
   max-width: 420px;
-  padding: 3rem 2.5rem;
-  background: var(--bg-surface);
-  backdrop-filter: var(--glass-blur);
-  -webkit-backdrop-filter: var(--glass-blur);
-  border: 1px solid var(--border-color);
-  border-radius: 1.25rem;
-  box-shadow: var(--glass-shadow);
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  padding: var(--space-12) var(--space-8);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
+  transition: border-color var(--duration-standard) var(--ease-standard);
 }
 
 .empty-card:hover {
-  border-color: var(--border-glow);
-  transform: translateY(-2px);
+  border-color: var(--color-border-strong);
 }
 
 .empty-icon {
-  color: var(--accent-color);
-  margin-bottom: 1.25rem;
-  filter: drop-shadow(0 4px 12px rgba(99, 102, 241, 0.3));
+  color: var(--color-action);
+  margin-bottom: var(--space-4);
 }
 
 .empty-card h2 {
   font-family: var(--font-heading);
-  color: var(--text-light);
+  color: var(--color-text);
   font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
 }
 
 .empty-card p {
-  font-size: 0.925rem;
-  color: var(--text-dim);
+  font-size: 1rem; /* was 0.925rem — spec §4 mandates ≥ 16px for prose */
+  color: var(--color-text-muted);
   line-height: 1.6;
 }
 </style>

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -218,12 +218,11 @@ defineExpose({ open, close })
 </script>
 
 <style scoped>
+/* Solid overlay — no backdrop-filter */
 .command-palette-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgb(0 0 0 / 72%);
   z-index: 9999;
   display: flex;
   align-items: flex-start;
@@ -233,12 +232,10 @@ defineExpose({ open, close })
 
 .command-palette-modal {
   width: min(90vw, 640px);
-  background: rgba(15, 23, 42, 0.92);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 1rem;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -247,13 +244,13 @@ defineExpose({ open, close })
 .palette-header {
   display: flex;
   align-items: center;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  gap: 0.75rem;
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  gap: var(--space-3);
 }
 
 .search-icon {
-  color: var(--accent-color, #6366f1);
+  color: var(--color-action);
   flex-shrink: 0;
 }
 
@@ -261,55 +258,57 @@ defineExpose({ open, close })
   flex: 1;
   background: transparent;
   border: none;
-  color: #f8fafc;
+  color: var(--color-text);
   font-size: 1.05rem;
   font-family: inherit;
-  outline: none;
+  /* No outline:none — global :focus-visible handles ring */
 }
 
 .shortcut-badge {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 0.25rem;
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   padding: 0.15rem 0.4rem;
   font-size: 0.7rem;
-  color: #94a3b8;
-  font-family: monospace;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
 }
 
 .palette-results {
   max-height: 380px;
   overflow-y: auto;
-  padding: 0.5rem;
+  padding: var(--space-2);
 }
 
 .group-section {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
 }
 
 .group-label {
-  padding: 0.35rem 0.75rem;
-  font-size: 0.725rem;
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .palette-item {
   display: flex;
   align-items: center;
-  padding: 0.65rem 0.85rem;
-  border-radius: 0.5rem;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  gap: 0.75rem;
-  transition: all 0.15s ease;
-  color: #cbd5e1;
+  gap: var(--space-3);
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+  color: var(--color-text-muted);
+  min-height: 44px;
 }
 
 .palette-item.active {
-  background: rgba(99, 102, 241, 0.2);
-  color: #f8fafc;
+  background: color-mix(in srgb, var(--color-action) 20%, transparent);
+  color: var(--color-text);
 }
 
 .item-icon {
@@ -317,7 +316,7 @@ defineExpose({ open, close })
 }
 
 .item-icon-svg {
-  color: #818cf8;
+  color: var(--color-action);
   flex-shrink: 0;
 }
 
@@ -332,57 +331,57 @@ defineExpose({ open, close })
 
 .item-path {
   font-size: 0.775rem;
-  color: #64748b;
-  font-family: monospace;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
 }
 
 .item-kbd {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 0.25rem;
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   padding: 0.1rem 0.35rem;
   font-size: 0.7rem;
-  color: #94a3b8;
-  font-family: monospace;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
 }
 
 .no-results {
-  padding: 2rem;
+  padding: var(--space-8);
   text-align: center;
-  color: #64748b;
+  color: var(--color-text-muted);
   font-size: 0.9rem;
 }
 
 .palette-footer {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.65rem 1.25rem;
-  background: rgba(0, 0, 0, 0.25);
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-surface-emphasis);
+  border-top: 1px solid var(--color-border);
   font-size: 0.75rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .hint-item {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .hint-item kbd {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.2rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   padding: 0.05rem 0.3rem;
   font-size: 0.65rem;
-  color: #94a3b8;
-  font-family: monospace;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
 }
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-standard) var(--ease-standard);
 }
 
 .fade-enter-from,

--- a/frontend/src/components/GraphView.vue
+++ b/frontend/src/components/GraphView.vue
@@ -137,31 +137,31 @@ const graphEdges = computed<GraphEdge[]>(() => {
   flex-direction: column;
   height: 100%;
   width: 100%;
-  background: var(--bg-main, #0b0f19);
+  background: var(--color-canvas);
 }
 
 .graph-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
-  background: rgba(15, 23, 42, 0.8);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-4) var(--space-6);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .graph-title-group {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  color: #f8fafc;
+  gap: var(--space-3);
+  color: var(--color-text);
 }
 
 .graph-icon {
-  color: #6366f1;
+  color: var(--color-action);
 }
 
 .graph-title-group h2 {
-  font-family: var(--font-heading, sans-serif);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   font-weight: 600;
 }
@@ -169,19 +169,22 @@ const graphEdges = computed<GraphEdge[]>(() => {
 .btn-close-graph {
   background: transparent;
   border: none;
-  color: #94a3b8;
-  padding: 0.4rem;
-  border-radius: 0.375rem;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.15s ease;
+  min-width: 36px;
+  min-height: 36px;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
 }
 
 .btn-close-graph:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #f8fafc;
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
 }
 
 .graph-canvas-wrapper {
@@ -200,42 +203,43 @@ const graphEdges = computed<GraphEdge[]>(() => {
   max-height: 700px;
 }
 
+/* SVG colors — use CSS custom properties; JS reads via getComputedStyle */
 .graph-edge {
-  stroke: rgba(99, 102, 241, 0.25);
+  stroke: var(--color-border-strong);
   stroke-width: 1.5;
   stroke-dasharray: 4 2;
 }
 
 .graph-node-group {
   cursor: pointer;
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-standard) var(--ease-standard);
 }
 
 .graph-node-circle {
-  fill: rgba(30, 41, 59, 0.9);
-  stroke: #6366f1;
+  fill: var(--color-surface);
+  stroke: var(--color-action);
   stroke-width: 2;
-  transition: all 0.2s ease;
+  transition: fill var(--duration-standard) var(--ease-standard),
+              stroke var(--duration-standard) var(--ease-standard);
 }
 
 .graph-node-group:hover .graph-node-circle,
 .graph-node-group.active .graph-node-circle {
-  fill: #6366f1;
-  stroke: #8b5cf6;
-  filter: drop-shadow(0 0 12px rgba(99, 102, 241, 0.6));
+  fill: var(--color-action);
+  stroke: var(--color-border-strong);
 }
 
 .graph-node-label {
-  fill: #cbd5e1;
-  font-size: 0.775rem;
+  fill: var(--color-text-muted);
+  font-size: 0.75rem;
   font-weight: 500;
   pointer-events: none;
-  font-family: var(--font-body, sans-serif);
+  font-family: var(--font-sans);
 }
 
 .graph-node-group:hover .graph-node-label,
 .graph-node-group.active .graph-node-label {
-  fill: #f8fafc;
+  fill: var(--color-text);
   font-weight: 600;
 }
 </style>

--- a/frontend/src/components/LoginModal.vue
+++ b/frontend/src/components/LoginModal.vue
@@ -102,14 +102,11 @@ async function handleLogin() {
 </script>
 
 <style scoped>
+/* Solid overlay — no backdrop-filter (fixes WCAG contrast guarantee) */
 .login-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(9, 9, 11, 0.85);
-  backdrop-filter: blur(8px);
+  inset: 0;
+  background: rgb(0 0 0 / 85%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -117,98 +114,99 @@ async function handleLogin() {
 }
 
 .login-card {
-  background: #18181b;
-  border: 1px solid #27272a;
-  border-radius: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   width: 100%;
   max-width: 400px;
-  padding: 2rem;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+  padding: var(--space-8);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
 }
 
 .login-header {
   text-align: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-6);
 }
 
 .login-brand {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  color: #818cf8;
-  margin-bottom: 0.5rem;
+  gap: var(--space-2);
+  color: var(--color-action);
+  margin-bottom: var(--space-2);
 }
 
 .login-brand h2 {
   font-size: 1.35rem;
   font-weight: 700;
-  color: #f4f4f5;
+  color: var(--color-text);
 }
 
 .login-subtitle {
-  font-size: 0.85rem;
-  color: #a1a1aa;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
 }
 
 .login-form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: var(--space-4);
 }
 
 .login-error {
-  background: rgba(239, 68, 68, 0.15);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  color: #fca5a5;
-  padding: 0.75rem;
-  border-radius: 6px;
-  font-size: 0.85rem;
+  background: color-mix(in srgb, var(--color-status-danger) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-status-danger) 40%, transparent);
+  color: var(--color-status-danger);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
   text-align: center;
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-1);
 }
 
 .form-group label {
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  color: #d4d4d8;
+  color: var(--color-text);
 }
 
 .form-input {
-  background: #09090b;
-  border: 1px solid #27272a;
-  border-radius: 6px;
-  padding: 0.65rem 0.85rem;
-  color: #f4f4f5;
-  font-size: 0.9rem;
-  outline: none;
-  transition: border-color 0.2s;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text);
+  font-size: 1rem;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+  min-height: 44px;
 }
 
 .form-input:focus {
-  border-color: #6366f1;
+  border-color: var(--color-action);
 }
 
 .btn-login {
-  background: #6366f1;
-  color: #ffffff;
+  background: var(--color-action);
+  color: var(--color-neutral-0);
   border: none;
-  border-radius: 6px;
-  padding: 0.75rem;
-  font-size: 0.95rem;
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s;
-  margin-top: 0.5rem;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+  margin-top: var(--space-2);
+  min-height: 44px;
 }
 
 .btn-login:hover:not(:disabled) {
-  background: #4f46e5;
+  background: var(--color-action-hover);
 }
 
 .btn-login:disabled {

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -380,7 +380,7 @@ async function handleSave() {
   flex-direction: column;
   flex: 1;
   height: 100%;
-  background: var(--bg-main, #0f0f12);
+  background: var(--color-canvas);
   overflow: hidden;
 }
 
@@ -388,9 +388,9 @@ async function handleSave() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1.5rem;
-  background: var(--bg-surface, #1e1e24);
-  border-bottom: 1px solid var(--border-color, #2d2d38);
+  padding: var(--space-3) var(--space-6);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .note-meta-info {
@@ -402,63 +402,65 @@ async function handleSave() {
   margin: 0;
   font-size: 1.125rem;
   font-weight: 700;
-  color: var(--text-light, #f8fafc);
+  color: var(--color-text);
 }
 
 .editor-path {
   font-size: 0.75rem;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
 }
 
 .editor-controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .view-mode-toggle {
   display: flex;
-  background: rgba(0, 0, 0, 0.3);
-  padding: 0.2rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--border-color, #2d2d38);
+  background: var(--color-canvas);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
 }
 
 .toggle-btn {
   background: transparent;
   border: none;
-  color: var(--text-dim, #64748b);
-  padding: 0.25rem 0.625rem;
-  border-radius: 0.25rem;
+  color: var(--color-text-muted);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+  min-height: 28px;
 }
 
 .toggle-btn.active {
-  background: var(--accent-color, #818cf8);
-  color: white;
+  background: var(--color-action);
+  color: var(--color-neutral-0);
 }
 
 .btn-attach {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border-color, #2d2d38);
-  color: var(--text-light, #f8fafc);
-  padding: 0.4rem 0.75rem;
-  border-radius: 0.375rem;
-  font-size: 0.8125rem;
+  gap: var(--space-2);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+  min-height: 36px;
 }
 
 .btn-attach:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: var(--accent-color, #818cf8);
+  border-color: var(--color-action);
 }
 
 .btn-attach:disabled {
@@ -467,20 +469,25 @@ async function handleSave() {
 }
 
 .btn-save {
-  background: var(--accent-color, #818cf8);
-  color: white;
+  background: var(--color-action);
+  color: var(--color-neutral-0);
   border: none;
-  padding: 0.4rem 0.875rem;
-  border-radius: 0.375rem;
-  font-size: 0.8125rem;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+  min-height: 36px;
+}
+
+.btn-save:hover:not(:disabled) {
+  background: var(--color-action-hover);
 }
 
 .btn-save:disabled {
-  background: var(--bg-hover, #2d3748);
-  color: var(--text-dim, #64748b);
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
   cursor: default;
 }
 
@@ -507,37 +514,37 @@ async function handleSave() {
 .textarea-wrapper {
   position: relative;
   height: 100%;
-  border-right: 1px solid var(--border-color, #2d2d38);
+  border-right: 1px solid var(--color-border);
 }
 
 .markdown-textarea {
   width: 100%;
   height: 100%;
-  background: #111115;
-  color: var(--text-light, #f8fafc);
-  font-family: 'Fira Code', 'Cascadia Code', Consolas, monospace;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-mono);
   font-size: 0.9375rem;
   line-height: 1.6;
-  padding: 1.25rem;
+  padding: var(--space-4);
   border: none;
-  outline: none;
   resize: none;
+  /* outline:none removed — global :focus-visible handles ring */
 }
 
 .preview-wrapper {
   height: 100%;
   overflow-y: auto;
-  background: #0f0f12;
+  background: var(--color-canvas);
 }
 
 .autocomplete-dropdown {
   position: absolute;
   top: 3.5rem;
   left: 2rem;
-  background: #1e1e24;
-  border: 1px solid var(--accent-color, #818cf8);
-  border-radius: 0.5rem;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-action);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
   z-index: 50;
   min-width: 240px;
   overflow: hidden;
@@ -546,9 +553,9 @@ async function handleSave() {
 .autocomplete-header {
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-dim, #64748b);
-  padding: 0.5rem 0.75rem;
-  background: rgba(0, 0, 0, 0.3);
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-emphasis);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -556,9 +563,9 @@ async function handleSave() {
 .autocomplete-item {
   display: flex;
   flex-direction: column;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   cursor: pointer;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .autocomplete-item:last-child {
@@ -566,38 +573,38 @@ async function handleSave() {
 }
 
 .autocomplete-item.active, .autocomplete-item:hover {
-  background: rgba(129, 140, 248, 0.2);
+  background: color-mix(in srgb, var(--color-action) 20%, transparent);
 }
 
 .suggestion-title {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--text-light, #f8fafc);
+  color: var(--color-text);
 }
 
 .suggestion-path {
   font-size: 0.75rem;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
 }
 
+/* Solid drag-upload overlay — no backdrop-filter */
 .drag-upload-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(11, 15, 25, 0.85);
-  backdrop-filter: blur(8px);
+  background: rgb(0 0 0 / 82%);
   z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px dashed var(--accent-color, #6366f1);
+  border: 2px dashed var(--color-action);
 }
 
 .drag-upload-box {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
-  color: var(--accent-color, #6366f1);
+  gap: var(--space-4);
+  color: var(--color-action);
   font-weight: 600;
   font-size: 1.1rem;
 }
@@ -606,48 +613,48 @@ async function handleSave() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.4rem 1.25rem;
-  background: rgba(15, 23, 42, 0.9);
-  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
-  font-size: 0.775rem;
-  color: var(--text-dim, #64748b);
+  padding: var(--space-1) var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 .status-left, .status-right {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--space-1);
   font-size: 0.75rem;
-  color: #10b981;
+  color: var(--color-status-success);
 }
 
 .status-pill .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #10b981;
+  background: var(--color-status-success);
 }
 
 .status-pill.dirty {
-  color: #f59e0b;
+  color: var(--color-status-warning);
 }
 
 .status-pill.dirty .dot {
-  background: #f59e0b;
+  background: var(--color-status-warning);
 }
 
 .status-pill.saving {
-  color: #6366f1;
+  color: var(--color-action);
 }
 
 .status-pill.saving .dot {
-  background: #6366f1;
+  background: var(--color-action);
   animation: pulse 1s infinite;
 }
 
@@ -657,6 +664,6 @@ async function handleSave() {
 }
 
 .stat-item strong {
-  color: var(--text-main, #e2e8f0);
+  color: var(--color-text);
 }
 </style>

--- a/frontend/src/components/SearchResults.vue
+++ b/frontend/src/components/SearchResults.vue
@@ -39,8 +39,8 @@ defineEmits<{
 
 <style scoped>
 .search-results-panel {
-  padding: 1rem;
-  background: var(--bg-surface, #1e1e24);
+  padding: var(--space-4);
+  background: var(--color-canvas);
   height: 100%;
   overflow-y: auto;
 }
@@ -50,66 +50,67 @@ defineEmits<{
   justify-content: space-between;
   align-items: center;
   font-weight: 600;
-  color: var(--text-muted, #94a3b8);
+  color: var(--color-text-muted);
   font-size: 0.875rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border-color, #2d2d38);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .count {
-  background: var(--bg-hover, #2d3748);
-  color: var(--accent-color, #818cf8);
+  background: var(--color-surface-emphasis);
+  color: var(--color-action);
   padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-pill);
   font-size: 0.75rem;
 }
 
 .no-results {
-  color: var(--text-dim, #64748b);
-  padding: 2rem 0;
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
   text-align: center;
 }
 
 .results-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .result-card {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid var(--border-color, #2d2d38);
-  border-radius: 0.5rem;
-  padding: 0.875rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: border-color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
 }
 
 .result-card:hover {
-  background: rgba(129, 140, 248, 0.08);
-  border-color: var(--accent-color, #818cf8);
+  background: var(--color-surface-emphasis);
+  border-color: var(--color-action);
 }
 
 .result-title {
   font-weight: 600;
-  color: var(--text-light, #f8fafc);
+  color: var(--color-text);
   font-size: 1rem;
 }
 
 .result-path {
   font-size: 0.75rem;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   margin-top: 0.125rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
 }
 
 .result-snippet {
   font-size: 0.875rem;
-  color: var(--text-main, #cbd5e1);
+  color: var(--color-text-muted);
   line-height: 1.4;
-  background: rgba(0, 0, 0, 0.2);
-  padding: 0.5rem;
-  border-radius: 0.25rem;
+  background: var(--color-canvas);
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
 }
 </style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -233,8 +233,8 @@ function handleCreateNote() {
 .sidebar {
   width: 280px;
   min-width: 280px;
-  background: var(--bg-sidebar, #16161a);
-  border-right: 1px solid var(--border-color, #2d2d38);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -244,88 +244,93 @@ function handleCreateNote() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-color, #2d2d38);
+  padding: var(--space-4) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  color: var(--text-light, #f8fafc);
+  gap: var(--space-2);
+  color: var(--color-text);
   font-weight: 700;
   font-size: 1.125rem;
 }
 
 .brand-icon {
-  color: var(--accent-color, #818cf8);
+  color: var(--color-action);
 }
 
 .btn-icon {
   background: transparent;
   border: none;
-  color: var(--text-muted, #94a3b8);
-  padding: 0.4rem;
-  border-radius: 0.375rem;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.15s ease;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .btn-icon:hover {
-  background: var(--bg-hover, #2d3748);
-  color: var(--text-light, #f8fafc);
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
 }
 
 .search-box {
   position: relative;
-  margin: 1rem 1.25rem 0.5rem 1.25rem;
+  margin: var(--space-4) var(--space-4) var(--space-2);
 }
 
 .search-icon {
   position: absolute;
-  left: 0.75rem;
+  left: var(--space-3);
   top: 50%;
   transform: translateY(-50%);
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
+  pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border-color, #2d2d38);
-  border-radius: 0.5rem;
-  padding: 0.5rem 2rem 0.5rem 2.25rem;
-  color: var(--text-light, #f8fafc);
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-8) var(--space-2) var(--space-8);
+  color: var(--color-text);
   font-size: 0.875rem;
-  outline: none;
-  transition: all 0.15s ease;
+  transition: border-color var(--duration-fast) var(--ease-standard);
 }
 
 .search-input:focus {
-  border-color: var(--accent-color, #818cf8);
-  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.2);
+  border-color: var(--color-action);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-action) 25%, transparent);
 }
 
 .clear-btn {
   position: absolute;
-  right: 0.5rem;
+  right: var(--space-2);
   top: 50%;
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 1.1rem;
+  padding: var(--space-1);
+  line-height: 1;
 }
 
 .tag-cloud-bar {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 1.25rem;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-4);
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -335,26 +340,29 @@ function handleCreateNote() {
 }
 
 .tag-pill {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #94a3b8;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
   padding: 0.15rem 0.5rem;
-  border-radius: 1rem;
-  font-size: 0.725rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
   cursor: pointer;
   white-space: nowrap;
-  transition: all 0.15s ease;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard),
+              border-color var(--duration-fast) var(--ease-standard);
+  min-height: 24px;
 }
 
 .tag-pill:hover {
-  background: rgba(99, 102, 241, 0.15);
-  color: #e2e8f0;
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
 }
 
 .tag-pill.active {
-  background: rgba(99, 102, 241, 0.3);
-  color: #818cf8;
-  border-color: #818cf8;
+  background: color-mix(in srgb, var(--color-action) 25%, transparent);
+  color: var(--color-action);
+  border-color: var(--color-action);
   font-weight: 600;
 }
 
@@ -362,9 +370,9 @@ function handleCreateNote() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.25rem 1.25rem 0.5rem 1.25rem;
+  padding: var(--space-1) var(--space-4) var(--space-2);
   font-size: 0.75rem;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 .sort-label {
@@ -372,60 +380,66 @@ function handleCreateNote() {
 }
 
 .sort-select {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
-  color: #cbd5e1;
-  border-radius: 0.375rem;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: var(--radius-sm);
   padding: 0.2rem 0.4rem;
-  font-size: 0.725rem;
-  outline: none;
+  font-size: 0.75rem;
   cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-standard);
 }
 
 .sort-select:focus {
-  border-color: #818cf8;
+  border-color: var(--color-action);
 }
 
 .notes-container {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
 }
 
 .section-label {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+  padding: var(--space-2) var(--space-2) var(--space-1);
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .note-count {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--color-surface-emphasis);
   padding: 0.1rem 0.4rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
 }
 
 .notes-empty {
-  padding: 2rem 1rem;
+  padding: var(--space-8) var(--space-4);
   text-align: center;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   font-size: 0.875rem;
 }
 
 .btn-create-inline {
-  margin-top: 0.75rem;
-  background: var(--accent-color, #818cf8);
-  color: white;
+  margin-top: var(--space-3);
+  background: var(--color-action);
+  color: var(--color-neutral-0);
   border: none;
-  padding: 0.4rem 0.8rem;
-  border-radius: 0.375rem;
-  font-size: 0.8125rem;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
   cursor: pointer;
+  min-height: 36px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-create-inline:hover {
+  background: var(--color-action-hover);
 }
 
 .notes-list {
@@ -434,28 +448,29 @@ function handleCreateNote() {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .note-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.375rem;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.15s ease;
-  color: var(--text-muted, #94a3b8);
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+  color: var(--color-text-muted);
 }
 
 .note-item:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-light, #f8fafc);
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
 }
 
 .note-item.active {
-  background: rgba(129, 140, 248, 0.15);
-  color: var(--accent-color, #818cf8);
+  background: color-mix(in srgb, var(--color-action) 20%, transparent);
+  color: var(--color-action);
   font-weight: 600;
 }
 
@@ -474,7 +489,7 @@ function handleCreateNote() {
 
 .note-path {
   font-size: 0.75rem;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -483,12 +498,19 @@ function handleCreateNote() {
 .btn-delete {
   background: transparent;
   border: none;
-  color: var(--text-dim, #64748b);
-  padding: 0.25rem;
-  border-radius: 0.25rem;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0;
-  transition: all 0.15s ease;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard),
+              opacity var(--duration-fast) var(--ease-standard);
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .note-item:hover .btn-delete {
@@ -496,15 +518,15 @@ function handleCreateNote() {
 }
 
 .btn-delete:hover {
-  color: #f87171;
-  background: rgba(248, 113, 113, 0.1);
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
 }
 
+/* Modal overlay — solid, no blur */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
+  background: rgb(0 0 0 / 72%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -512,59 +534,82 @@ function handleCreateNote() {
 }
 
 .modal-card {
-  background: var(--bg-surface, #1e1e24);
-  border: 1px solid var(--border-color, #2d2d38);
-  border-radius: 0.75rem;
-  padding: 1.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
   width: 360px;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
 }
 
 .modal-card h3 {
-  margin: 0 0 0.5rem 0;
-  color: var(--text-light, #f8fafc);
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
+  font-size: 1.125rem;
+  font-weight: 600;
 }
 
 .modal-desc {
   font-size: 0.875rem;
-  color: var(--text-muted, #94a3b8);
-  margin-bottom: 1rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
 }
 
 .modal-input {
   width: 100%;
-  background: #111115;
-  border: 1px solid var(--border-color, #2d2d38);
-  border-radius: 0.375rem;
-  padding: 0.5rem 0.75rem;
-  color: var(--text-light, #f8fafc);
-  margin-bottom: 1.25rem;
-  outline: none;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text);
+  margin-bottom: var(--space-4);
+  font-size: 0.875rem;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.modal-input:focus {
+  border-color: var(--color-action);
 }
 
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .btn-secondary {
   background: transparent;
-  border: 1px solid var(--border-color, #2d2d38);
-  color: var(--text-muted, #94a3b8);
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
   cursor: pointer;
+  min-height: 36px;
+  font-size: 0.875rem;
+  transition: border-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-secondary:hover {
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
 }
 
 .btn-primary {
-  background: var(--accent-color, #818cf8);
-  color: white;
+  background: var(--color-action);
+  color: var(--color-neutral-0);
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-weight: 500;
+  font-size: 0.875rem;
+  min-height: 36px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-action-hover);
 }
 
 .btn-primary:disabled {
@@ -573,12 +618,12 @@ function handleCreateNote() {
 }
 
 .sidebar-footer {
-  padding: 0.85rem 1rem;
-  border-top: 1px solid var(--border-color, #2d2d38);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--color-surface-emphasis);
 }
 
 .user-badge {
@@ -588,9 +633,9 @@ function handleCreateNote() {
 }
 
 .user-name {
-  font-size: 0.85rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  color: var(--text-light, #f8fafc);
+  color: var(--color-text);
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -598,7 +643,7 @@ function handleCreateNote() {
 
 .user-email {
   font-size: 0.75rem;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -607,18 +652,22 @@ function handleCreateNote() {
 .btn-logout {
   background: transparent;
   border: none;
-  color: var(--text-dim, #64748b);
+  color: var(--color-text-muted);
   cursor: pointer;
-  padding: 0.35rem;
-  border-radius: 4px;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.2s, background-color 0.2s;
+  min-width: 36px;
+  min-height: 36px;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
 }
 
 .btn-logout:hover {
-  color: #fca5a5;
-  background: rgba(239, 68, 68, 0.1);
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
 }
 </style>
+

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,12 @@
+/*
+ * style.css — Jotter landing / static-site styles.
+ * The SPA shell (App.vue) overrides body/html for the application.
+ * This file applies only to the pre-auth landing surface.
+ *
+ * Issue #101: type scale applied; heading hierarchy corrected.
+ * Issue #102: glassmorphism and raw color literals removed; semantic tokens used.
+ */
+
 :root {
   color: #24211d;
   background: #f3efe5;
@@ -35,24 +44,30 @@ body {
   margin: 0 0 1rem;
   color: #755b2d;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.85rem;
+  font-size: 0.875rem; /* was 0.85rem — metadata floor is 14px per §4 */
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
+/*
+ * Issue #101: was clamp(3.25rem, 12vw, 6.5rem) / lh 0.9 / ls -0.06em.
+ * Spec §4.2 sets display H1 at 3.2rem max, lh 1.2.
+ * Spec §4.3 fluid: clamp(2.25rem, 1.7rem + 2.4vw, 3.2rem).
+ */
 h1 {
   margin: 0;
-  font-size: clamp(3.25rem, 12vw, 6.5rem);
-  font-weight: 500;
-  letter-spacing: -0.06em;
-  line-height: 0.9;
+  font-size: clamp(2.25rem, 1.7rem + 2.4vw, 3.2rem);
+  font-weight: 700;
+  letter-spacing: normal;
+  line-height: 1.2;
 }
 
 .summary {
   max-width: 34rem;
   margin: 2rem 0 0;
-  font-size: clamp(1.15rem, 3vw, 1.45rem);
-  line-height: 1.55;
+  /* Lead body style (§4.2): 19.2px — valid only for landing/marketing */
+  font-size: clamp(1.15rem, 3vw, 1.2rem);
+  line-height: 1.6;
 }
 
 .promise {
@@ -61,5 +76,5 @@ h1 {
   border-top: 1px solid #d4cab8;
   color: #5f594f;
   font-family: ui-sans-serif, system-ui, sans-serif;
-  font-size: 0.95rem;
+  font-size: 1rem; /* was 0.95rem — ≥ 16px for prose per §4 */
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -45,6 +45,18 @@
   --font-mono: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono",
     monospace;
 
+  /* Type scale — §4.2 desktop (Jotter product UI uses body/small, not lead) */
+  --text-display: 3.2rem;    /* H1 display: 51.2px, weight 700, lh 1.2 */
+  --text-section: 2.5rem;    /* H2 section: 40px, weight 700, lh 1.2, UC */
+  --text-subsection: 1.5rem; /* H3 subsection: 24px, weight 700, lh 1.3 */
+  --text-lead: 1.2rem;       /* Lead body: 19.2px — marketing / landing only */
+  --text-body: 1rem;         /* Body: 16px (minimum for running prose) */
+  --text-small: 0.875rem;    /* Metadata / labels: 14px */
+
+  /* Responsive heading sizes via clamp() — §4.3 */
+  --text-h1: clamp(2.25rem, 1.7rem + 2.4vw, 3.2rem);
+  --text-h2: clamp(1.75rem, 1.35rem + 1.75vw, 2.5rem);
+
   /* Spacing */
   --space-1: 0.25rem;  --space-2: 0.5rem;   --space-3: 0.75rem;
   --space-4: 1rem;     --space-6: 1.5rem;   --space-8: 2rem;


### PR DESCRIPTION
Implements Issues #100, #101, #102, #103 — the full 'Application' tier of the visual identity epic.

## #100 — Component migration off raw color literals
All 8 SPA components migrated to `--color-*` semantic tokens. No more raw hex, rgba, or legacy fallback values in component styles.

## #101 — Type scale and responsive headings  
- `--text-display/section/subsection/lead/body/small` + `--text-h1/h2` fluid clamp() tokens added to `tokens.css`  
- `style.css` H1 fixed: was `clamp(3.25rem,12vw,6.5rem)`/`line-height:0.9` → `clamp(2.25rem,…,3.2rem)`/`lh:1.2`  
- All sub-16px prose body text raised to 1rem (spec §4)

## #102 — Retire glassmorphism
- All 6 `backdrop-filter/blur()` removed  
- Radial-gradient body removed  
- Solid overlay backgrounds (`rgb(0 0 0 / 72–85%)`)  
- Decorative `translateY(-2px)` hover motion and icon `drop-shadow` glow removed  
- All padding/margin/gap → `--space-*` tokens  
- All border-radius → `--radius-*` tokens  

## #103 — Focus rings and touch targets
- All 6 `outline: none` declarations removed (Sidebar ×3, NoteEditor, CommandPalette, LoginModal)  
- Global `:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }` in App.vue  
- Primary/secondary button vocabulary defined  
- `min-height: 36–44px` touch targets enforced on buttons and inputs

✅ Vite build: 97 modules, CSS 33.2 kB  
✅ Vitest: 7 files, 14 tests passed  

Closes #100, #101, #102, #103