### PR TITLE
Add workspace publish UI, fix two real publish bugs (#165) — completes Tier 3

### DIFF
--- a/app/Http/Controllers/WorkspacePublishController.php
+++ b/app/Http/Controllers/WorkspacePublishController.php
@@ -55,8 +55,9 @@ final class WorkspacePublishController extends Controller
             }
         }
 
-        $notes = Note::query()->where('workspace_id', $workspaceId)->get();
+        $notes = Note::query()->where('workspace_id', $workspaceId)->orderBy('path')->get();
         $publishedCount = 0;
+        $publishedPages = [];
 
         foreach ($notes as $note) {
             $fullPath = rtrim($workspace->vault_path, '/').'/'.$note->path;
@@ -82,8 +83,21 @@ final class WorkspacePublishController extends Controller
 
                 file_put_contents($outPath, $pageHtml);
                 $publishedCount++;
+                $publishedPages[] = ['title' => $note->title, 'href' => $relPath];
             }
         }
+
+        // The site needs a landing page: nothing above ever writes index.html,
+        // and there's no guarantee a note is published at that exact path.
+        $indexLinks = collect($publishedPages)
+            ->map(fn ($p) => '<li><a href="'.e($p['href']).'">'.e($p['title']).'</a></li>')
+            ->implode('');
+        $indexHtml = view('publish.page', [
+            'title' => $workspace->name,
+            'html' => '<ul class="publish-index">'.$indexLinks.'</ul>',
+            'assetPrefix' => '',
+        ])->render();
+        file_put_contents($siteDir.'/index.html', $indexHtml);
 
         $publishedUrl = url("storage/sites/{$workspace->slug}/index.html");
 

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -5,6 +5,7 @@ for directory in \
     storage/app/private \
     storage/app/vaults \
     storage/app/imports \
+    storage/app/public \
     storage/framework/cache/data \
     storage/framework/sessions \
     storage/framework/views \

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,7 @@
       @import-workspace="handleImportWorkspace"
       @export-workspace="handleExportWorkspace"
       @toggle-link-report="handleToggleLinkReport"
+      @publish-workspace="handlePublishWorkspace"
     />
 
     <!-- Main Content Area -->
@@ -103,12 +104,20 @@
     <!-- Success Banner -->
     <div v-if="successMessage" class="success-banner" data-testid="success-banner" role="status">
       <span>{{ successMessage }}</span>
+      <a
+        v-if="successLink"
+        :href="successLink"
+        target="_blank"
+        rel="noopener"
+        class="success-banner-link"
+        data-testid="success-banner-link"
+      >Open</a>
       <button
         type="button"
         class="error-banner-dismiss"
         data-testid="success-banner-dismiss"
         aria-label="Dismiss message"
-        @click="successMessage = null"
+        @click="successMessage = null; successLink = null"
       >&times;</button>
     </div>
 
@@ -158,7 +167,8 @@ import {
   getOrCreateDailyNote,
   getAuditLogs,
   importWorkspaceArchive,
-  getLinkReport
+  getLinkReport,
+  publishWorkspace
 } from './services/api'
 import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport } from './services/types'
 
