### PR TITLE
Render sidebar notes as a browsable folder tree (#169)

### DIFF
--- a/frontend/src/components/NoteTreeNode.vue
+++ b/frontend/src/components/NoteTreeNode.vue
@@ -1,0 +1,232 @@
+<template>
+  <div v-if="node.type === 'folder'" class="tree-folder">
+    <button
+      type="button"
+      class="folder-row"
+      :style="{ paddingLeft: `${depth * 14 + 8}px` }"
+      :aria-expanded="expanded"
+      @click="expanded = !expanded"
+    >
+      <svg
+        class="chevron"
+        :class="{ collapsed: !expanded }"
+        viewBox="0 0 24 24"
+        width="12"
+        height="12"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+      >
+        <polyline points="9 6 15 12 9 18"></polyline>
+      </svg>
+      <svg class="folder-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"></path>
+      </svg>
+      <span class="folder-name">{{ node.name }}</span>
+      <span class="folder-count">{{ noteCount }}</span>
+    </button>
+    <div v-if="expanded" class="folder-children">
+      <NoteTreeNode
+        v-for="child in node.children"
+        :key="child.type === 'folder' ? `f:${child.fullPath}` : `n:${child.note.id}`"
+        :node="child"
+        :selected-note-id="selectedNoteId"
+        :depth="depth + 1"
+        @select-note="$emit('select-note', $event)"
+        @delete-note="$emit('delete-note', $event)"
+      />
+    </div>
+  </div>
+
+  <div
+    v-else
+    class="note-item"
+    :class="{ active: selectedNoteId === node.note.id }"
+    :style="{ paddingLeft: `${depth * 14 + 8}px` }"
+    @click="$emit('select-note', node.note.id)"
+  >
+    <div class="note-info">
+      <span class="note-title">{{ node.note.title || node.note.path }}</span>
+      <span class="note-path">{{ node.note.path }}</span>
+    </div>
+    <button
+      class="btn-delete"
+      title="Delete note"
+      @click.stop="$emit('delete-note', node.note.id)"
+    >
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { NoteMeta } from '../services/types'
+
+export interface TreeFolder {
+  type: 'folder'
+  name: string
+  fullPath: string
+  children: TreeNode[]
+}
+
+export interface TreeFile {
+  type: 'file'
+  note: NoteMeta
+}
+
+export type TreeNode = TreeFolder | TreeFile
+
+const props = defineProps<{
+  node: TreeNode
+  selectedNoteId: number | null
+  depth: number
+}>()
+
+defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'delete-note', noteId: number): void
+}>()
+
+const expanded = ref(true)
+
+function countNotes(node: TreeNode): number {
+  if (node.type === 'file') return 1
+  return node.children.reduce((sum, child) => sum + countNotes(child), 0)
+}
+
+const noteCount = computed(() => (props.node.type === 'folder' ? countNotes(props.node) : 0))
+</script>
+
+<style scoped>
+.folder-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-2) var(--space-2) 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  min-height: 32px;
+  text-align: left;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+}
+
+.folder-row:hover {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
+}
+
+.chevron {
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.folder-icon {
+  flex-shrink: 0;
+  color: var(--color-action);
+}
+
+.folder-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-count {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.05rem 0.375rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.note-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+  padding-right: var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+  color: var(--color-text-muted);
+}
+
+.note-item:hover {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
+}
+
+.note-item.active {
+  background: color-mix(in srgb, var(--color-action) 20%, transparent);
+  color: var(--color-action);
+  font-weight: 600;
+}
+
+.note-info {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.note-title {
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-path {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.btn-delete {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard),
+              opacity var(--duration-fast) var(--ease-standard);
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.note-item:hover .btn-delete {
+  opacity: 1;
+}
+
+.btn-delete:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -79,30 +79,17 @@
         <button class="btn-create-inline" @click="showNewNoteModal = true">Create a note</button>
       </div>
 
-      <ul v-else class="notes-list">
-        <li 
-          v-for="note in filteredAndSortedNotes" 
-          :key="note.id"
-          class="note-item"
-          :class="{ active: selectedNoteId === note.id }"
-          @click="$emit('select-note', note.id)"
-        >
-          <div class="note-info">
-            <span class="note-title">{{ note.title || note.path }}</span>
-            <span class="note-path">{{ note.path }}</span>
-          </div>
-          <button 
-            class="btn-delete" 
-            title="Delete note"
-            @click.stop="$emit('delete-note', note.id)"
-          >
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="3 6 5 6 21 6"></polyline>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-            </svg>
-          </button>
-        </li>
-      </ul>
+      <div v-else class="notes-list">
+        <NoteTreeNode
+          v-for="node in noteTree"
+          :key="node.type === 'folder' ? `f:${node.fullPath}` : `n:${node.note.id}`"
+          :node="node"
+          :selected-note-id="selectedNoteId"
+          :depth="0"
+          @select-note="$emit('select-note', $event)"
+          @delete-note="$emit('delete-note', $event)"
+        />
+      </div>
     </div>
 
     <!-- New Note Dialog -->
@@ -145,6 +132,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { NoteMeta, AuthUser } from '../services/types'
+import NoteTreeNode from './NoteTreeNode.vue'
+import type { TreeFolder, TreeNode } from './NoteTreeNode.vue'
 
 const props = defineProps<{
   notes: NoteMeta[]
@@ -210,6 +199,43 @@ const filteredAndSortedNotes = computed(() => {
     return a.path.localeCompare(b.path)
   })
 })
+
+function buildTree(notes: NoteMeta[]): TreeNode[] {
+  const root: TreeFolder = { type: 'folder', name: '', fullPath: '', children: [] }
+  const folders = new Map<string, TreeFolder>([['', root]])
+
+  function getFolder(path: string): TreeFolder {
+    const existing = folders.get(path)
+    if (existing) return existing
+    const lastSlash = path.lastIndexOf('/')
+    const parentPath = lastSlash === -1 ? '' : path.slice(0, lastSlash)
+    const name = lastSlash === -1 ? path : path.slice(lastSlash + 1)
+    const parent = getFolder(parentPath)
+    const folder: TreeFolder = { type: 'folder', name, fullPath: path, children: [] }
+    parent.children.push(folder)
+    folders.set(path, folder)
+    return folder
+  }
+
+  for (const note of notes) {
+    const lastSlash = note.path.lastIndexOf('/')
+    const folderPath = lastSlash === -1 ? '' : note.path.slice(0, lastSlash)
+    getFolder(folderPath).children.push({ type: 'file', note })
+  }
+
+  function sortChildren(folder: TreeFolder) {
+    const subfolders = folder.children.filter((c): c is TreeFolder => c.type === 'folder')
+    const files = folder.children.filter((c) => c.type === 'file')
+    subfolders.sort((a, b) => a.name.localeCompare(b.name))
+    subfolders.forEach(sortChildren)
+    folder.children = [...subfolders, ...files]
+  }
+  sortChildren(root)
+
+  return root.children
+}
+
+const noteTree = computed(() => buildTree(filteredAndSortedNotes.value))
 
 function onSearchInput() {
   emit('search', searchQuery.value)


### PR DESCRIPTION
## Summary
- Fixes #169. Sidebar notes list was a flat `<li>` list; notes with `/` in their path had no visual hierarchy.
- New `NoteTreeNode.vue` recursively groups notes by folder segment. Folders sort alphabetically before files, collapsible (default expanded), with a note-count badge.
- Leaf note rows keep the exact same markup/classes (`note-item`, `note-title`, `note-path`) as before, so `.notes-list` still contains the note's path text — `e2e/notes.spec.ts:61` keeps passing unchanged.

## Test plan
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 24/24 passing (incl. `a11y.spec.ts` Sidebar axe check)
- [x] Manual Playwright check against dev server: created `projects/alpha/notes.md`, `projects/beta.md`, `root-note.md`; confirmed nested tree renders (`projects` → `alpha` → `notes.md`, `beta.md` alongside), folder collapse hides children, root file stays visible.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
