### PR TITLE
Add attachment browser/delete UI (#168)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,6 +10,7 @@
       @delete-note="handleDeleteNote"
       @search="handleSearch"
       @logout="handleLogout"
+      @toggle-attachments="handleToggleAttachments"
     />
 
     <!-- Main Content Area -->
@@ -21,6 +22,14 @@
         :active-note-id="activeNoteId"
         @select-note="handleSelectNoteFromGraph"
         @close="isGraphViewActive = false"
+      />
+
+      <!-- Attachments View Mode -->
+      <AttachmentsPanel
+        v-else-if="isAttachmentsActive"
+        :attachments="attachments"
+        :loading="attachmentsLoading"
+        @delete-attachment="handleDeleteAttachment"
       />
 
       <!-- Search View Mode -->
@@ -96,6 +105,7 @@ import SearchResults from './components/SearchResults.vue'
 import LoginModal from './components/LoginModal.vue'
 import CommandPalette from './components/CommandPalette.vue'
 import GraphView from './components/GraphView.vue'
+import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import {
   getWorkspaces,
   getNotes,
@@ -106,9 +116,11 @@ import {
   searchNotes,
   getMe,
   logout,
-  setUnauthenticatedHandler
+  setUnauthenticatedHandler,
+  getAttachments,
+  deleteAttachment
 } from './services/api'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters } from './services/types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem } from './services/types'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -124,6 +136,10 @@ const isSearchActive = ref(false)
 const searchQuery = ref('')
 const searchResults = ref<SearchResult[]>([])
 const searchFilters = ref<SearchFilters>({})
+
+const isAttachmentsActive = ref(false)
+const attachments = ref<AttachmentItem[]>([])
+const attachmentsLoading = ref(false)
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -229,7 +245,40 @@ async function loadActiveNote(noteId: number) {
 
 async function handleSelectNote(noteId: number) {
   isSearchActive.value = false
+  isAttachmentsActive.value = false
   await loadActiveNote(noteId)
+}
+
+async function handleToggleAttachments() {
+  isAttachmentsActive.value = !isAttachmentsActive.value
+  if (isAttachmentsActive.value) {
+    isSearchActive.value = false
+    await refreshAttachments()
+  }
+}
+
+async function refreshAttachments() {
+  if (!activeWorkspaceId.value) return
+  attachmentsLoading.value = true
+  try {
+    attachments.value = await getAttachments(activeWorkspaceId.value)
+  } catch (err) {
+    console.error('Failed to load attachments:', err)
+  } finally {
+    attachmentsLoading.value = false
+  }
+}
+
+async function handleDeleteAttachment(attachment: AttachmentItem) {
+  if (!activeWorkspaceId.value) return
+  if (!confirm(`Delete "${attachment.path.split('/').pop()}"? This cannot be undone.`)) return
+  try {
+    await deleteAttachment(activeWorkspaceId.value, attachment.id)
+    attachments.value = attachments.value.filter(a => a.id !== attachment.id)
+  } catch (err) {
+    console.error('Failed to delete attachment:', err)
+    errorMessage.value = 'Failed to delete attachment.'
+  }
 }
 
 async function handleCreateNote(path: string) {
@@ -296,6 +345,7 @@ async function runSearch(query: string, filters: SearchFilters) {
 }
 
 async function handleSearch(query: string) {
+  isAttachmentsActive.value = false
   searchQuery.value = query
   await runSearch(query, searchFilters.value)
 }

--- a/frontend/src/AttachmentsPanel.spec.ts
+++ b/frontend/src/AttachmentsPanel.spec.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import AttachmentsPanel from './components/AttachmentsPanel.vue'
+
+const attachment = {
+  id: 1,
+  workspace_id: 1,
+  path: 'inbox/photo.png',
+  mime: 'image/png',
+  size: 2048,
+  created_at: '2026-07-01T00:00:00Z',
+  url: '/api/workspaces/1/attachments/inbox/photo.png'
+}
+
+describe('AttachmentsPanel', () => {
+  it('shows the empty state when there are no attachments', () => {
+    const wrapper = mount(AttachmentsPanel, { props: { attachments: [] } })
+    expect(wrapper.text()).toContain('No attachments yet.')
+  })
+
+  it('renders one card per attachment with filename and size', () => {
+    const wrapper = mount(AttachmentsPanel, { props: { attachments: [attachment] } })
+    expect(wrapper.text()).toContain('photo.png')
+    expect(wrapper.text()).toContain('2.0 KB')
+  })
+
+  it('emits delete-attachment with the full attachment on delete click', async () => {
+    const wrapper = mount(AttachmentsPanel, { props: { attachments: [attachment] } })
+    await wrapper.get('[data-testid="attachment-delete-btn"]').trigger('click')
+
+    const events = wrapper.emitted('delete-attachment')
+    expect(events).toBeTruthy()
+    expect(events![0][0]).toEqual(attachment)
+  })
+
+  it('shows a loading state', () => {
+    const wrapper = mount(AttachmentsPanel, { props: { attachments: [], loading: true } })
+    expect(wrapper.text()).toContain('Loading attachments')
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -7,6 +7,7 @@ import CommandPalette from './components/CommandPalette.vue'
 import SearchResults from './components/SearchResults.vue'
 import BacklinksPanel from './components/BacklinksPanel.vue'
 import MarkdownPreview from './components/MarkdownPreview.vue'
+import AttachmentsPanel from './components/AttachmentsPanel.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -106,6 +107,26 @@ describe('Accessibility Audit (axe-core)', () => {
     const wrapper = mount(MarkdownPreview, {
       attachTo: document.body,
       props: { content: '# Hello World\n\nThis is a test note.' },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('AttachmentsPanel has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(AttachmentsPanel, {
+      attachTo: document.body,
+      props: {
+        attachments: [
+          { id: 1, workspace_id: 1, path: 'inbox/photo.png', mime: 'image/png', size: 2048, created_at: '2026-07-01T00:00:00Z', url: '/api/workspaces/1/attachments/inbox/photo.png' },
+          { id: 2, workspace_id: 1, path: 'inbox/report.pdf', mime: 'application/pdf', size: 40960, created_at: '2026-07-02T00:00:00Z', url: '/api/workspaces/1/attachments/inbox/report.pdf' },
+        ],
+      },
     })
     const results = await axe.run(wrapper.element, {
       rules: {

--- a/frontend/src/components/AttachmentsPanel.vue
+++ b/frontend/src/components/AttachmentsPanel.vue
@@ -1,0 +1,213 @@
+<template>
+  <div class="attachments-panel">
+    <div class="panel-header">
+      <h2>Attachments</h2>
+      <span class="attachment-count">{{ attachments.length }}</span>
+    </div>
+
+    <div v-if="loading" class="panel-empty">
+      <p>Loading attachments…</p>
+    </div>
+
+    <div v-else-if="attachments.length === 0" class="panel-empty">
+      <p>No attachments yet.</p>
+      <p class="panel-empty-hint">Drag a file onto a note's editor to upload one.</p>
+    </div>
+
+    <ul v-else class="attachment-grid">
+      <li v-for="attachment in attachments" :key="attachment.id" class="attachment-card">
+        <a
+          :href="attachment.url"
+          target="_blank"
+          rel="noopener"
+          class="attachment-preview-link"
+          :aria-label="`Open ${filename(attachment.path)}`"
+        >
+          <img
+            v-if="attachment.mime.startsWith('image/')"
+            :src="attachment.url"
+            :alt="filename(attachment.path)"
+            class="attachment-thumb"
+          />
+          <div v-else class="attachment-icon">
+            <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+            </svg>
+          </div>
+        </a>
+        <div class="attachment-meta">
+          <span class="attachment-name" :title="attachment.path">{{ filename(attachment.path) }}</span>
+          <span class="attachment-sub">{{ formatSize(attachment.size) }} &middot; {{ formatDate(attachment.created_at) }}</span>
+        </div>
+        <button
+          class="btn-delete-attachment"
+          data-testid="attachment-delete-btn"
+          title="Delete attachment"
+          :aria-label="`Delete ${filename(attachment.path)}`"
+          @click="$emit('delete-attachment', attachment)"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AttachmentItem } from '../services/types'
+
+defineProps<{
+  attachments: AttachmentItem[]
+  loading?: boolean
+}>()
+
+defineEmits<{
+  (e: 'delete-attachment', attachment: AttachmentItem): void
+}>()
+
+function filename(path: string): string {
+  return path.split('/').pop() || path
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+</script>
+
+<style scoped>
+.attachments-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.panel-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.attachment-count {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.panel-empty {
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
+}
+
+.panel-empty-hint {
+  font-size: 0.875rem;
+  margin-top: var(--space-2);
+}
+
+.attachment-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: var(--space-4);
+}
+
+.attachment-card {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.attachment-card:hover {
+  border-color: var(--color-border-strong);
+}
+
+.attachment-preview-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 110px;
+  background: var(--color-canvas);
+}
+
+.attachment-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.attachment-icon {
+  color: var(--color-text-muted);
+}
+
+.attachment-meta {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) var(--space-3);
+  gap: 0.1rem;
+}
+
+.attachment-name {
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.attachment-sub {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+.btn-delete-attachment {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-delete-attachment:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 15%, transparent);
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -12,12 +12,19 @@
         </svg>
         <span class="brand-title">Jotter</span>
       </div>
-      <button class="btn-icon" data-testid="new-note-btn" title="New Note" @click="showNewNoteModal = true">
-        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-          <line x1="12" y1="5" x2="12" y2="19"></line>
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg>
-      </button>
+      <div class="header-actions">
+        <button class="btn-icon" data-testid="attachments-btn" title="Attachments" @click="$emit('toggle-attachments')">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
+          </svg>
+        </button>
+        <button class="btn-icon" data-testid="new-note-btn" title="New Note" @click="showNewNoteModal = true">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
+      </div>
     </div>
 
     <!-- Search Input -->
@@ -147,6 +154,7 @@ const emit = defineEmits<{
   (e: 'delete-note', noteId: number): void
   (e: 'search', query: string): void
   (e: 'logout'): void
+  (e: 'toggle-attachments'): void
 }>()
 
 const searchQuery = ref('')
@@ -285,6 +293,12 @@ function handleCreateNote() {
 
 .brand-icon {
   color: var(--color-action);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .btn-icon {


### PR DESCRIPTION
## Summary
- Fixes #168. `getAttachments()`/`deleteAttachment()` were already defined in `api.ts` and fully supported server-side, but nothing in the SPA called either — `NoteEditor.vue`'s drag-drop upload was the only attachment entry point in the UI.
- New `AttachmentsPanel.vue`: workspace-level grid view (image thumbnails, generic file icon otherwise, filename/size/date, open-in-new-tab, delete-with-confirm).
- New `attachments-btn` toggle in the sidebar header opens it as a fourth main-content view mode (alongside notes/search/graph), following the existing `isSearchActive`/`isGraphViewActive` pattern in `App.vue`.

## Test plan
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 29/29 passing (new `AttachmentsPanel.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: simulated a real drag-drop upload into `NoteEditor.vue`'s drop overlay, opened the attachments panel, confirmed the file listed with correct name/size, deleted it, confirmed the panel returns to the empty state.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
