### PR TITLE
Fix #146: MCP read_note called undefined VaultStorage::getNoteContent()

### DIFF
--- a/app/Http/Controllers/McpController.php
+++ b/app/Http/Controllers/McpController.php
@@ -123,7 +123,7 @@ final class McpController extends Controller
                 }
 
                 $vaultStorage = new \App\Domain\Vault\VaultStorage();
-                $content = $vaultStorage->getNoteContent($workspace, $path);
+                $content = $vaultStorage->readContents($workspace, $path);
 
                 return response()->json([
                     'jsonrpc' => '2.0',

--- a/tests/Feature/McpReadOnlyToolsTest.php
+++ b/tests/Feature/McpReadOnlyToolsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Domain\Vault\VaultStorage;
 use App\Models\MachineToken;
 use App\Models\Membership;
 use App\Models\Note;
@@ -87,5 +88,22 @@ class McpReadOnlyToolsTest extends TestCase
             $deniedRes->assertStatus(403);
             $deniedRes->assertJsonPath('error.code', -32003);
         }
+
+        // 3. read_note on an existing, authorized note returns its actual content
+        $storage = $this->app->make(VaultStorage::class);
+        $storage->write($workspaceA, 'mcp-read-note.md', "# MCP Read Note\nActual content.");
+
+        $readRes = $this->withHeader('Authorization', 'Bearer '.$plainToken)
+            ->postJson('/api/mcp', [
+                'jsonrpc' => '2.0',
+                'method' => 'tools/call',
+                'params' => [
+                    'name' => 'read_note',
+                    'arguments' => ['workspace_id' => $workspaceA->id, 'path' => 'mcp-read-note.md'],
+                ],
+                'id' => 1,
+            ]);
+        $readRes->assertOk();
+        $readRes->assertJsonPath('result.content.0.text', "# MCP Read Note\nActual content.");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #146. `VaultStorage` has no `getNoteContent()` method — the accessor is `readContents(Workspace, string): string`. Every `read_note` MCP tool call hit a fatal error instead of returning content.

## Verification

Confirmed both ways: reverting to `getNoteContent()` reproduces `500` on the new assertion in `McpReadOnlyToolsTest`; `readContents()` passes.

## Test plan

- [x] Extended `tests/Feature/McpReadOnlyToolsTest.php` to actually call `read_note` on a real note and assert the returned content matches.
- [x] `./scripts/jt.sh test` — 101 PHPUnit + 20 Vitest, all pass.
- [ ] Confirm GitHub Actions is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)