### PR TITLE
Add comments UI (#158) — completes Tier 2

### DIFF
--- a/frontend/src/CommentsPanel.spec.ts
+++ b/frontend/src/CommentsPanel.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CommentsPanel from './components/CommentsPanel.vue'
+
+const comment = {
+  id: 1,
+  workspace_id: 1,
+  note_id: 1,
+  user_id: 1,
+  actor_name: 'Alex',
+  content: 'Looks good',
+  anchor_line: null,
+  created_at: '2026-07-01T00:00:00Z'
+}
+
+describe('CommentsPanel', () => {
+  it('shows the empty state when there are no comments', () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    expect(wrapper.text()).toContain('No comments on this note yet.')
+  })
+
+  it('renders one entry per comment with author and content', () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [comment] } })
+    expect(wrapper.text()).toContain('Alex')
+    expect(wrapper.text()).toContain('Looks good')
+  })
+
+  it('shows the anchor line when set', () => {
+    const wrapper = mount(CommentsPanel, {
+      props: { comments: [{ ...comment, anchor_line: 12 }] }
+    })
+    expect(wrapper.text()).toContain('line 12')
+  })
+
+  it('emits add-comment with the trimmed content and clears the input', async () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    const textarea = wrapper.get('[data-testid="comment-input"]')
+    await textarea.setValue('  nice work  ')
+    await wrapper.get('.comment-form').trigger('submit')
+
+    expect(wrapper.emitted('add-comment')![0]).toEqual(['nice work'])
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('does not emit add-comment for a blank comment', async () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    await wrapper.get('.comment-form').trigger('submit')
+    expect(wrapper.emitted('add-comment')).toBeFalsy()
+  })
+
+  it('emits delete-comment with the comment id', async () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [comment] } })
+    await wrapper.get('[data-testid="comment-delete-btn"]').trigger('click')
+    expect(wrapper.emitted('delete-comment')![0]).toEqual([1])
+  })
+
+  it('shows an error message when provided', () => {
+    const wrapper = mount(CommentsPanel, {
+      props: { comments: [], errorMessage: 'You can only delete your own comments.' }
+    })
+    expect(wrapper.text()).toContain('You can only delete your own comments.')
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -10,6 +10,7 @@ import MarkdownPreview from './components/MarkdownPreview.vue'
 import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
 import PropertiesPanel from './components/PropertiesPanel.vue'
+import CommentsPanel from './components/CommentsPanel.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -169,6 +170,25 @@ describe('Accessibility Audit (axe-core)', () => {
         properties: [
           { name: 'status', type: 'string', value: 'draft' },
           { name: 'priority', type: 'numeric', value: 3 },
+        ],
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('CommentsPanel has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(CommentsPanel, {
+      attachTo: document.body,
+      props: {
+        comments: [
+          { id: 1, workspace_id: 1, note_id: 1, user_id: 1, actor_name: 'Alex', content: 'Looks good', anchor_line: null, created_at: '2026-07-01T00:00:00Z' },
         ],
       },
     })

--- a/frontend/src/components/CommentsPanel.vue
+++ b/frontend/src/components/CommentsPanel.vue
@@ -1,0 +1,249 @@
+<template>
+  <aside class="comments-panel" aria-label="Comments">
+    <div class="comments-header">
+      <div class="header-title">
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+        </svg>
+        <span>Comments</span>
+      </div>
+      <span class="count-badge">{{ comments.length }}</span>
+    </div>
+
+    <p v-if="errorMessage" class="comments-error" role="alert">{{ errorMessage }}</p>
+
+    <div v-if="comments.length === 0" class="comments-empty">
+      <p>No comments on this note yet.</p>
+    </div>
+
+    <ul v-else class="comments-list">
+      <li v-for="comment in comments" :key="comment.id" class="comment-item" data-testid="comment-item">
+        <div class="comment-meta">
+          <span class="comment-author">{{ comment.actor_name }}</span>
+          <span v-if="comment.anchor_line" class="comment-anchor">line {{ comment.anchor_line }}</span>
+          <span class="comment-date">{{ formatDate(comment.created_at) }}</span>
+        </div>
+        <p class="comment-content">{{ comment.content }}</p>
+        <button
+          class="btn-delete-comment"
+          data-testid="comment-delete-btn"
+          :aria-label="`Delete comment by ${comment.actor_name}`"
+          title="Delete comment"
+          @click="$emit('delete-comment', comment.id)"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+      </li>
+    </ul>
+
+    <form class="comment-form" @submit.prevent="handleSubmit">
+      <textarea
+        v-model="newContent"
+        placeholder="Write a comment... use @name to mention someone"
+        aria-label="New comment"
+        data-testid="comment-input"
+        class="comment-form-textarea"
+        rows="2"
+      ></textarea>
+      <button type="submit" class="btn-add-comment" data-testid="comment-submit-btn" :disabled="!newContent.trim()">
+        Comment
+      </button>
+    </form>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { NoteComment } from '../services/types'
+
+defineProps<{
+  comments: NoteComment[]
+  errorMessage?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'add-comment', content: string): void
+  (e: 'delete-comment', commentId: number): void
+}>()
+
+const newContent = ref('')
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+    })
+  } catch {
+    return iso
+  }
+}
+
+function handleSubmit() {
+  const content = newContent.value.trim()
+  if (!content) return
+  emit('add-comment', content)
+  newContent.value = ''
+}
+</script>
+
+<style scoped>
+.comments-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.comments-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-action);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+}
+
+.comments-error {
+  color: var(--color-status-danger);
+  font-size: 0.8125rem;
+  margin-bottom: var(--space-2);
+}
+
+.comments-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.comments-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.comment-item {
+  position: relative;
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  padding-right: var(--space-8);
+}
+
+.comment-meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: 0.2rem;
+}
+
+.comment-author {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.comment-anchor {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  background: var(--color-canvas);
+  border-radius: var(--radius-sm);
+  padding: 0 0.375rem;
+}
+
+.comment-date {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+.comment-content {
+  color: var(--color-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.btn-delete-comment {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-delete-comment:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.comment-form-textarea {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.btn-add-comment {
+  align-self: flex-end;
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-add-comment:hover:not(:disabled) {
+  background: var(--color-action-hover);
+}
+
+.btn-add-comment:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -165,6 +165,14 @@
       @delete-property="handleDeleteProperty"
     />
 
+    <!-- Comments Panel -->
+    <CommentsPanel
+      :comments="comments"
+      :error-message="commentsError"
+      @add-comment="handleAddComment"
+      @delete-comment="handleDeleteComment"
+    />
+
     <!-- Backlinks Panel -->
     <BacklinksPanel
       :backlinks="note.backlinks || []"
@@ -188,12 +196,18 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from 'vue'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta } from '../services/types'
-import { uploadAttachment, getNoteRevisions, getNoteRevision, restoreNoteRevision, setNoteProperty, deleteNoteProperty } from '../services/api'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment } from '../services/types'
+import {
+  uploadAttachment,
+  getNoteRevisions, getNoteRevision, restoreNoteRevision,
+  setNoteProperty, deleteNoteProperty,
+  getNoteComments, addNoteComment, deleteNoteComment
+} from '../services/api'
 import MarkdownPreview from './MarkdownPreview.vue'
 import BacklinksPanel from './BacklinksPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import PropertiesPanel from './PropertiesPanel.vue'
+import CommentsPanel from './CommentsPanel.vue'
 
 const props = defineProps<{
   note: NoteDetail
@@ -222,6 +236,9 @@ const revisionsLoading = ref(false)
 const selectedRevisionId = ref<number | null>(null)
 const revisionPreviewContent = ref<string | null>(null)
 const revisionPreviewLoading = ref(false)
+
+const comments = ref<NoteComment[]>([])
+const commentsError = ref<string | null>(null)
 
 // Live Statistics
 const charCount = computed(() => editableContent.value.length)
@@ -276,7 +293,42 @@ watch(() => props.note, (newNote) => {
   isDirty.value = false
   showAutocomplete.value = false
   showHistory.value = false
+  loadComments(newNote.id)
 }, { immediate: true })
+
+async function loadComments(noteId: number) {
+  commentsError.value = null
+  if (!props.workspaceId) return
+  try {
+    comments.value = await getNoteComments(props.workspaceId, noteId)
+  } catch (err) {
+    console.error('Failed to load comments:', err)
+  }
+}
+
+async function handleAddComment(content: string) {
+  if (!props.workspaceId) return
+  commentsError.value = null
+  try {
+    const comment = await addNoteComment(props.workspaceId, props.note.id, content)
+    comments.value.push(comment)
+  } catch (err: any) {
+    console.error('Failed to add comment:', err)
+    commentsError.value = err.response?.data?.message || 'Failed to add comment.'
+  }
+}
+
+async function handleDeleteComment(commentId: number) {
+  if (!props.workspaceId) return
+  commentsError.value = null
+  try {
+    await deleteNoteComment(props.workspaceId, props.note.id, commentId)
+    comments.value = comments.value.filter(c => c.id !== commentId)
+  } catch (err: any) {
+    console.error('Failed to delete comment:', err)
+    commentsError.value = err.response?.data?.message || 'You can only delete your own comments.'
+  }
+}
 
 watch(editableContent, (newVal) => {
   if (newVal !== props.note.content) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -168,6 +168,28 @@ export async function getOrCreateDailyNote(workspaceId: number, dateStr?: string
     : `/workspaces/${workspaceId}/daily`
   const response = await api.post<{ data: { id: number } }>(url)
   return response.data.data
+}
+
+export async function getNoteComments(workspaceId: number, noteId: number): Promise<NoteComment[]> {
+  const response = await api.get<{ data: NoteComment[] }>(`/workspaces/${workspaceId}/notes/${noteId}/comments`)
+  return response.data.data
+}
+
+export async function addNoteComment(
+  workspaceId: number,
+  noteId: number,
+  content: string,
+  anchorLine?: number
+): Promise<NoteComment> {
+  const response = await api.post<{ data: NoteComment }>(`/workspaces/${workspaceId}/notes/${noteId}/comments`, {
+    content,
+    anchor_line: anchorLine ?? undefined
+  })
+  return response.data.data
+}
+
+export async function deleteNoteComment(workspaceId: number, noteId: number, commentId: number): Promise<void> {
+  await api.delete(`/workspaces/${workspaceId}/notes/${noteId}/comments/${commentId}`)
 }
 
 export async function getAttachments(workspaceId: number): Promise<AttachmentItem[]> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -69,6 +69,17 @@ export interface NoteRevisionDetail extends NoteRevisionMeta {
   content: string
 }
 
+export interface NoteComment {
+  id: number
+  workspace_id: number
+  note_id: number
+  user_id: number | null
+  actor_name: string
+  content: string
+  anchor_line: number | null
+  created_at: string
+}
+
 export interface AttachmentItem {
   id: number
   workspace_id: number


### PR DESCRIPTION
## Summary
- Fixes #158, the last Tier 2 UI-audit item. `WorkspaceCommentController` (list/add/delete with `@mention` parsing and ownership-or-admin delete authorization, hardened back in #145) had no SPA UI.
- New `CommentsPanel.vue` embedded in `NoteEditor.vue` (between Properties and Backlinks): lists comments (author, timestamp, optional anchor line, content), an add form, and a delete button per comment. A failed delete (e.g. non-owner without admin) surfaces as an inline error message instead of failing silently.

## Test plan
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 51/51 passing (new `CommentsPanel.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: added two comments (one with an `@mention`) to a note, confirmed both display correctly, deleted one, confirmed the panel reflects the remaining one.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
