### PR TITLE
Fix GrandpaSSOnIdentityProvider querying the wrong sessions/users tables

### DIFF
--- a/app/Domain/Auth/Providers/GrandpaSSOnIdentityProvider.php
+++ b/app/Domain/Auth/Providers/GrandpaSSOnIdentityProvider.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
+use PDO;
 
 final class GrandpaSSOnIdentityProvider implements IdentityProvider
 {
@@ -24,41 +24,10 @@ final class GrandpaSSOnIdentityProvider implements IdentityProvider
         // 1. Check GrandpaSSOn AUTHSESSID session cookie
         $authSessId = $request->cookie('AUTHSESSID') ?? ($_COOKIE['AUTHSESSID'] ?? null);
 
-        if ($authSessId && Schema::hasTable('sessions') && Schema::hasTable('users')) {
-            try {
-                $session = DB::table('sessions')
-                    ->where('id', $authSessId)
-                    ->where('expires_at', '>', time())
-                    ->first();
-
-                if ($session && ! empty($session->user_id)) {
-                    $ssoUser = DB::table('users')
-                        ->where('id', $session->user_id)
-                        ->where('status', 'active')
-                        ->first();
-
-                    if ($ssoUser) {
-                        $user = User::query()->firstOrCreate(
-                            ['email' => $ssoUser->primary_email],
-                            [
-                                'name' => $ssoUser->display_name ?? 'SSO User',
-                                'password' => bcrypt(uniqid('sso_', true)),
-                                'is_admin' => false,
-                            ],
-                        );
-
-                        return new AuthenticatedSubject(
-                            subjectId: (string) $ssoUser->id,
-                            email: $ssoUser->primary_email,
-                            name: $ssoUser->display_name ?? 'SSO User',
-                            isAdmin: (bool) ($user->is_admin ?? false),
-                            user: $user,
-                            attributes: ['sso_provider' => 'grandpasson'],
-                        );
-                    }
-                }
-            } catch (\Throwable) {
-                // Ignore missing table / DB error
+        if ($authSessId) {
+            $subject = $this->resolveFromGrandpaSsonSession((string) $authSessId);
+            if ($subject !== null) {
+                return $subject;
             }
         }
 
@@ -76,6 +45,61 @@ final class GrandpaSSOnIdentityProvider implements IdentityProvider
         }
 
         return null;
+    }
+
+    /**
+     * GrandpaSSOn's `sessions`/`users` tables live in the same shared MySQL database as
+     * this app's own tables, distinguished only by table-name prefix. Eloquent/DB::table()
+     * would silently apply *this app's own* connection prefix (e.g. jt_) and query the
+     * wrong tables entirely, so this queries via the raw PDO connection with GrandpaSSOn's
+     * configured prefix (jotter.sso.db_prefix / JOTTER_SSO_DB_PREFIX) instead.
+     */
+    private function resolveFromGrandpaSsonSession(string $authSessId): ?AuthenticatedSubject
+    {
+        $prefix = (string) config('jotter.sso.db_prefix', '');
+        $sessionsTable = $prefix.'sessions';
+        $usersTable = $prefix.'users';
+
+        try {
+            $pdo = DB::connection()->getPdo();
+
+            $stmt = $pdo->prepare("SELECT * FROM {$sessionsTable} WHERE id = :id AND expires_at > :now LIMIT 1");
+            $stmt->execute(['id' => $authSessId, 'now' => time()]);
+            $session = $stmt->fetch(PDO::FETCH_OBJ);
+
+            if (! $session || empty($session->user_id)) {
+                return null;
+            }
+
+            $stmt = $pdo->prepare("SELECT * FROM {$usersTable} WHERE id = :id AND status = 'active' LIMIT 1");
+            $stmt->execute(['id' => $session->user_id]);
+            $ssoUser = $stmt->fetch(PDO::FETCH_OBJ);
+
+            if (! $ssoUser) {
+                return null;
+            }
+
+            $user = User::query()->firstOrCreate(
+                ['email' => $ssoUser->primary_email],
+                [
+                    'name' => $ssoUser->display_name ?? 'SSO User',
+                    'password' => bcrypt(uniqid('sso_', true)),
+                    'is_admin' => false,
+                ],
+            );
+
+            return new AuthenticatedSubject(
+                subjectId: (string) $ssoUser->id,
+                email: $ssoUser->primary_email,
+                name: $ssoUser->display_name ?? 'SSO User',
+                isAdmin: (bool) ($user->is_admin ?? false),
+                user: $user,
+                attributes: ['sso_provider' => 'grandpasson'],
+            );
+        } catch (\Throwable) {
+            // Missing table / DB error / GrandpaSSOn not deployed alongside this app
+            return null;
+        }
     }
 
     public function authenticate(array $credentials, Request $request): ?AuthenticatedSubject

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -17,6 +17,14 @@ return [
     'auth_provider' => env('JOTTER_AUTH_PROVIDER', env('AUTH_PROVIDER', 'local')),
     'auth_bypass' => (bool) env('JOTTER_AUTH_BYPASS', false),
 
+    // GrandpaSSOnIdentityProvider's AUTHSESSID cookie path reads GrandpaSSOn's own
+    // `sessions`/`users` tables directly. On shared hosting they share one MySQL
+    // database/schema with this app, distinguished only by table-name prefix — this
+    // must match GrandpaSSOn's own DB_PREFIX, not Jotter's (JOTTER_DB_PREFIX/DB_PREFIX).
+    'sso' => [
+        'db_prefix' => env('JOTTER_SSO_DB_PREFIX', 'sso_'),
+    ],
+
     'attachments' => [
         'max_size_kb' => (int) env('JOTTER_ATTACHMENT_MAX_SIZE_KB', 20480), // 20MB
         'allowed_mimes' => [

--- a/tests/Feature/GrandpaSSOnAdminEscalationTest.php
+++ b/tests/Feature/GrandpaSSOnAdminEscalationTest.php
@@ -11,83 +11,122 @@ use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 /**
- * GrandpaSSOnIdentityProvider::resolveIdentity() reads its AUTHSESSID cookie path against
- * generic `sessions`/`users` columns (expires_at, primary_email, display_name, status) that
- * do not exist on Jotter's own schema; these columns are added here only for the duration of
- * this test to faithfully exercise that code path.
+ * GrandpaSSOnIdentityProvider::resolveIdentity() reads GrandpaSSOn's own `sessions`/`users`
+ * tables directly via a raw PDO connection with a configurable prefix (jotter.sso.db_prefix),
+ * since on shared hosting they live in the same MySQL database/schema as Jotter's own tables
+ * but under a different prefix. These tables are created here (with GrandpaSSOn's real column
+ * shape: id CHAR(36) UUID, primary_email, display_name, status, expires_at as a Unix
+ * timestamp int) only for the duration of this test.
  */
 final class GrandpaSSOnAdminEscalationTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const PREFIX = 'test_sso_';
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        // expires_at is an unsigned integer here (unix timestamp) to match how
-        // resolveIdentity() actually compares it (`> time()`); a real GrandpaSSOn
-        // deployment's `sessions` schema is unspecified and out of scope for this stub.
-        Schema::table('sessions', function ($table) {
-            $table->unsignedBigInteger('expires_at')->nullable();
+        config(['jotter.sso.db_prefix' => self::PREFIX]);
+
+        Schema::create(self::PREFIX.'users', function ($table) {
+            $table->string('id', 36)->primary();
+            $table->string('primary_email');
+            $table->string('display_name')->nullable();
+            $table->string('status')->default('active');
         });
 
-        Schema::table('users', function ($table) {
-            $table->string('primary_email')->nullable();
-            $table->string('display_name')->nullable();
-            $table->string('status')->nullable();
+        Schema::create(self::PREFIX.'sessions', function ($table) {
+            $table->string('id', 64)->primary();
+            $table->string('user_id', 36)->nullable();
+            $table->unsignedBigInteger('expires_at');
         });
     }
 
     protected function tearDown(): void
     {
-        Schema::table('sessions', function ($table) {
-            $table->dropColumn('expires_at');
-        });
-
-        Schema::table('users', function ($table) {
-            $table->dropColumn(['primary_email', 'display_name', 'status']);
-        });
+        Schema::dropIfExists(self::PREFIX.'sessions');
+        Schema::dropIfExists(self::PREFIX.'users');
 
         parent::tearDown();
     }
 
     public function test_a_brand_new_sso_user_is_not_granted_admin_by_default(): void
     {
-        $ssoUserId = 999001;
+        $ssoUserId = $this->insertSsoUser('new-sso-user@example.com', 'New SSO User');
+        $sessionId = $this->insertSsoSession($ssoUserId, time() + 3600);
 
-        DB::table('users')->insert([
-            'id' => $ssoUserId,
-            'name' => 'SSO Placeholder',
-            'email' => 'sso-placeholder-'.uniqid().'@example.com',
-            'password' => bcrypt('unused'),
-            'is_admin' => false,
-            'primary_email' => 'new-sso-user@example.com',
-            'display_name' => 'New SSO User',
-            'status' => 'active',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
-        DB::table('sessions')->insert([
-            'id' => 'sso-session-'.uniqid(),
-            'user_id' => $ssoUserId,
-            'expires_at' => time() + 3600,
-            'last_activity' => time(),
-            'payload' => base64_encode(serialize([])),
-        ]);
-
-        $sessionId = DB::table('sessions')->where('user_id', $ssoUserId)->value('id');
-
-        $request = Request::create('/api/notes', 'GET');
-        $request->cookies->set('AUTHSESSID', $sessionId);
-
-        $provider = new GrandpaSSOnIdentityProvider();
-        $subject = $provider->resolveIdentity($request);
+        $subject = $this->resolveWithCookie($sessionId);
 
         $this->assertNotNull($subject);
         $this->assertFalse($subject->isAdmin);
+        $this->assertSame('new-sso-user@example.com', $subject->email);
 
         $localUser = User::query()->where('email', 'new-sso-user@example.com')->firstOrFail();
         $this->assertFalse((bool) $localUser->is_admin);
+    }
+
+    public function test_an_expired_session_is_not_resolved(): void
+    {
+        $ssoUserId = $this->insertSsoUser('expired-user@example.com', 'Expired User');
+        $sessionId = $this->insertSsoSession($ssoUserId, time() - 60);
+
+        $subject = $this->resolveWithCookie($sessionId);
+
+        $this->assertNull($subject);
+        $this->assertDatabaseMissing('users', ['email' => 'expired-user@example.com']);
+    }
+
+    public function test_an_unknown_session_id_is_not_resolved(): void
+    {
+        $subject = $this->resolveWithCookie('does-not-exist');
+
+        $this->assertNull($subject);
+    }
+
+    public function test_a_disabled_sso_user_is_not_resolved(): void
+    {
+        $ssoUserId = $this->insertSsoUser('disabled-user@example.com', 'Disabled User', 'disabled');
+        $sessionId = $this->insertSsoSession($ssoUserId, time() + 3600);
+
+        $subject = $this->resolveWithCookie($sessionId);
+
+        $this->assertNull($subject);
+    }
+
+    private function insertSsoUser(string $email, string $displayName, string $status = 'active'): string
+    {
+        $id = (string) \Illuminate\Support\Str::uuid();
+
+        DB::table(self::PREFIX.'users')->insert([
+            'id' => $id,
+            'primary_email' => $email,
+            'display_name' => $displayName,
+            'status' => $status,
+        ]);
+
+        return $id;
+    }
+
+    private function insertSsoSession(string $ssoUserId, int $expiresAt): string
+    {
+        $sessionId = 'sso-session-'.uniqid();
+
+        DB::table(self::PREFIX.'sessions')->insert([
+            'id' => $sessionId,
+            'user_id' => $ssoUserId,
+            'expires_at' => $expiresAt,
+        ]);
+
+        return $sessionId;
+    }
+
+    private function resolveWithCookie(string $authSessId): ?\App\Domain\Auth\AuthenticatedSubject
+    {
+        $request = Request::create('/api/notes', 'GET');
+        $request->cookies->set('AUTHSESSID', $authSessId);
+
+        return (new GrandpaSSOnIdentityProvider())->resolveIdentity($request);
     }
 }


### PR DESCRIPTION
## Summary

Found while reviewing production compatibility of the three sibling apps for hub.taskconnect.com.br (Jotter, TaskConnect, GrandpaSSOn sharing one MySQL database, distinguished by table prefix).

`GrandpaSSOnIdentityProvider::resolveIdentity()`'s AUTHSESSID-cookie path used `DB::table('sessions')`/`DB::table('users')`. Eloquent's default connection silently applies **this app's own** `DB_PREFIX` (e.g. `jt_` in production) to those calls — meaning it queried `jt_sessions`/`jt_users`, Jotter's own local session table, never GrandpaSSOn's actual identity data. This is a separate, more fundamental bug than the admin-escalation issue fixed in #147: even with that fix, this code could never resolve a real SSO session, because it was never looking at the right tables.

## Fix

Query GrandpaSSOn's real `sessions`/`users` tables via the raw PDO connection with a **separately configurable** prefix (`jotter.sso.db_prefix` / `JOTTER_SSO_DB_PREFIX`, default `sso_` matching the documented shared-DB deployment convention), instead of going through Eloquent's auto-prefixed query builder.

## Test plan

- [x] Rewrote `tests/Feature/GrandpaSSOnAdminEscalationTest.php` to create real GrandpaSSOn-shaped tables under a test prefix (matching its actual schema: `id CHAR(36)` UUID, `primary_email`, `display_name`, `status`; `sessions.expires_at` as a Unix timestamp int) instead of bolting fake columns onto Jotter's own tables. Added coverage for expired sessions, unknown session ids, and disabled SSO users.
- [x] `./scripts/jt.sh artisan test` — 105 PHPUnit (101 + 4), all pass. (Full `jt.sh test` including Vitest wasn't runnable in this sandbox due to unrelated system memory pressure blocking a Docker image pull — this change touches no frontend code, so that risk is effectively zero; CI will run the full suite.)
- [ ] Confirm GitHub Actions is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)