### PR TITLE
Fix #156: expose search filters (title/tags/modified-date) in the UI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,7 +28,10 @@
         v-else-if="isSearchActive"
         :query="searchQuery"
         :results="searchResults"
+        :filters="searchFilters"
+        :available-tags="availableTagsForSearch"
         @select-note="handleSelectNote"
+        @update:filters="handleSearchFiltersChange"
       />
 
       <!-- Active Note Editor -->
@@ -86,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import Sidebar from './components/Sidebar.vue'
 import NoteEditor from './components/NoteEditor.vue'
 import SearchResults from './components/SearchResults.vue'
@@ -105,7 +108,7 @@ import {
   logout,
   setUnauthenticatedHandler
 } from './services/api'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser } from './services/types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters } from './services/types'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -120,6 +123,19 @@ const isGraphViewActive = ref(false)
 const isSearchActive = ref(false)
 const searchQuery = ref('')
 const searchResults = ref<SearchResult[]>([])
+const searchFilters = ref<SearchFilters>({})
+
+const availableTagsForSearch = computed(() => {
+  const tagSet = new Set<string>()
+  for (const n of notes.value) {
+    if (n.frontmatter?.tags && Array.isArray(n.frontmatter.tags)) {
+      for (const t of n.frontmatter.tags) {
+        if (typeof t === 'string') tagSet.add(t.replace(/^#/, ''))
+      }
+    }
+  }
+  return Array.from(tagSet).sort()
+})
 
 const errorMessage = ref<string | null>(null)
 
@@ -254,21 +270,39 @@ async function handleDeleteNote(noteId: number) {
   }
 }
 
-async function handleSearch(query: string) {
-  searchQuery.value = query
-  if (!query.trim()) {
+function hasActiveFilters(filters: SearchFilters): boolean {
+  return Boolean(
+    filters.title?.trim() ||
+    filters.modifiedAfter ||
+    filters.modifiedBefore ||
+    (filters.tags && filters.tags.length > 0)
+  )
+}
+
+async function runSearch(query: string, filters: SearchFilters) {
+  if (!query.trim() && !hasActiveFilters(filters)) {
     isSearchActive.value = false
     searchResults.value = []
     return
   }
   if (!activeWorkspaceId.value) return
   try {
-    const results = await searchNotes(activeWorkspaceId.value, query)
+    const results = await searchNotes(activeWorkspaceId.value, query, filters)
     searchResults.value = results
     isSearchActive.value = true
   } catch (err) {
     console.error('Search failed:', err)
   }
+}
+
+async function handleSearch(query: string) {
+  searchQuery.value = query
+  await runSearch(query, searchFilters.value)
+}
+
+async function handleSearchFiltersChange(filters: SearchFilters) {
+  searchFilters.value = filters
+  await runSearch(searchQuery.value, filters)
 }
 
 async function handleWikilinkNavigation(target: string) {

--- a/frontend/src/SearchResults.spec.ts
+++ b/frontend/src/SearchResults.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import SearchResults from './components/SearchResults.vue'
+
+describe('SearchResults filters', () => {
+  it('emits update:filters with a trimmed title on change', async () => {
+    const wrapper = mount(SearchResults, {
+      props: { query: 'demo', results: [], filters: {}, availableTags: [] }
+    })
+
+    const titleInput = wrapper.get('[data-testid="search-filter-title"]')
+    await titleInput.setValue('  Meeting Notes  ')
+    await titleInput.trigger('change')
+
+    const events = wrapper.emitted('update:filters')
+    expect(events).toBeTruthy()
+    expect(events![events!.length - 1][0]).toEqual({
+      title: 'Meeting Notes',
+      modifiedAfter: undefined,
+      modifiedBefore: undefined,
+      tags: undefined
+    })
+  })
+
+  it('toggles a tag on and off and emits the resulting tags array', async () => {
+    const wrapper = mount(SearchResults, {
+      props: { query: '', results: [], filters: {}, availableTags: ['work', 'personal'] }
+    })
+
+    const tagButtons = wrapper.findAll('[data-testid="search-filter-tag"]')
+    expect(tagButtons).toHaveLength(2)
+
+    await tagButtons[0].trigger('click')
+    let events = wrapper.emitted('update:filters')!
+    expect(events[events.length - 1][0]).toMatchObject({ tags: ['work'] })
+
+    await tagButtons[0].trigger('click')
+    events = wrapper.emitted('update:filters')!
+    expect(events[events.length - 1][0]).toMatchObject({ tags: undefined })
+  })
+
+  it('clear filters resets title, dates, and tags', async () => {
+    const wrapper = mount(SearchResults, {
+      props: {
+        query: '',
+        results: [],
+        filters: { title: 'foo', tags: ['work'], modifiedAfter: '2026-01-01' },
+        availableTags: ['work']
+      }
+    })
+
+    const clearBtn = wrapper.get('[data-testid="search-filter-clear"]')
+    await clearBtn.trigger('click')
+
+    const events = wrapper.emitted('update:filters')!
+    expect(events[events.length - 1][0]).toEqual({
+      title: undefined,
+      modifiedAfter: undefined,
+      modifiedBefore: undefined,
+      tags: undefined
+    })
+  })
+
+  it('does not show the clear-filters button when no filters are active', () => {
+    const wrapper = mount(SearchResults, {
+      props: { query: '', results: [], filters: {}, availableTags: [] }
+    })
+
+    expect(wrapper.find('[data-testid="search-filter-clear"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -75,7 +75,7 @@ describe('Accessibility Audit (axe-core)', () => {
   it('SearchResults has no serious or critical structural accessibility violations', async () => {
     const wrapper = mount(SearchResults, {
       attachTo: document.body,
-      props: { query: 'test', results: [] },
+      props: { query: 'test', results: [], filters: {}, availableTags: [] },
     })
     const results = await axe.run(wrapper.element, {
       rules: {

--- a/frontend/src/components/SearchResults.vue
+++ b/frontend/src/components/SearchResults.vue
@@ -5,14 +5,68 @@
       <span class="count">{{ results.length }} matches</span>
     </div>
 
+    <div class="filter-bar">
+      <input
+        v-model="titleDraft"
+        type="text"
+        class="filter-input"
+        placeholder="Filter by title..."
+        aria-label="Filter by title"
+        data-testid="search-filter-title"
+        @change="emitFilters"
+      />
+
+      <input
+        v-model="modifiedAfterDraft"
+        type="date"
+        class="filter-input"
+        aria-label="Modified after"
+        data-testid="search-filter-modified-after"
+        @change="emitFilters"
+      />
+      <span class="filter-range-sep" aria-hidden="true">–</span>
+      <input
+        v-model="modifiedBeforeDraft"
+        type="date"
+        class="filter-input"
+        aria-label="Modified before"
+        data-testid="search-filter-modified-before"
+        @change="emitFilters"
+      />
+
+      <div v-if="availableTags.length > 0" class="filter-tags">
+        <button
+          v-for="tag in availableTags"
+          :key="tag"
+          type="button"
+          class="tag-pill"
+          :class="{ active: selectedTags.includes(tag) }"
+          data-testid="search-filter-tag"
+          @click="toggleTag(tag)"
+        >
+          #{{ tag }}
+        </button>
+      </div>
+
+      <button
+        v-if="hasActiveFilters"
+        type="button"
+        class="clear-filters-btn"
+        data-testid="search-filter-clear"
+        @click="clearFilters"
+      >
+        Clear filters
+      </button>
+    </div>
+
     <div v-if="results.length === 0" class="no-results">
       No notes found matching your search.
     </div>
 
     <div v-else class="results-list">
-      <div 
-        v-for="item in results" 
-        :key="item.note_id" 
+      <div
+        v-for="item in results"
+        :key="item.note_id"
         class="result-card"
         @click="$emit('select-note', item.note_id)"
       >
@@ -25,16 +79,71 @@
 </template>
 
 <script setup lang="ts">
-import type { SearchResult } from '../services/types'
+import { computed, ref, watch } from 'vue'
+import type { SearchResult, SearchFilters } from '../services/types'
 
-defineProps<{
+const props = defineProps<{
   query: string
   results: SearchResult[]
+  filters: SearchFilters
+  availableTags: string[]
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'select-note', noteId: number): void
+  (e: 'update:filters', filters: SearchFilters): void
 }>()
+
+const titleDraft = ref(props.filters.title ?? '')
+const modifiedAfterDraft = ref(props.filters.modifiedAfter ?? '')
+const modifiedBeforeDraft = ref(props.filters.modifiedBefore ?? '')
+const selectedTags = ref<string[]>([...(props.filters.tags ?? [])])
+
+watch(
+  () => props.filters,
+  (filters) => {
+    titleDraft.value = filters.title ?? ''
+    modifiedAfterDraft.value = filters.modifiedAfter ?? ''
+    modifiedBeforeDraft.value = filters.modifiedBefore ?? ''
+    selectedTags.value = [...(filters.tags ?? [])]
+  }
+)
+
+const hasActiveFilters = computed(() =>
+  Boolean(
+    titleDraft.value.trim() ||
+    modifiedAfterDraft.value ||
+    modifiedBeforeDraft.value ||
+    selectedTags.value.length > 0
+  )
+)
+
+function emitFilters() {
+  emit('update:filters', {
+    title: titleDraft.value.trim() || undefined,
+    modifiedAfter: modifiedAfterDraft.value || undefined,
+    modifiedBefore: modifiedBeforeDraft.value || undefined,
+    tags: selectedTags.value.length > 0 ? [...selectedTags.value] : undefined
+  })
+}
+
+function toggleTag(tag: string) {
+  const idx = selectedTags.value.indexOf(tag)
+  if (idx === -1) {
+    selectedTags.value.push(tag)
+  } else {
+    selectedTags.value.splice(idx, 1)
+  }
+  emitFilters()
+}
+
+function clearFilters() {
+  titleDraft.value = ''
+  modifiedAfterDraft.value = ''
+  modifiedBeforeDraft.value = ''
+  selectedTags.value = []
+  emitFilters()
+}
 </script>
 
 <style scoped>
@@ -63,6 +172,74 @@ defineEmits<{
   padding: 0.125rem 0.5rem;
   border-radius: var(--radius-pill);
   font-size: 0.75rem;
+}
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.filter-input {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  min-height: 36px;
+}
+
+.filter-input:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
+.filter-range-sep {
+  color: var(--color-text-muted);
+}
+
+.filter-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.tag-pill {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.tag-pill.active {
+  background: var(--color-action);
+  color: var(--color-on-action, #fff);
+  border-color: var(--color-action);
+}
+
+.clear-filters-btn {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.clear-filters-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
 }
 
 .no-results {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -87,10 +87,24 @@ export async function deleteNote(workspaceId: number, noteId: number): Promise<v
   await api.delete(`/workspaces/${workspaceId}/notes/${noteId}`)
 }
 
-export async function searchNotes(workspaceId: number, query: string): Promise<SearchResult[]> {
-  if (!query.trim()) return []
+export async function searchNotes(
+  workspaceId: number,
+  query: string,
+  filters: SearchFilters = {}
+): Promise<SearchResult[]> {
+  const params = new URLSearchParams()
+  if (query.trim()) params.set('q', query.trim())
+  if (filters.title?.trim()) params.set('title', filters.title.trim())
+  if (filters.modifiedAfter) params.set('modified_after', filters.modifiedAfter)
+  if (filters.modifiedBefore) params.set('modified_before', filters.modifiedBefore)
+  for (const tag of filters.tags ?? []) {
+    if (tag.trim()) params.append('tags[]', tag.trim())
+  }
+
+  if ([...params.keys()].length === 0) return []
+
   const response = await api.get<{ data: SearchResult[] }>(
-    `/workspaces/${workspaceId}/search?q=${encodeURIComponent(query.trim())}`
+    `/workspaces/${workspaceId}/search?${params.toString()}`
   )
   return response.data.data
 }

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -33,6 +33,13 @@ export interface SearchResult {
   score: number
 }
 
+export interface SearchFilters {
+  title?: string
+  tags?: string[]
+  modifiedAfter?: string
+  modifiedBefore?: string
+}
+
 export interface AuthUser {
   subject_id: string
   email: string


### PR DESCRIPTION
## Summary

Fixes #156. Backend `SearchCriteria` (title, tags, modified-date range — #52) has been available since Milestone A, but `searchNotes()` only ever sent `?q=` to the API — the filter parameters never reached the UI. This was found via a UI audit against `docs/20260727-jotter-roadmap-ai-agent.md`.

## What changed

- `SearchResults.vue`: new filter bar — title input, modified-after/before date range, and tag toggle pills built from the workspace's known tags. A "Clear filters" action appears only when a filter is active.
- `App.vue`: new `searchFilters` state, `runSearch()`/`handleSearchFiltersChange()` wiring so filters combine with the query and re-trigger search on change (including filter-only searches with an empty query, matching what the backend already accepts).
- `services/api.ts` / `types.ts`: `searchNotes()` now accepts a `SearchFilters` object and builds the existing `title`/`tags[]`/`modified_after`/`modified_before` query params.

## Test plan

- [x] New `SearchResults.spec.ts` (4 tests: title filter emits trimmed value, tag toggle on/off, clear resets all, clear button hidden when no filters active).
- [x] `a11y.spec.ts` updated for the new required props; axe-core WCAG 2.2 AA check passes (added `aria-label`s to the new inputs after axe caught them missing).
- [x] Full Vitest suite: 24/24 pass. `vue-tsc -b`: clean.
- [x] **Verified in a real browser** against the running dev app (not just unit tests) — screenshots + a scripted flow: created two notes sharing a search term ("zzyzx"), confirmed the query alone returns both (2 matches), and applying the title filter ("Alpha") narrows to 1 and keeps the correct note.
- [ ] Confirm GitHub Actions is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)