@@ -203,6 +213,7 @@ const availableTagsForSearch = computed(() => {
 
 const errorMessage = ref<string | null>(null)
 const successMessage = ref<string | null>(null)
+const successLink = ref<string | null>(null)
 
 async function handleSelectNoteFromGraph(noteId: number) {
   isGraphViewActive.value = false
@@ -362,6 +373,18 @@ async function handleImportWorkspace(archive: File, overwrite: boolean) {
 function handleExportWorkspace() {
   if (!activeWorkspaceId.value) return
   window.location.href = `/api/workspaces/${activeWorkspaceId.value}/export`
+}
+
+async function handlePublishWorkspace() {
+  if (!activeWorkspaceId.value) return
+  try {
+    const result = await publishWorkspace(activeWorkspaceId.value)
+    successMessage.value = `Published ${result.notes_published} note(s) to the static site.`
+    successLink.value = result.site_url
+  } catch (err: any) {
+    console.error('Failed to publish workspace:', err)
+    errorMessage.value = `Failed to publish workspace: ${err.response?.data?.message || err.message || 'Unknown error'}`
+  }
 }
 
 async function refreshAuditLog() {
@@ -601,6 +624,14 @@ body {
   border-radius: var(--radius-sm, 6px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   font-size: 0.9rem;
+}
+
+.success-banner-link {
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .error-banner-dismiss {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -108,6 +108,19 @@
               </svg>
               <span>Broken Links &amp; Orphans</span>
             </button>
+            <button
+              class="more-menu-item"
+              data-testid="publish-workspace-btn"
+              role="menuitem"
+              @click="closeMoreMenuAnd(() => $emit('publish-workspace'))"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="2" y1="12" x2="22" y2="12"></line>
+                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+              </svg>
+              <span>Publish Static Site</span>
+            </button>
           </div>
         </div>
         <button class="btn-icon" data-testid="new-note-btn" title="New Note" @click="showNewNoteModal = true">
@@ -292,6 +305,7 @@ const emit = defineEmits<{
   (e: 'import-workspace', archive: File, overwrite: boolean): void
   (e: 'export-workspace'): void
   (e: 'toggle-link-report'): void
+  (e: 'publish-workspace'): void
 }>()
 
 const searchQuery = ref('')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -223,6 +223,18 @@ export async function getAuditLogs(workspaceId: number): Promise<AuditLogEntry[]
   return response.data.audit_logs
 }
 
+export interface PublishResult {
+  message: string
+  workspace: string
+  notes_published: number
+  site_url: string
+}
+
+export async function publishWorkspace(workspaceId: number): Promise<PublishResult> {
+  const response = await api.post<PublishResult>(`/workspaces/${workspaceId}/publish`)
+  return response.data
+}
+
 export async function getLinkReport(workspaceId: number): Promise<LinkReport> {
   const response = await api.get<LinkReport>(`/workspaces/${workspaceId}/link-report`)
   return response.data

--- a/tests/Feature/WorkspacePublishTest.php
+++ b/tests/Feature/WorkspacePublishTest.php
@@ -57,4 +57,44 @@ final class WorkspacePublishTest extends TestCase
 
         $this->assertFileExists(storage_path('app/public/sites/main/publish.css'));
     }
+
+    public function test_index_page_is_generated_even_when_no_note_is_at_that_path(): void
+    {
+        // Regression: the previous test's fixture happened to be named
+        // index.md, which made index.html exist as a side effect of the
+        // per-note loop — masking that the returned site_url (always
+        // pointing at index.html) had no guarantee of ever existing for any
+        // other vault layout. Here nothing is named "index".
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'default', 'name' => 'Default']);
+
+        $vaultDir = storage_path('app/vaults/publish_test_no_index');
+        if (! is_dir($vaultDir)) {
+            mkdir($vaultDir, 0755, true);
+        }
+        file_put_contents($vaultDir.'/hello.md', '# Hello World');
+        file_put_contents($vaultDir.'/goodbye.md', '# Goodbye World');
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'no-index',
+            'name' => 'No Index',
+            'vault_path' => $vaultDir,
+        ]);
+
+        $this->artisan('vault:reindex', ['--workspace' => $workspace->id]);
+
+        $response = $this->actingAs($admin)
+            ->postJson("/api/workspaces/{$workspace->id}/publish");
+
+        $response->assertOk()->assertJsonPath('notes_published', 2);
+
+        $indexFile = storage_path('app/public/sites/no-index/index.html');
+        $this->assertFileExists($indexFile);
+
+        $indexHtml = file_get_contents($indexFile);
+        $this->assertStringContainsString('hello.html', $indexHtml);
+        $this->assertStringContainsString('goodbye.html', $indexHtml);
+        $this->assertStringContainsString('Hello World', $indexHtml);
+    }
 }


### PR DESCRIPTION
## Summary

Three things, discovered and fixed while building/verifying #165 end-to-end:

**1. Publish UI.** `WorkspacePublishController` existed server-side with no SPA entry point. Adds a "Publish Static Site" item to the sidebar's More-actions menu; the result surfaces via the success banner, now extended with an optional clickable "Open" link (`successLink`) so users can jump straight to the published site.

**2. `storage/app/public` permissions (same bug class as #140/#164).** The publish endpoint's `mkdir()` failed with `Permission denied` — that path was missing from `entrypoint.sh`'s ownership loop, same pattern as `storage/app/imports` for #164. Reproduced via a real `POST` that 500'd; confirmed the exact directory was root-owned on a reset container. Fixed by adding it to the chown loop.

**3. Missing `index.html` (found while verifying fix #2 end-to-end).** `WorkspacePublishController` always returns a `site_url` pointing at `index.html`, but nothing in the publish loop ever wrote that file — only per-note pages named after their vault paths. The existing test only ever passed because its fixture note happened to be named `index.md`, coincidentally masking the gap for every other vault layout. Confirmed live: fetching the returned `site_url` 403'd on a real dev server even after fixing #2. Fixed by always writing an explicit `index.html` listing links to every published note. Added a regression test using notes deliberately *not* named "index" that asserts the index page's actual content, not just its existence.

This closes out **Tier 3** of the UI-audit queue (#166, #164, #163, #167, #165 all shipped).

## Test plan
- [x] `./scripts/jt.sh artisan test` — 106 passed (full backend suite, incl. the new regression test — confirmed it exercises the real bug via a fresh vault with no `index.md`)
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 64/64 passing
- [x] Manual Playwright check against dev server: reproduced the 500 (permission) and the 403 (missing index.html) directly before fixing each, then confirmed a full publish → fetch `site_url` round trip returns 200 with real HTML content.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
