### PR TITLE
Note Version History (#51), Daily Notes & Templates (#56), and Epics #57 & #58 Closure

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,17 +20,17 @@ Roadmap priorities 1–5 (search, nested folders, tags, backlinks, attachments) 
 
 The only Phase 1 items the product does not already have.
 
-- [ ] **Version history** — roadmap priority 6; promoted from v2 to v1 (spec §6). Revision snapshots with restore. **Storage design is constrained:** no per-revision files in the vault (spec §14.5 C6, §4 inode quotas). Decide DB-stored deltas vs. bounded snapshot retention first.
+- [x] **Version history** — roadmap priority 6; promoted from v2 to v1 (spec §6). Revision snapshots with restore, deduplication, and pruning command (#51).
 - [x] **Search filters** — roadmap priority 1 asks for filters by title, tags, and modified date. Filtered search endpoints ship via `SearchCriteria` value object (#52).
 - [x] **Markdown / JSON import** — hardened archive extraction (zip-slip/symlink/allowlist guards), bounded import job and endpoint, JSON backup format round-trip, and collision policy (#53, #76, #77, #78).
 
 ## Milestone B — connected knowledge
 
-- [ ] **Daily notes and templates** — roadmap priority 7; already scoped as v1.
+- [x] **Daily notes and templates** — conventional _templates/ folder, variable substitution, daily journal note flow (#56).
 - [x] **Broken-link report** — workspace-wide report of unresolved `[[wikilinks]]` and orphan notes via `GET /api/workspaces/{w}/link-report` (#55).
 - [x] **Typed note properties** — rebuildable typed projection from front-matter, workspace properties API, front-matter write-through (#54, #79, #80, #81).
-- [ ] **Richer block / slash-command surface** — callouts, toggles, tables, dividers, embeds.
-- [ ] **MCP server** — the second half of AI-KB Layer 1; `llms.txt` retrieval already ships.
+- [x] **Richer block / slash-command surface** — declarative block registry, callouts, toggles, tables, dividers, slash insertion menu (#57, #86, #87, #88).
+- [x] **MCP server** — machine-token auth over IdentityProvider seam, read-only vault tools & resources (#58, #89, #90, #91).
 
 ## Milestone C — team collaboration
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -65,6 +65,10 @@
   - Milestone B: Rebuildable typed property projection (#80 — `note_properties` schema, `NotePropertyProjector`, `VaultReindexer` integration, drop-and-rebuild test)
   - Milestone B: Expose properties in notes API (#81 — `GET /api/workspaces/{w}/properties`, front-matter write-through via `VaultStorage`)
   - Milestone B: Broken-link and orphan report (#55 — `GET /api/workspaces/{w}/link-report` endpoint returning unresolved wikilinks and orphan notes)
+  - Milestone A: Note version history with restore (#51 — `note_revisions` schema, `NoteRevisions` service with content-hash deduplication, `vault:prune-revisions` command, REST revision endpoints)
+  - Milestone B: Daily notes and note templates (#56 — `_templates/` folder, `TemplateEngine` variable substitution, `POST /notes/from-template`, `GET|POST /daily/{date?}`)
+  - Milestone B: Richer block and slash-command surface epic (#57 — declarative block registry, dual-path sanitization, callouts, toggles, tables, dividers, slash insertion menu)
+  - Milestone B: MCP server epic (#58 — machine-token auth over IdentityProvider seam, read-only vault tools & resources)
 
 ---
 

--- a/app/Console/Commands/VaultPruneRevisionsCommand.php
+++ b/app/Console/Commands/VaultPruneRevisionsCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\NoteRevision;
+use Illuminate\Console\Command;
+
+final class VaultPruneRevisionsCommand extends Command
+{
+    protected $signature = 'vault:prune-revisions {--days=30 : Prune revisions older than N days}';
+
+    protected $description = 'Prune old note revision history';
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+        $cutoff = now()->subDays($days);
+
+        $deleted = NoteRevision::query()
+            ->where('created_at', '<', $cutoff)
+            ->delete();
+
+        $this->info("Pruned {$deleted} note revisions older than {$days} days.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Templates/TemplateEngine.php
+++ b/app/Domain/Templates/TemplateEngine.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domain\Templates;
+
+use Illuminate\Support\Carbon;
+
+final class TemplateEngine
+{
+    /**
+     * Substitutes standard template variables cleanly without eval.
+     *
+     * Supported variables:
+     * {{title}}, {{workspace}}, {{date}}, {{time}}, {{iso_datetime}},
+     * {{date:YYYY-MM-DD}}, {{date:YYYY-MM}}, {{date:YYYY}}
+     */
+    public function render(string $content, array $context = []): string
+    {
+        $now = isset($context['date']) ? Carbon::parse($context['date']) : now();
+
+        $replacements = [
+            '{{title}}' => $context['title'] ?? 'Untitled',
+            '{{workspace}}' => $context['workspace'] ?? 'Default',
+            '{{date}}' => $now->toDateString(),
+            '{{time}}' => $now->toTimeString(),
+            '{{iso_datetime}}' => $now->toIso8601String(),
+            '{{date:YYYY-MM-DD}}' => $now->format('Y-m-d'),
+            '{{date:YYYY-MM}}' => $now->format('Y-m'),
+            '{{date:YYYY}}' => $now->format('Y'),
+        ];
+
+        return strtr($content, $replacements);
+    }
+}

--- a/app/Domain/Vault/NoteRevisions.php
+++ b/app/Domain/Vault/NoteRevisions.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use App\Models\Note;
+use App\Models\NoteRevision;
+use App\Models\Workspace;
+use InvalidArgumentException;
+
+final class NoteRevisions
+{
+    /**
+     * Records a revision snapshot if the content has changed (deduplicated by sha256 content_hash).
+     */
+    public function recordRevision(Note $note, string $content, ?string $actorId = null): ?NoteRevision
+    {
+        $contentHash = hash('sha256', $content);
+
+        /** @var NoteRevision|null $latest */
+        $latest = NoteRevision::query()
+            ->where('note_id', $note->id)
+            ->latest('id')
+            ->first();
+
+        if ($latest && $latest->content_hash === $contentHash) {
+            return null; // Content unchanged, deduplicate
+        }
+
+        return NoteRevision::query()->create([
+            'workspace_id' => $note->workspace_id,
+            'note_id' => $note->id,
+            'content_hash' => $contentHash,
+            'content' => $content,
+            'actor_id' => $actorId,
+        ]);
+    }
+
+    /**
+     * Restores a past revision by writing its content back through VaultStorage,
+     * which in turn produces a new revision snapshot (non-destructive restore).
+     */
+    public function restoreRevision(Workspace $workspace, Note $note, NoteRevision $revision, VaultStorage $storage, ?string $actorId = null): Note
+    {
+        if ($revision->workspace_id !== $workspace->id || $revision->note_id !== $note->id) {
+            throw new InvalidArgumentException("Revision {$revision->id} does not belong to note {$note->id} in workspace {$workspace->id}");
+        }
+
+        return $storage->write($workspace, $note->path, $revision->content);
+    }
+}

--- a/app/Domain/Vault/VaultReindexer.php
+++ b/app/Domain/Vault/VaultReindexer.php
@@ -19,6 +19,7 @@ final class VaultReindexer
         private readonly VaultPathGuard $paths = new VaultPathGuard,
         private readonly NoteProjector $projector = new NoteProjector,
         private readonly WikilinkProjector $wikilinks = new WikilinkProjector,
+        private readonly NoteRevisions $revisions = new NoteRevisions,
     ) {}
 
     /**
@@ -117,7 +118,8 @@ final class VaultReindexer
             }
 
             $document = MarkdownDocument::parse($raw, $this->fallbackTitle($relative));
-            $this->projector->project($workspace, $relative, $document);
+            $note = $this->projector->project($workspace, $relative, $document);
+            $this->revisions->recordRevision($note, $raw);
             $count++;
 
         }

--- a/app/Domain/Vault/VaultStorage.php
+++ b/app/Domain/Vault/VaultStorage.php
@@ -14,6 +14,7 @@ final class VaultStorage
     public function __construct(
         private readonly VaultPathGuard $paths = new VaultPathGuard,
         private readonly NoteProjector $projector = new NoteProjector,
+        private readonly NoteRevisions $revisions = new NoteRevisions,
     ) {}
 
     public function read(Workspace $workspace, string $relativePath): MarkdownDocument
@@ -53,7 +54,10 @@ final class VaultStorage
 
         $document = MarkdownDocument::parse($contents, $this->fallbackTitle($relative));
 
-        return $this->projector->project($workspace, $relative, $document);
+        $note = $this->projector->project($workspace, $relative, $document);
+        $this->revisions->recordRevision($note, $contents);
+
+        return $note;
     }
 
     /**

--- a/app/Http/Controllers/WorkspaceNoteRevisionController.php
+++ b/app/Http/Controllers/WorkspaceNoteRevisionController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Domain\Vault\NoteRevisions;
+use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
+use App\Models\NoteRevision;
+use App\Models\Workspace;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class WorkspaceNoteRevisionController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider,
+        private readonly NoteRevisions $noteRevisions,
+        private readonly VaultStorage $vaultStorage
+    ) {}
+
+    public function index(Request $request, int $workspaceId, int $noteId): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $note = Note::query()
+            ->where('workspace_id', $workspaceId)
+            ->where('id', $noteId)
+            ->first();
+
+        if (! $note) {
+            return response()->json(['message' => 'Note not found.'], 404);
+        }
+
+        $revisions = NoteRevision::query()
+            ->where('workspace_id', $workspaceId)
+            ->where('note_id', $noteId)
+            ->orderByDesc('id')
+            ->get(['id', 'note_id', 'content_hash', 'actor_id', 'created_at']);
+
+        return response()->json(['data' => $revisions]);
+    }
+
+    public function show(Request $request, int $workspaceId, int $noteId, int $revisionId): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $revision = NoteRevision::query()
+            ->where('workspace_id', $workspaceId)
+            ->where('note_id', $noteId)
+            ->where('id', $revisionId)
+            ->first();
+
+        if (! $revision) {
+            return response()->json(['message' => 'Revision not found.'], 404);
+        }
+
+        return response()->json(['data' => $revision]);
+    }
+
+    public function restore(Request $request, int $workspaceId, int $noteId, int $revisionId): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $workspace = Workspace::query()->find($workspaceId);
+        $note = Note::query()->where('workspace_id', $workspaceId)->where('id', $noteId)->first();
+        $revision = NoteRevision::query()->where('workspace_id', $workspaceId)->where('note_id', $noteId)->where('id', $revisionId)->first();
+
+        if (! $workspace || ! $note || ! $revision) {
+            return response()->json(['message' => 'Resource not found.'], 404);
+        }
+
+        $restoredNote = $this->noteRevisions->restoreRevision(
+            $workspace,
+            $note,
+            $revision,
+            $this->vaultStorage,
+            $subject->subjectId
+        );
+
+        return response()->json([
+            'message' => 'Revision restored successfully.',
+            'data' => $restoredNote,
+        ]);
+    }
+}

--- a/app/Http/Controllers/WorkspaceTemplateController.php
+++ b/app/Http/Controllers/WorkspaceTemplateController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Domain\Templates\TemplateEngine;
+use App\Domain\Vault\VaultPathGuard;
+use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
+use App\Models\Workspace;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+final class WorkspaceTemplateController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider,
+        private readonly VaultStorage $vaultStorage,
+        private readonly VaultPathGuard $pathGuard,
+        private readonly TemplateEngine $templateEngine
+    ) {}
+
+    public function createFromTemplate(Request $request, int $workspaceId): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $workspace = Workspace::query()->find($workspaceId);
+        if (! $workspace) {
+            return response()->json(['message' => 'Workspace not found.'], 404);
+        }
+
+        $request->validate([
+            'template_path' => ['required', 'string'],
+            'target_path' => ['required', 'string'],
+            'title' => ['nullable', 'string'],
+        ]);
+
+        $templatePath = $request->string('template_path')->trim()->toString();
+        $targetPath = $request->string('target_path')->trim()->toString();
+
+        if (! $this->vaultStorage->exists($workspace, $templatePath)) {
+            return response()->json(['message' => "Template note not found: {$templatePath}"], 404);
+        }
+
+        $rawTemplate = $this->vaultStorage->readContents($workspace, $templatePath);
+        $title = $request->input('title') ?: basename(str_replace('\\', '/', $targetPath), '.md');
+
+        $renderedContent = $this->templateEngine->render($rawTemplate, [
+            'title' => $title,
+            'workspace' => $workspace->name,
+        ]);
+
+        $note = $this->vaultStorage->write($workspace, $targetPath, $renderedContent);
+
+        return response()->json([
+            'message' => 'Note created from template.',
+            'data' => $note,
+        ], 201);
+    }
+
+    public function dailyNote(Request $request, int $workspaceId, ?string $dateStr = null): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $workspace = Workspace::query()->find($workspaceId);
+        if (! $workspace) {
+            return response()->json(['message' => 'Workspace not found.'], 404);
+        }
+
+        $date = $dateStr ? Carbon::parse($dateStr) : now();
+        $year = $date->format('Y');
+        $month = $date->format('m');
+        $day = $date->format('Y-m-d');
+
+        $relativePath = "journal/{$year}/{$month}/{$day}.md";
+
+        // Validate path safety (§8 S2)
+        try {
+            $this->pathGuard->resolve($workspace, $relativePath, mustExist: false, mustBeMarkdown: true);
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Invalid daily note path pattern.'], 400);
+        }
+
+        // If daily note already exists, return existing note
+        $existing = Note::query()->where('workspace_id', $workspaceId)->where('path', $relativePath)->first();
+        if ($existing) {
+            return response()->json(['data' => $existing]);
+        }
+
+        // Create daily note from template if _templates/daily.md exists, or fallback default
+        $templatePath = '_templates/daily.md';
+        if ($this->vaultStorage->exists($workspace, $templatePath)) {
+            $raw = $this->vaultStorage->readContents($workspace, $templatePath);
+            $content = $this->templateEngine->render($raw, [
+                'title' => "Journal {$day}",
+                'workspace' => $workspace->name,
+                'date' => $date->toIso8601String(),
+            ]);
+        } else {
+            $content = "# Journal {$day}\n\nDaily notes for {$day}.";
+        }
+
+        $note = $this->vaultStorage->write($workspace, $relativePath, $content);
+
+        return response()->json(['data' => $note], 201);
+    }
+}

--- a/app/Models/NoteRevision.php
+++ b/app/Models/NoteRevision.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class NoteRevision extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'workspace_id',
+        'note_id',
+        'content_hash',
+        'content',
+        'actor_id',
+    ];
+
+    public function note(): BelongsTo
+    {
+        return $this->belongsTo(Note::class);
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/database/migrations/2026_07_28_000005_create_note_revisions_table.php
+++ b/database/migrations/2026_07_28_000005_create_note_revisions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('note_revisions')) {
+            Schema::create('note_revisions', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+                $table->foreignId('note_id')->constrained('notes')->cascadeOnDelete();
+                $table->string('content_hash', 64);
+                $table->longText('content');
+                $table->string('actor_id')->nullable();
+                $table->timestamps();
+
+                $table->index(['note_id', 'created_at']);
+                $table->index(['workspace_id', 'note_id']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('note_revisions');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,10 +54,16 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::get('/workspaces/{workspace}/search', WorkspaceSearchController::class);
     Route::get('/workspaces/{workspace}/notes', [WorkspaceNoteController::class, 'index']);
     Route::post('/workspaces/{workspace}/notes', [WorkspaceNoteController::class, 'store']);
+    Route::post('/workspaces/{workspace}/notes/from-template', [\App\Http\Controllers\WorkspaceTemplateController::class, 'createFromTemplate']);
+    Route::match(['get', 'post'], '/workspaces/{workspace}/daily/{date?}', [\App\Http\Controllers\WorkspaceTemplateController::class, 'dailyNote']);
     Route::get('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'show']);
     Route::put('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'update']);
     Route::post('/workspaces/{workspace}/notes/{note}/move', [WorkspaceNoteController::class, 'move']);
     Route::delete('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'destroy']);
+
+    Route::get('/workspaces/{workspace}/notes/{note}/revisions', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'index']);
+    Route::get('/workspaces/{workspace}/notes/{note}/revisions/{revision}', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'show']);
+    Route::post('/workspaces/{workspace}/notes/{note}/revisions/{revision}/restore', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'restore']);
 
     Route::get('/workspaces/{workspace}/properties', [\App\Http\Controllers\WorkspacePropertyController::class, 'index']);
     Route::post('/workspaces/{workspace}/notes/{note}/properties', [\App\Http\Controllers\WorkspacePropertyController::class, 'setProperty']);

--- a/tests/Feature/DailyNotesAndTemplatesTest.php
+++ b/tests/Feature/DailyNotesAndTemplatesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class DailyNotesAndTemplatesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_template_substitution_and_idempotent_daily_note_creation(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'test', 'name' => 'Test']);
+
+        $vaultPath = storage_path('app/vaults/tmpl_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'main',
+            'name' => 'Main Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+
+        // 1. Create a template note in _templates/meeting.md
+        $storage->write($workspace, '_templates/meeting.md', "---\ntitle: \"{{title}}\"\n---\n# Meeting: {{title}}\n\nWorkspace: {{workspace}}");
+
+        // 2. Create note from template
+        $fromTmplRes = $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/notes/from-template", [
+            'template_path' => '_templates/meeting.md',
+            'target_path' => 'meetings/standup.md',
+            'title' => 'Project Standup',
+        ]);
+
+        $fromTmplRes->assertCreated()
+            ->assertJsonPath('data.path', 'meetings/standup.md');
+
+        $this->assertFileExists($vaultPath.'/meetings/standup.md');
+        $this->assertStringContainsString('Meeting: Project Standup', file_get_contents($vaultPath.'/meetings/standup.md'));
+        $this->assertStringContainsString('Workspace: Main Workspace', file_get_contents($vaultPath.'/meetings/standup.md'));
+
+        // 3. Create Daily Note for date 2026-07-28
+        $dailyRes1 = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/daily/2026-07-28");
+        $dailyRes1->assertCreated()
+            ->assertJsonPath('data.path', 'journal/2026/07/2026-07-28.md');
+
+        $this->assertFileExists($vaultPath.'/journal/2026/07/2026-07-28.md');
+
+        // 4. Idempotent call returns same existing daily note
+        $dailyRes2 = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/daily/2026-07-28");
+        $dailyRes2->assertOk()
+            ->assertJsonPath('data.id', $dailyRes1->json('data.id'));
+    }
+}

--- a/tests/Feature/NoteRevisionTest.php
+++ b/tests/Feature/NoteRevisionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultReindexer;
+use App\Domain\Vault\VaultStorage;
+use App\Models\NoteRevision;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class NoteRevisionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_note_revision_creation_deduplication_restore_isolation_and_pruning(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'test', 'name' => 'Test']);
+
+        $vaultPath = storage_path('app/vaults/rev_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'main',
+            'name' => 'Main Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+
+        // 1. Initial write creates revision
+        $note = $storage->write($workspace, 'history.md', "# Version 1\nFirst version content.");
+        $this->assertDatabaseHas('note_revisions', [
+            'workspace_id' => $workspace->id,
+            'note_id' => $note->id,
+        ]);
+        $this->assertDatabaseCount('note_revisions', 1);
+
+        // 2. Re-saving identical content deduplicates (no extra revision created)
+        $storage->write($workspace, 'history.md', "# Version 1\nFirst version content.");
+        $this->assertDatabaseCount('note_revisions', 1);
+
+        // 3. Edit produces second revision
+        $storage->write($workspace, 'history.md', "# Version 2\nSecond version content.");
+        $this->assertDatabaseCount('note_revisions', 2);
+
+        $revisions = NoteRevision::query()->where('note_id', $note->id)->orderBy('id')->get();
+        $rev1 = $revisions[0];
+        $rev2 = $revisions[1];
+
+        // 4. Test API GET revisions list and show
+        $listRes = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions");
+        $listRes->assertOk()->assertJsonCount(2, 'data');
+
+        $showRes = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/{$rev1->id}");
+        $showRes->assertOk()->assertJsonPath('data.content', "# Version 1\nFirst version content.");
+
+        // 5. Restore Version 1 via API
+        $restoreRes = $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/{$rev1->id}/restore");
+        $restoreRes->assertOk();
+        $this->assertEquals("# Version 1\nFirst version content.", file_get_contents($vaultPath.'/history.md'));
+
+        // Restore creates a 3rd revision with Version 1 content
+        $this->assertDatabaseCount('note_revisions', 3);
+
+        // 6. Test out-of-band disk edit picked up by vault:reindex
+        file_put_contents($vaultPath.'/history.md', "# Version 4 Out-of-band\nDisk edit.");
+        /** @var VaultReindexer $reindexer */
+        $reindexer = $this->app->make(VaultReindexer::class);
+        $reindexer->reindex($workspace);
+        $this->assertDatabaseCount('note_revisions', 4);
+
+        // 7. Test Pruning command
+        $rev1->created_at = now()->subDays(60);
+        $rev1->save();
+
+        $this->artisan('vault:prune-revisions', ['--days' => 30])
+            ->assertExitCode(0);
+
+        $this->assertDatabaseMissing('note_revisions', ['id' => $rev1->id]);
+        $this->assertDatabaseCount('note_revisions', 3);
+    }
+}


### PR DESCRIPTION
Delivers Milestone A Note Version History (#51), Milestone B Daily Notes & Templates (#56), and closes completed Epics #57 and #58.

## #51 — Milestone A: Note Version History with Restore
- `note_revisions` table migration and `NoteRevision` Eloquent model.
- `NoteRevisions` domain service hooked into `VaultStorage` and `VaultReindexer` for automatic content-hash deduplicated revision snapshotting.
- REST endpoints `GET /notes/{n}/revisions`, `GET /notes/{n}/revisions/{r}`, and `POST /notes/{n}/revisions/{r}/restore`.
- `php artisan vault:prune-revisions --days=30` bounded retention command.
- Verified in `NoteRevisionTest`.

## #56 — Milestone B: Daily Notes & Note Templates
- Conventional `_templates/` template storage.
- `TemplateEngine` substituting `{{title}}`, `{{workspace}}`, `{{date}}`, `{{time}}`, `{{iso_datetime}}`, `{{date:YYYY-MM-DD}}`.
- Endpoint `POST /api/workspaces/{w}/notes/from-template`.
- Endpoint `GET|POST /api/workspaces/{w}/daily/{date?}` resolving path `journal/{YYYY}/{MM}/{YYYY-MM-DD}.md` through `VaultPathGuard` with idempotent creation from daily template or fallback.
- Verified in `DailyNotesAndTemplatesTest`.

## #57 & #58 — Epic Closures
- Closes Epic #57 (Richer block surface) — sub-issues #86, #87, #88 complete.
- Closes Epic #58 (MCP server) — sub-issues #89, #90, #91 complete.

✅ Token Guard: 4/4 passed  
✅ PHPUnit: 97 passed (504 assertions)  
✅ Vitest: 8 files, 20 tests passed  

Closes #51, #56, #57, #58