### PR TITLE
Fix #147: GrandpaSSOn SSO users no longer default to admin

### DIFF
--- a/app/Domain/Auth/Providers/GrandpaSSOnIdentityProvider.php
+++ b/app/Domain/Auth/Providers/GrandpaSSOnIdentityProvider.php
@@ -43,7 +43,7 @@ final class GrandpaSSOnIdentityProvider implements IdentityProvider
                             [
                                 'name' => $ssoUser->display_name ?? 'SSO User',
                                 'password' => bcrypt(uniqid('sso_', true)),
-                                'is_admin' => true,
+                                'is_admin' => false,
                             ],
                         );
 
@@ -51,7 +51,7 @@ final class GrandpaSSOnIdentityProvider implements IdentityProvider
                             subjectId: (string) $ssoUser->id,
                             email: $ssoUser->primary_email,
                             name: $ssoUser->display_name ?? 'SSO User',
-                            isAdmin: (bool) ($user->is_admin ?? true),
+                            isAdmin: (bool) ($user->is_admin ?? false),
                             user: $user,
                             attributes: ['sso_provider' => 'grandpasson'],
                         );

--- a/tests/Feature/GrandpaSSOnAdminEscalationTest.php
+++ b/tests/Feature/GrandpaSSOnAdminEscalationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Auth\Providers\GrandpaSSOnIdentityProvider;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * GrandpaSSOnIdentityProvider::resolveIdentity() reads its AUTHSESSID cookie path against
+ * generic `sessions`/`users` columns (expires_at, primary_email, display_name, status) that
+ * do not exist on Jotter's own schema; these columns are added here only for the duration of
+ * this test to faithfully exercise that code path.
+ */
+final class GrandpaSSOnAdminEscalationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // expires_at is an unsigned integer here (unix timestamp) to match how
+        // resolveIdentity() actually compares it (`> time()`); a real GrandpaSSOn
+        // deployment's `sessions` schema is unspecified and out of scope for this stub.
+        Schema::table('sessions', function ($table) {
+            $table->unsignedBigInteger('expires_at')->nullable();
+        });
+
+        Schema::table('users', function ($table) {
+            $table->string('primary_email')->nullable();
+            $table->string('display_name')->nullable();
+            $table->string('status')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::table('sessions', function ($table) {
+            $table->dropColumn('expires_at');
+        });
+
+        Schema::table('users', function ($table) {
+            $table->dropColumn(['primary_email', 'display_name', 'status']);
+        });
+
+        parent::tearDown();
+    }
+
+    public function test_a_brand_new_sso_user_is_not_granted_admin_by_default(): void
+    {
+        $ssoUserId = 999001;
+
+        DB::table('users')->insert([
+            'id' => $ssoUserId,
+            'name' => 'SSO Placeholder',
+            'email' => 'sso-placeholder-'.uniqid().'@example.com',
+            'password' => bcrypt('unused'),
+            'is_admin' => false,
+            'primary_email' => 'new-sso-user@example.com',
+            'display_name' => 'New SSO User',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('sessions')->insert([
+            'id' => 'sso-session-'.uniqid(),
+            'user_id' => $ssoUserId,
+            'expires_at' => time() + 3600,
+            'last_activity' => time(),
+            'payload' => base64_encode(serialize([])),
+        ]);
+
+        $sessionId = DB::table('sessions')->where('user_id', $ssoUserId)->value('id');
+
+        $request = Request::create('/api/notes', 'GET');
+        $request->cookies->set('AUTHSESSID', $sessionId);
+
+        $provider = new GrandpaSSOnIdentityProvider();
+        $subject = $provider->resolveIdentity($request);
+
+        $this->assertNotNull($subject);
+        $this->assertFalse($subject->isAdmin);
+
+        $localUser = User::query()->where('email', 'new-sso-user@example.com')->firstOrFail();
+        $this->assertFalse((bool) $localUser->is_admin);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #147. `GrandpaSSOnIdentityProvider::resolveIdentity()` hardcoded `'is_admin' => true` when creating a local `User` for a new incoming SSO session, and separately defaulted a null `is_admin` to `true` on the returned subject. Both cases now default to `false` (least privilege).

## A note on reachability

While building a regression test I found the AUTHSESSID-cookie branch has its own separate, pre-existing bug: it compares a `DATETIME`/`TIMESTAMP` `expires_at` column against a raw Unix-epoch integer (`WHERE expires_at > time()`). MySQL casts the datetime string to an integer by taking only its leading digits (i.e. the year), so this condition can never be true against a real timestamp column — the branch is effectively dead code today given the actual `sessions` table shape. Not fixing that here (separate concern, and this whole adapter is an explicitly disabled stub per spec §7.6/§9); the regression test builds its own compatible schema in `setUp()`/`tearDown()` to exercise the `is_admin` logic directly instead of depending on that unrelated defect. Worth its own follow-up if the GrandpaSSOn adapter is ever made real.

## Verification

Confirmed both ways: reverting to `true` fails the new test; the fix passes.

## Test plan

- [x] New `tests/Feature/GrandpaSSOnAdminEscalationTest.php`.
- [x] `./scripts/jt.sh test` — 102 PHPUnit (101 + 1 new) + 20 Vitest, all pass.
- [ ] Confirm GitHub Actions is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)