### PR TITLE
Add typed properties UI and fix value serialization bug (#160)

### DIFF
--- a/app/Models/NoteProperty.php
+++ b/app/Models/NoteProperty.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Domain\Vault\NotePropertyType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,6 +24,7 @@ final class NoteProperty extends Model
     ];
 
     protected $casts = [
+        'type' => NotePropertyType::class,
         'value_numeric' => 'float',
         'value_boolean' => 'boolean',
         'value_datetime' => 'datetime',

--- a/frontend/src/PropertiesPanel.spec.ts
+++ b/frontend/src/PropertiesPanel.spec.ts
@@ -1,0 +1,57 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import PropertiesPanel from './components/PropertiesPanel.vue'
+
+describe('PropertiesPanel', () => {
+  it('shows the empty state when there are no properties', () => {
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+    expect(wrapper.text()).toContain('No typed properties on this note yet.')
+  })
+
+  it('renders one row per property with name, type, and value', () => {
+    const wrapper = mount(PropertiesPanel, {
+      props: { properties: [{ name: 'status', type: 'string', value: 'draft' }] }
+    })
+    const text = wrapper.text()
+    expect(text).toContain('status')
+    expect(text).toContain('string')
+    expect(text).toContain('draft')
+  })
+
+  it('joins list values with commas', () => {
+    const wrapper = mount(PropertiesPanel, {
+      props: { properties: [{ name: 'tags', type: 'list', value: ['a', 'b', 'c'] }] }
+    })
+    expect(wrapper.text()).toContain('a, b, c')
+  })
+
+  it('emits delete-property with the property name', async () => {
+    const wrapper = mount(PropertiesPanel, {
+      props: { properties: [{ name: 'status', type: 'string', value: 'draft' }] }
+    })
+    await wrapper.get('[data-testid="property-delete-btn"]').trigger('click')
+    expect(wrapper.emitted('delete-property')![0]).toEqual(['status'])
+  })
+
+  it('emits add-property with a numeric value coerced to a number', async () => {
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+
+    await wrapper.get('[data-testid="property-name-input"]').setValue('priority')
+    await wrapper.get('[data-testid="property-type-select"]').setValue('numeric')
+    await wrapper.get('[data-testid="property-value-input"]').setValue('5')
+    await wrapper.get('.property-form').trigger('submit')
+
+    expect(wrapper.emitted('add-property')![0]).toEqual(['priority', 5])
+  })
+
+  it('emits add-property with a list value split on commas', async () => {
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+
+    await wrapper.get('[data-testid="property-name-input"]').setValue('tags')
+    await wrapper.get('[data-testid="property-type-select"]').setValue('list')
+    await wrapper.get('[data-testid="property-value-input"]').setValue('a, b , c')
+    await wrapper.get('.property-form').trigger('submit')
+
+    expect(wrapper.emitted('add-property')![0]).toEqual(['tags', ['a', 'b', 'c']])
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -9,6 +9,7 @@ import BacklinksPanel from './components/BacklinksPanel.vue'
 import MarkdownPreview from './components/MarkdownPreview.vue'
 import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
+import PropertiesPanel from './components/PropertiesPanel.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -149,6 +150,26 @@ describe('Accessibility Audit (axe-core)', () => {
         ],
         selectedRevisionId: 2,
         previewContent: '# Old content',
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('PropertiesPanel has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(PropertiesPanel, {
+      attachTo: document.body,
+      props: {
+        properties: [
+          { name: 'status', type: 'string', value: 'draft' },
+          { name: 'priority', type: 'numeric', value: 3 },
+        ],
       },
     })
     const results = await axe.run(wrapper.element, {

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -158,6 +158,13 @@
       </div>
     </footer>
 
+    <!-- Properties Panel -->
+    <PropertiesPanel
+      :properties="note.properties || []"
+      @add-property="handleAddProperty"
+      @delete-property="handleDeleteProperty"
+    />
+
     <!-- Backlinks Panel -->
     <BacklinksPanel
       :backlinks="note.backlinks || []"
@@ -182,10 +189,11 @@
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from 'vue'
 import type { NoteDetail, NoteMeta, NoteRevisionMeta } from '../services/types'
-import { uploadAttachment, getNoteRevisions, getNoteRevision, restoreNoteRevision } from '../services/api'
+import { uploadAttachment, getNoteRevisions, getNoteRevision, restoreNoteRevision, setNoteProperty, deleteNoteProperty } from '../services/api'
 import MarkdownPreview from './MarkdownPreview.vue'
 import BacklinksPanel from './BacklinksPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
+import PropertiesPanel from './PropertiesPanel.vue'
 
 const props = defineProps<{
   note: NoteDetail
@@ -433,6 +441,26 @@ async function handleRestoreRevision(revisionId: number) {
     emit('select-note', props.note.id)
   } catch (err) {
     console.error('Failed to restore revision:', err)
+  }
+}
+
+async function handleAddProperty(name: string, value: unknown) {
+  if (!props.workspaceId) return
+  try {
+    await setNoteProperty(props.workspaceId, props.note.id, name, value)
+    emit('select-note', props.note.id)
+  } catch (err) {
+    console.error('Failed to set property:', err)
+  }
+}
+
+async function handleDeleteProperty(name: string) {
+  if (!props.workspaceId) return
+  try {
+    await deleteNoteProperty(props.workspaceId, props.note.id, name)
+    emit('select-note', props.note.id)
+  } catch (err) {
+    console.error('Failed to delete property:', err)
   }
 }
 

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,0 +1,292 @@
+<template>
+  <aside class="properties-panel" aria-label="Properties">
+    <div class="properties-header">
+      <div class="header-title">
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <path d="M3 6h18M7 12h10M11 18h2"></path>
+        </svg>
+        <span>Properties</span>
+      </div>
+      <span class="count-badge">{{ properties.length }}</span>
+    </div>
+
+    <div v-if="properties.length === 0" class="properties-empty">
+      <p>No typed properties on this note yet.</p>
+    </div>
+
+    <ul v-else class="properties-list">
+      <li v-for="prop in properties" :key="prop.name" class="property-item" data-testid="property-item">
+        <div class="property-info">
+          <span class="property-name">{{ prop.name }}</span>
+          <span class="property-type">{{ prop.type }}</span>
+          <span class="property-value">{{ formatValue(prop) }}</span>
+        </div>
+        <button
+          class="btn-delete-property"
+          data-testid="property-delete-btn"
+          :aria-label="`Delete property ${prop.name}`"
+          title="Delete property"
+          @click="$emit('delete-property', prop.name)"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+      </li>
+    </ul>
+
+    <form class="property-form" @submit.prevent="handleSubmit">
+      <input
+        v-model="newName"
+        type="text"
+        placeholder="Property name"
+        aria-label="New property name"
+        data-testid="property-name-input"
+        class="property-form-input"
+        required
+      />
+      <select v-model="newType" aria-label="New property type" data-testid="property-type-select" class="property-form-select">
+        <option value="string">Text</option>
+        <option value="numeric">Number</option>
+        <option value="boolean">Checkbox</option>
+        <option value="datetime">Date/time</option>
+        <option value="list">List (comma-separated)</option>
+      </select>
+
+      <input
+        v-if="newType === 'string' || newType === 'list'"
+        v-model="newValueText"
+        type="text"
+        placeholder="Value"
+        aria-label="New property value"
+        data-testid="property-value-input"
+        class="property-form-input"
+      />
+      <input
+        v-else-if="newType === 'numeric'"
+        v-model="newValueText"
+        type="number"
+        placeholder="Value"
+        aria-label="New property value"
+        data-testid="property-value-input"
+        class="property-form-input"
+      />
+      <input
+        v-else-if="newType === 'datetime'"
+        v-model="newValueText"
+        type="datetime-local"
+        aria-label="New property value"
+        data-testid="property-value-input"
+        class="property-form-input"
+      />
+      <label v-else-if="newType === 'boolean'" class="property-checkbox-label">
+        <input v-model="newValueBool" type="checkbox" aria-label="New property value" data-testid="property-value-input" />
+        <span>{{ newValueBool ? 'True' : 'False' }}</span>
+      </label>
+
+      <button type="submit" class="btn-add-property" data-testid="property-add-btn">Add</button>
+    </form>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { NoteProperty, NotePropertyType } from '../services/types'
+
+defineProps<{
+  properties: NoteProperty[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'add-property', name: string, value: unknown): void
+  (e: 'delete-property', name: string): void
+}>()
+
+const newName = ref('')
+const newType = ref<NotePropertyType>('string')
+const newValueText = ref('')
+const newValueBool = ref(false)
+
+function formatValue(prop: NoteProperty): string {
+  if (prop.value === null || prop.value === undefined) return '—'
+  if (Array.isArray(prop.value)) return prop.value.join(', ')
+  if (typeof prop.value === 'object') return JSON.stringify(prop.value)
+  return String(prop.value)
+}
+
+function handleSubmit() {
+  const name = newName.value.trim()
+  if (!name) return
+
+  let value: unknown
+  switch (newType.value) {
+    case 'numeric':
+      value = Number(newValueText.value)
+      break
+    case 'boolean':
+      value = newValueBool.value
+      break
+    case 'list':
+      value = newValueText.value.split(',').map(s => s.trim()).filter(Boolean)
+      break
+    default:
+      value = newValueText.value
+  }
+
+  emit('add-property', name, value)
+  newName.value = ''
+  newValueText.value = ''
+  newValueBool.value = false
+  newType.value = 'string'
+}
+</script>
+
+<style scoped>
+.properties-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.properties-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-action);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+}
+
+.properties-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.properties-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.property-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+}
+
+.property-info {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  overflow: hidden;
+}
+
+.property-name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.property-type {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  background: var(--color-canvas);
+  border-radius: var(--radius-sm);
+  padding: 0 0.375rem;
+}
+
+.property-value {
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.btn-delete-property {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-delete-property:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
+}
+
+.property-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.property-form-input,
+.property-form-select {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.property-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 0.8125rem;
+}
+
+.btn-add-property {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-add-property:hover {
+  background: var(--color-action-hover);
+}
+</style>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -121,6 +121,31 @@ export async function getNoteRevision(workspaceId: number, noteId: number, revis
 
 export async function restoreNoteRevision(workspaceId: number, noteId: number, revisionId: number): Promise<void> {
   await api.post(`/workspaces/${workspaceId}/notes/${noteId}/revisions/${revisionId}/restore`)
+}
+
+export async function setNoteProperty(
+  workspaceId: number,
+  noteId: number,
+  name: string,
+  value: unknown
+): Promise<NoteDetail> {
+  const response = await api.post<{ data: NoteDetail }>(
+    `/workspaces/${workspaceId}/notes/${noteId}/properties`,
+    { name, value }
+  )
+  return response.data.data
+}
+
+export async function deleteNoteProperty(workspaceId: number, noteId: number, name: string): Promise<NoteDetail> {
+  const response = await api.delete<{ data: NoteDetail }>(
+    `/workspaces/${workspaceId}/notes/${noteId}/properties/${encodeURIComponent(name)}`
+  )
+  return response.data.data
+}
+
+export async function getWorkspaceProperties(workspaceId: number): Promise<Pick<NoteProperty, 'name' | 'type'>[]> {
+  const response = await api.get<{ data: Pick<NoteProperty, 'name' | 'type'>[] }>(`/workspaces/${workspaceId}/properties`)
+  return response.data.data
 }
 
 export async function getAttachments(workspaceId: number): Promise<AttachmentItem[]> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -20,9 +20,18 @@ export interface Backlink {
   target_ref?: string
 }
 
+export type NotePropertyType = 'string' | 'numeric' | 'boolean' | 'datetime' | 'list' | 'json'
+
+export interface NoteProperty {
+  name: string
+  type: NotePropertyType
+  value: string | number | boolean | string[] | Record<string, unknown> | null
+}
+
 export interface NoteDetail extends NoteMeta {
   content: string
   backlinks: Backlink[]
+  properties?: NoteProperty[]
 }
 
 export interface SearchResult {

--- a/tests/Feature/NotePropertiesApiTest.php
+++ b/tests/Feature/NotePropertiesApiTest.php
@@ -54,6 +54,20 @@ class NotePropertiesApiTest extends TestCase
         ]);
         $setRes2->assertOk();
 
+        // Regression: the API response must return typed values, not just typed labels.
+        // NoteProperty::type was never cast to the NotePropertyType enum, so the
+        // match($p->type) in metadata() always fell through to the default
+        // (value_string) branch — numeric/boolean/datetime/list/json values were
+        // silently dropped from every API response despite being stored correctly.
+        $properties = collect($setRes2->json('data.properties'))->keyBy('name');
+        $this->assertSame('active', $properties->get('status')['value']);
+        $this->assertEquals(5.0, $properties->get('priority')['value']);
+
+        $showRes = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$noteId}");
+        $showProperties = collect($showRes->json('data.properties'))->keyBy('name');
+        $this->assertSame('active', $showProperties->get('status')['value']);
+        $this->assertEquals(5.0, $showProperties->get('priority')['value']);
+
         // 4. Test workspace distinct properties endpoint
         $propListRes = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/properties");
         $propListRes->assertOk()->assertJsonCount(2, 'data');


### PR DESCRIPTION
## Summary
- Fixes #160. `getWorkspaceProperties()`, note-scoped `setProperty`/`deleteProperty` endpoints, and the whole `note_properties` typed projection existed server-side with no SPA UI.
- New `PropertiesPanel.vue` embedded in `NoteEditor.vue` (next to Backlinks): lists existing properties (name/type/value), a delete button per row, and an add form with a type selector (string/numeric/boolean/datetime/list) that shapes the submitted value so the backend's type inference lands correctly.

**Also fixes a real backend bug found while verifying this in a browser** (not just this PR's own code): `NoteProperty::type` was never cast to the `NotePropertyType` enum in `app/Models/NoteProperty.php`. Both controllers' `metadata()` do `match ($p->type) { NotePropertyType::NUMERIC => ..., ... default => $p->value_string }` — since `$p->type` was a raw string, the enum-case arms never matched and every non-string property (numeric/boolean/datetime/list/json) silently returned `null` from every API response, despite being stored correctly in the DB. Fixed with a model-level enum cast (one line). Added a regression test in `NotePropertiesApiTest.php` that asserts the actual response value, not just its type label — confirmed it fails with `null` on the pre-fix code via `git stash`, passes after.

## Test plan
- [x] `./scripts/jt.sh artisan test` — 105 passed (full backend suite, incl. new regression assertions)
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 43/43 passing (new `PropertiesPanel.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: added a string, numeric, and list property to a note, confirmed all three display their correct typed values (not just the string one — this is what the backend bug would have hidden), confirmed the frontmatter written to disk, deleted one and confirmed the list updates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
