### PR TITLE
docs(status,backlog): record 3 adherence gaps found in spec/backlog review

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,6 +6,16 @@ Roadmap priorities 1–5 (search, nested folders, tags, backlinks, attachments) 
 
 ---
 
+## Known gaps (open, 2026-07-28)
+
+Found during a review of whether `main` is 100% adherent to the roadmap and this backlog. All backlog milestones below are checked off, but three gaps mean that claim doesn't fully hold without these caveats. Each has a detailed GitHub issue; none are resolved by this pass except where noted.
+
+- **CI is red on `main`, still, after the prior fix.** `frontend/e2e/notes.spec.ts` fails on the current `main` HEAD with the same symptom #49 diagnosed and closed as fixed — the fix didn't hold, and code landed after it (the version-history epic, #51/#136) that changed the exact code path the failing test exercises. Root cause needs re-investigation in a Docker-capable environment. Tracked in **#140**.
+- **This file was self-contradictory.** The "Recorded Decisions" section marked C1–C6 resolved while the "Needs a decision" section below it still listed the same five as open blockers — added by different commits that were never reconciled. **Fixed in this pass**; see **#141**.
+- **Dead-code cleanup from #66 was incomplete.** `WorkspaceAuthorizationPlaceholder` was deleted from `app/`, but six tests in `tests/Feature/WorkspaceNotesApiTest.php` still reference it by name; since nothing imports the class, PHP resolves it to an unrelated string and the `withoutMiddleware()` calls silently no-op instead of bypassing anything. `STATUS.md`'s description of this item was also stale (it said the file was still present). Tracked in **#142**.
+
+---
+
 ## Delivered (not backlog — recorded so the roadmap is not re-planned against it)
 
 - Full-text search, nested vault folders, tags + front-matter projection, backlinks, attachments — v0 §7.
@@ -112,13 +122,8 @@ If Note A assigns string `"2"` to property `priority` and Note B assigns integer
 
 ## Needs a decision (spec §14.5)
 
