### PR TITLE
Add audit log viewer UI and fix query excluding workspace-scoped events (#166)

### DIFF
--- a/app/Http/Controllers/AuditLogQueryController.php
+++ b/app/Http/Controllers/AuditLogQueryController.php
@@ -31,10 +31,16 @@ final class AuditLogQueryController extends Controller
         }
 
         $logs = AuditLog::query()
-            ->where('tenant_id', $workspace->tenant_id)
-            ->where(function ($q) use ($workspaceId) {
+            ->where(function ($q) use ($workspaceId, $workspace) {
+                // Workspace-scoped events: workspace_id alone already
+                // unambiguously identifies the tenant, so it's sufficient on
+                // its own — requiring a separately-populated tenant_id too
+                // silently hid every event whose recorder call omitted it
+                // (e.g. WorkspaceEventEmitter::emitMention()).
                 $q->where('workspace_id', $workspaceId)
-                    ->orWhereNull('workspace_id');
+                    ->orWhere(function ($q2) use ($workspace) {
+                        $q2->whereNull('workspace_id')->where('tenant_id', $workspace->tenant_id);
+                    });
             })
             ->latest('id')
             ->limit(50)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@
       @logout="handleLogout"
       @toggle-attachments="handleToggleAttachments"
       @daily-note="handleDailyNote"
+      @toggle-audit-log="handleToggleAuditLog"
     />
 
     <!-- Main Content Area -->
@@ -32,6 +33,13 @@
         :attachments="attachments"
         :loading="attachmentsLoading"
         @delete-attachment="handleDeleteAttachment"
+      />
+
+      <!-- Audit Log View Mode -->
+      <AuditLogViewer
+        v-else-if="isAuditLogActive"
+        :entries="auditLogEntries"
+        :loading="auditLogLoading"
       />
 
       <!-- Search View Mode -->
@@ -108,6 +116,7 @@ import LoginModal from './components/LoginModal.vue'
 import CommandPalette from './components/CommandPalette.vue'
 import GraphView from './components/GraphView.vue'
 import AttachmentsPanel from './components/AttachmentsPanel.vue'
+import AuditLogViewer from './components/AuditLogViewer.vue'
 import {
   getWorkspaces,
   getNotes,
@@ -122,9 +131,10 @@ import {
   getAttachments,
   deleteAttachment,
   createNoteFromTemplate,
-  getOrCreateDailyNote
+  getOrCreateDailyNote,
+  getAuditLogs
 } from './services/api'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem } from './services/types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry } from './services/types'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -144,6 +154,10 @@ const searchFilters = ref<SearchFilters>({})
 const isAttachmentsActive = ref(false)
 const attachments = ref<AttachmentItem[]>([])
 const attachmentsLoading = ref(false)
+
+const isAuditLogActive = ref(false)
+const auditLogEntries = ref<AuditLogEntry[]>([])
+const auditLogLoading = ref(false)
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -250,6 +264,7 @@ async function loadActiveNote(noteId: number) {
 async function handleSelectNote(noteId: number) {
   isSearchActive.value = false
   isAttachmentsActive.value = false
+  isAuditLogActive.value = false
   await loadActiveNote(noteId)
 }
 
@@ -257,7 +272,29 @@ async function handleToggleAttachments() {
   isAttachmentsActive.value = !isAttachmentsActive.value
   if (isAttachmentsActive.value) {
     isSearchActive.value = false
+    isAuditLogActive.value = false
     await refreshAttachments()
+  }
+}
+
+async function handleToggleAuditLog() {
+  isAuditLogActive.value = !isAuditLogActive.value
+  if (isAuditLogActive.value) {
+    isSearchActive.value = false
+    isAttachmentsActive.value = false
+    await refreshAuditLog()
+  }
+}
+
+async function refreshAuditLog() {
+  if (!activeWorkspaceId.value) return
+  auditLogLoading.value = true
+  try {
+    auditLogEntries.value = await getAuditLogs(activeWorkspaceId.value)
+  } catch (err) {
+    console.error('Failed to load audit log:', err)
+  } finally {
+    auditLogLoading.value = false
   }
 }
 
@@ -374,6 +411,7 @@ async function runSearch(query: string, filters: SearchFilters) {
 
 async function handleSearch(query: string) {
   isAttachmentsActive.value = false
+  isAuditLogActive.value = false
   searchQuery.value = query
   await runSearch(query, searchFilters.value)
 }

--- a/frontend/src/AuditLogViewer.spec.ts
+++ b/frontend/src/AuditLogViewer.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import AuditLogViewer from './components/AuditLogViewer.vue'
+
+const entries = [
+  { id: 1, actor_subject_id: 'user:1', event: 'note.created', metadata: { path: 'a.md' }, ip_address: '127.0.0.1', created_at: '2026-07-01T00:00:00Z' },
+  { id: 2, actor_subject_id: null, event: 'auth.login_success', metadata: null, ip_address: '127.0.0.1', created_at: '2026-07-01T00:01:00Z' }
+]
+
+describe('AuditLogViewer', () => {
+  it('shows the empty state when there are no entries', () => {
+    const wrapper = mount(AuditLogViewer, { props: { entries: [] } })
+    expect(wrapper.text()).toContain('No audit events recorded yet.')
+  })
+
+  it('renders one row per entry', () => {
+    const wrapper = mount(AuditLogViewer, { props: { entries } })
+    expect(wrapper.findAll('[data-testid="audit-log-row"]')).toHaveLength(2)
+  })
+
+  it('shows a loading state', () => {
+    const wrapper = mount(AuditLogViewer, { props: { entries: [], loading: true } })
+    expect(wrapper.text()).toContain('Loading audit log')
+  })
+
+  it('only shows a details toggle for entries with metadata', () => {
+    const wrapper = mount(AuditLogViewer, { props: { entries } })
+    expect(wrapper.findAll('[data-testid="audit-log-details-toggle"]')).toHaveLength(1)
+  })
+
+  it('expands metadata as pretty-printed JSON on click', async () => {
+    const wrapper = mount(AuditLogViewer, { props: { entries } })
+    expect(wrapper.find('[data-testid="audit-log-details"]').exists()).toBe(false)
+
+    await wrapper.get('[data-testid="audit-log-details-toggle"]').trigger('click')
+    expect(wrapper.get('[data-testid="audit-log-details"]').text()).toContain('"path": "a.md"')
+
+    await wrapper.get('[data-testid="audit-log-details-toggle"]').trigger('click')
+    expect(wrapper.find('[data-testid="audit-log-details"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -11,6 +11,7 @@ import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
 import PropertiesPanel from './components/PropertiesPanel.vue'
 import CommentsPanel from './components/CommentsPanel.vue'
+import AuditLogViewer from './components/AuditLogViewer.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -189,6 +190,26 @@ describe('Accessibility Audit (axe-core)', () => {
       props: {
         comments: [
           { id: 1, workspace_id: 1, note_id: 1, user_id: 1, actor_name: 'Alex', content: 'Looks good', anchor_line: null, created_at: '2026-07-01T00:00:00Z' },
+        ],
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('AuditLogViewer has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(AuditLogViewer, {
+      attachTo: document.body,
+      props: {
+        entries: [
+          { id: 1, actor_subject_id: 'user:1', event: 'note.created', metadata: { path: 'a.md' }, ip_address: '127.0.0.1', created_at: '2026-07-01T00:00:00Z' },
+          { id: 2, actor_subject_id: null, event: 'auth.login_success', metadata: null, ip_address: '127.0.0.1', created_at: '2026-07-01T00:01:00Z' },
         ],
       },
     })

--- a/frontend/src/components/AuditLogViewer.vue
+++ b/frontend/src/components/AuditLogViewer.vue
@@ -1,0 +1,207 @@
+<template>
+  <div class="audit-log-viewer">
+    <div class="panel-header">
+      <h2>Audit Log</h2>
+      <span class="entry-count">{{ entries.length }}</span>
+    </div>
+    <p class="panel-hint">Most recent 50 events for this workspace, newest first.</p>
+
+    <div v-if="loading" class="panel-empty">
+      <p>Loading audit log…</p>
+    </div>
+
+    <div v-else-if="entries.length === 0" class="panel-empty">
+      <p>No audit events recorded yet.</p>
+    </div>
+
+    <table v-else class="audit-table">
+      <thead>
+        <tr>
+          <th scope="col">Time</th>
+          <th scope="col">Event</th>
+          <th scope="col">Actor</th>
+          <th scope="col">IP</th>
+          <th scope="col"><span class="sr-only">Details</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="entry in entries" :key="entry.id">
+          <tr class="audit-row" data-testid="audit-log-row">
+            <td class="audit-time">{{ formatDate(entry.created_at) }}</td>
+            <td><span class="event-badge">{{ entry.event }}</span></td>
+            <td class="audit-actor">{{ entry.actor_subject_id || '—' }}</td>
+            <td class="audit-ip">{{ entry.ip_address || '—' }}</td>
+            <td>
+              <button
+                v-if="entry.metadata && Object.keys(entry.metadata).length > 0"
+                type="button"
+                class="btn-toggle-details"
+                data-testid="audit-log-details-toggle"
+                :aria-expanded="expandedId === entry.id"
+                :aria-label="`Toggle details for ${entry.event} event`"
+                @click="expandedId = expandedId === entry.id ? null : entry.id"
+              >
+                {{ expandedId === entry.id ? 'Hide' : 'Details' }}
+              </button>
+            </td>
+          </tr>
+          <tr v-if="expandedId === entry.id" class="audit-details-row">
+            <td colspan="5">
+              <pre class="audit-metadata" data-testid="audit-log-details">{{ JSON.stringify(entry.metadata, null, 2) }}</pre>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { AuditLogEntry } from '../services/types'
+
+defineProps<{
+  entries: AuditLogEntry[]
+  loading?: boolean
+}>()
+
+const expandedId = ref<number | null>(null)
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit'
+    })
+  } catch {
+    return iso
+  }
+}
+</script>
+
+<style scoped>
+.audit-log-viewer {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.panel-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.entry-count {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.panel-hint {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-5);
+}
+
+.panel-empty {
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.audit-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.audit-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.audit-row td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.audit-time {
+  white-space: nowrap;
+  color: var(--color-text-muted);
+}
+
+.event-badge {
+  background: var(--color-surface-emphasis);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.4rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+}
+
+.audit-actor,
+.audit-ip {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+}
+
+.btn-toggle-details {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+  cursor: pointer;
+  min-height: 28px;
+  transition: border-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-toggle-details:hover {
+  border-color: var(--color-action);
+  color: var(--color-action);
+}
+
+.audit-details-row td {
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 var(--space-3) var(--space-3);
+}
+
+.audit-metadata {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  font-size: 0.75rem;
+  color: var(--color-text);
+  overflow-x: auto;
+  white-space: pre;
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -18,6 +18,14 @@
             <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
           </svg>
         </button>
+        <button class="btn-icon" data-testid="audit-log-btn" title="Audit Log" @click="$emit('toggle-audit-log')">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+            <line x1="9" y1="13" x2="15" y2="13"></line>
+            <line x1="9" y1="17" x2="13" y2="17"></line>
+          </svg>
+        </button>
         <button class="btn-icon" data-testid="daily-note-btn" title="Today's Daily Note" @click="$emit('daily-note')">
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
             <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
@@ -179,6 +187,7 @@ const emit = defineEmits<{
   (e: 'logout'): void
   (e: 'toggle-attachments'): void
   (e: 'daily-note'): void
+  (e: 'toggle-audit-log'): void
 }>()
 
 const searchQuery = ref('')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -190,6 +190,13 @@ export async function addNoteComment(
 
 export async function deleteNoteComment(workspaceId: number, noteId: number, commentId: number): Promise<void> {
   await api.delete(`/workspaces/${workspaceId}/notes/${noteId}/comments/${commentId}`)
+}
+
+export async function getAuditLogs(workspaceId: number): Promise<AuditLogEntry[]> {
+  const response = await api.get<{ workspace_id: number; audit_logs: AuditLogEntry[] }>(
+    `/workspaces/${workspaceId}/audit-logs`
+  )
+  return response.data.audit_logs
 }
 
 export async function getAttachments(workspaceId: number): Promise<AttachmentItem[]> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -80,6 +80,15 @@ export interface NoteComment {
   created_at: string
 }
 
+export interface AuditLogEntry {
+  id: number
+  actor_subject_id: string | null
+  event: string
+  metadata: Record<string, unknown> | null
+  ip_address: string | null
+  created_at: string | null
+}
+
 export interface AttachmentItem {
   id: number
   workspace_id: number

--- a/tests/Feature/AuditLogQueryTest.php
+++ b/tests/Feature/AuditLogQueryTest.php
@@ -24,10 +24,30 @@ final class AuditLogQueryTest extends TestCase
             'vault_path' => storage_path('app/vaults/audit_test'),
         ]);
 
+        // Regression: workspace-scoped events must show up even when the
+        // recorder call site never populated tenant_id — this is the normal
+        // case in practice (e.g. WorkspaceEventEmitter::emitMention() only
+        // ever passes workspaceId). Requiring an exact tenant_id match on
+        // top of workspace_id silently hid every one of these.
         AuditLog::create([
+            'workspace_id' => $workspace->id,
             'actor_subject_id' => (string) $admin->id,
-            'event' => 'note.created',
+            'event' => 'note.updated',
             'metadata' => ['path' => 'welcome.md'],
+            'ip_address' => '127.0.0.1',
+        ]);
+
+        // A log for a different workspace must not leak in.
+        $otherWorkspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'other',
+            'name' => 'Other',
+            'vault_path' => storage_path('app/vaults/audit_test_other'),
+        ]);
+        AuditLog::create([
+            'workspace_id' => $otherWorkspace->id,
+            'event' => 'note.created',
+            'metadata' => [],
             'ip_address' => '127.0.0.1',
         ]);
 
@@ -38,6 +58,8 @@ final class AuditLogQueryTest extends TestCase
             ->assertJsonStructure([
                 'workspace_id',
                 'audit_logs',
-            ]);
+            ])
+            ->assertJsonCount(1, 'audit_logs')
+            ->assertJsonPath('audit_logs.0.event', 'note.updated');
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #166. `AuditLogQueryController` existed server-side with no SPA UI.
- New `AuditLogViewer.vue`: a table view (time/event/actor/IP, expandable JSON metadata per row) toggled from a new sidebar header button, alongside Attachments and Daily Note.

**Also fixes a real backend bug found while verifying this in a browser**: the query required an exact `tenant_id` match on top of `workspace_id`, but most `AuditRecorder::record()` call sites (e.g. `WorkspaceEventEmitter::emitMention()`) only ever pass `workspaceId`, never `tenantId` — so every workspace-scoped event was silently invisible, even though `workspace_id` alone already unambiguously identifies the tenant. In the dev DB, **every single `audit_log` row had a null `tenant_id`**, meaning the endpoint returned zero results 100% of the time in practice — the viewer would have shipped permanently empty. Fixed by scoping on `workspace_id` alone for workspace-scoped events (the `tenant_id` check now only applies to the null-workspace/tenant-wide branch). Strengthened `AuditLogQueryTest` to assert actual returned content instead of just JSON structure (the old test only checked shape, which is exactly why this slipped through) — confirmed it fails without the fix (`0` vs expected `1`, via `git stash`) and passes with it.

## Test plan
- [x] `./scripts/jt.sh artisan test` — 105 passed (full backend suite, incl. strengthened regression test)
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 57/57 passing (new `AuditLogViewer.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: posted a comment with an `@mention` (the one code path that reliably produces a workspace-scoped audit event), opened the audit log viewer, confirmed the `note.updated` entry appears with correct actor/IP/timestamp, expanded its metadata and confirmed the pretty-printed JSON is correct.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