-These block the roadmap items above. Until each is answered, the constraint wins.
+C1, C2, C3, C5, and C6 were resolved — see **Recorded Decisions** above. This section previously still listed them as open `TODO(spec)` blockers after they were resolved; that self-contradiction was found and fixed here (#141).
 
-- **C1 — Collaboration model.** Roadmap Phase 3 lists presence indicators; its baseline assumes realtime collaboration. Spec §3 N1 and §4 exclude both — no websockets on shared hosting. `TODO(spec): confirm collaboration stays asynchronous — comments and mentions yes, presence and live cursors no.`
-- **C2 — Structured collections.** Roadmap Phase 4 wants database-like collections over note metadata. Spec §1 says MySQL is only an index. `TODO(spec): decide whether collections project from front-matter on disk, or whether the Markdown-on-disk invariant is being amended.`
-- **C3 — Synced blocks.** Roadmap priority 8. Transclusion that does not degrade to readable Markdown breaks Obsidian compatibility. `TODO(spec): choose a plain-Markdown-safe syntax, or drop the item.`
-- **C5 — Offline / mobile-first.** Roadmap Phase 5 differentiators contradict §2's deliberate local-first inversion. `TODO(spec): confirm WebDAV + Obsidian is the mobile and offline answer.`
-- **C6 — History storage.** See Milestone A. `TODO(spec): DB deltas or bounded snapshots; no per-revision files in the vault.`
 - **Roadmap baseline provenance.** `TODO(spec): confirm whether the roadmap's gap analysis was drawn from a different product of the same name. Until confirmed, spec §14.3 governs what counts as delivered.`
 
 ## Not adopted

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,7 @@
 - **Last Updated:** 2026-07-28
 - **Repo:** https://github.com/suporterfid/jotter
 - **Production Site:** https://hub.taskconnect.com.br/
-- **CI Status:** 🔴 Red on `main` — PHPUnit and Vitest pass; one Playwright spec fails (see §3)
+- **CI Status:** 🔴 Red on `main` — PHPUnit and Vitest pass; one Playwright spec fails, confirmed still failing on the current HEAD, not just historically (see §3, #140)
 - **Planning authority:** `docs/jotter-initial-spec-and-build-plan.md` §14 sequences post-v0 work from `docs/20260727-jotter-roadmap-ai-agent.md`
 
 ---
@@ -100,15 +100,17 @@ Six roadmap items conflict with hard constraints and are parked pending decision
 
 ## 3. Known issues
 
-- **CI is red on `main`.** The workflow has failed on every run since 2026-07-27 22:28, including the latest (`f57003d`). The current failure is narrow: `frontend/e2e/notes.spec.ts:26` times out waiting for `[data-testid="editor-title"]` to contain `e2e-demo` (1 failed, 1 passed). PHPUnit and Vitest pass. §0.3 of the spec requires green CI per PR, so this blocks the next unit.
-- **`WorkspaceAuthorizationPlaceholder` is still present** in `app/Http/Middleware/` but is no longer aliased — `AuthorizeWorkspaceAccess` replaced it. Dead code pending removal.
+- **CI is red on `main`, and #49's fix did not hold.** #49 diagnosed this as a login-modal race, fixed the timeout, and was closed `completed` on 2026-07-28. The identical failure reproduces on the current `main` HEAD (`4d10b087`, run [30386678242](https://github.com/suporterfid/jotter/actions/runs/30386678242)) in a CI run that started after that fix and after three more feature PRs landed on top of it: `frontend/e2e/notes.spec.ts:26` still times out waiting for `[data-testid="editor-title"]` to contain `e2e-demo` (1 failed, 1 passed). PHPUnit and Vitest pass. The already-fixed login timeout rules out the original hypothesis; the version-history epic (#51/#136) added a synchronous revision-write to the exact code path this test exercises and is the leading new candidate, but is not confirmed — this sandbox has no Docker daemon available to reproduce and trace it. §0.3 of the spec requires green CI per PR, so this blocks the next unit. Tracked in **#140**.
+- **`WorkspaceAuthorizationPlaceholder` is fully deleted from `app/`** (#66's file-removal criterion was met), but its "and any test referencing it" criterion wasn't: six tests in `tests/Feature/WorkspaceNotesApiTest.php` still call `withoutMiddleware(WorkspaceAuthorizationPlaceholder::class)` against a class name that no longer resolves to anything, which silently no-ops instead of bypassing authorization as the tests assume. Tracked in **#142**.
 - **The WebDAV adapter is hand-rolled, not SabreDAV.** `sabre/dav` is not a dependency despite the commit message and earlier status notes saying so.
+- ~~**`BACKLOG.md` was self-contradictory**~~ — the "Recorded Decisions" and "Needs a decision" sections disagreed about whether C1–C6 were resolved. Fixed; see #141.
 
 ---
 
 ## 4. Next
 
-1. Fix the failing Playwright spec and restore green CI; add branch protection so §0.3 is enforced rather than conventional.
-2. Resolve the §14.5 decisions that block planning — C1, C2, and C6 gate the nearest work.
-3. Then Milestone A's remainder: version history (once C6 is decided), search filters, import.
-4. **Visual identity (#96)** — cross-cutting presentation workstream adopting a shared dark/purple design system with semantic tokens, Open Sans, and WCAG 2.2 AA across the SPA, the Laravel shell, and the published static site. Sequenced independently of Milestones A–D and blocked on none of the §14.5 decisions, but gated behind item 1 like every other PR. See `BACKLOG.md`.
+1. **Root-cause and fix #140** (CI red on `main`, again) in an environment with a working Docker daemon — this blocks everything else per §0.3, and the fact that #49's fix didn't hold means this needs an actual green post-merge run before being called done, not just a local pass.
+2. Clean up **#142** (dead middleware-name references in `WorkspaceNotesApiTest.php`) — small, but it's a latent test-authorization gap.
+3. Resolve the remaining §14.5 decision — roadmap baseline provenance is the only one still open; C1–C6 are recorded resolved (see `BACKLOG.md`).
+4. Then Milestone A/B/C/D are all recorded complete — re-verify against a green CI before treating that as trustworthy, since #140 shows a "done" item can regress silently without branch protection.
+5. **Visual identity (#96)** — cross-cutting presentation workstream adopting a shared dark/purple design system with semantic tokens, Open Sans, and WCAG 2.2 AA across the SPA, the Laravel shell, and the published static site. Recorded complete; gated behind item 1 like every other PR for the same reason as item 4.


### PR DESCRIPTION
## Summary

A review of whether `main` is 100% adherent to `docs/20260727-jotter-roadmap-ai-agent.md` and whether `BACKLOG.md` is fully done found three gaps, verified against live CI/GitHub state rather than the docs' own claims. Each is filed as a detailed issue; this PR records them in `BACKLOG.md`/`STATUS.md` and fixes the one that was pure documentation.

- **#140 — CI is still red on `main`.** #49 diagnosed the `notes.spec.ts` failure, fixed it, and was closed `completed`. The identical failure reproduces on the current `main` HEAD (`4d10b087`) in a run that started *after* that fix and after three more feature PRs landed. The already-fixed login timeout rules out #49's original hypothesis; the version-history epic (#51/#136) added a synchronous revision-write to the exact code path the failing test exercises, and is the leading unconfirmed candidate — this sandbox has no Docker daemon, so live root-causing needs a Docker-capable environment. Not fixed by this PR — it's a real code investigation.
- **#141 — `BACKLOG.md` contradicted itself.** The "Recorded Decisions" section marked C1–C6 resolved; the "Needs a decision" section below it still listed the same five as open `TODO(spec)` blockers, because the commit that added the former never touched the latter. **Fixed in this PR** — the stale entries are removed, leaving only the one genuinely-open item (roadmap baseline provenance).
- **#142 — #66's dead-code cleanup was incomplete.** `WorkspaceAuthorizationPlaceholder` is deleted from `app/`, but six tests in `tests/Feature/WorkspaceNotesApiTest.php` still reference it by name with no import; PHP resolves the name to an unrelated string, so the `withoutMiddleware()` calls silently no-op instead of bypassing anything. `STATUS.md`'s description of this item was also stale. Not fixed by this PR — it's a test-code change.

## Changes

- `BACKLOG.md`: new "Known gaps (open)" section up top linking all three issues; reconciled the C1–C6 contradiction in "Needs a decision".
- `STATUS.md`: "Known issues" and "Next" sections updated with current, verified evidence (commit SHAs, run links) instead of the stale references they previously cited.

## Test plan

Documentation-only change (plus a code-free edit to `BACKLOG.md`'s own text). No `jt` commands apply.

- [x] Verified live CI state via the GitHub Actions API for the current `main` HEAD before writing #140.
- [x] Verified `WorkspaceAuthorizationPlaceholder` is absent from `app/` but present in test code before writing #142.
- [x] Re-read the resulting `BACKLOG.md`/`STATUS.md` diff for internal consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141qjWwCXzc1FCR3HqzGoyp)_