### PR TITLE
Add notifications UI (#159) — first Tier 4 item

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,12 +5,15 @@
       :notes="notes"
       :selected-note-id="activeNoteId"
       :current-user="currentUser"
+      :notifications="notifications"
       @select-note="handleSelectNote"
       @create-note="handleCreateNote"
       @create-note-from-template="handleCreateNoteFromTemplate"
       @delete-note="handleDeleteNote"
       @search="handleSearch"
       @logout="handleLogout"
+      @mark-notification-read="handleMarkNotificationRead"
+      @delete-notification="handleDeleteNotification"
       @toggle-attachments="handleToggleAttachments"
       @daily-note="handleDailyNote"
       @toggle-audit-log="handleToggleAuditLog"
@@ -168,9 +171,12 @@ import {
   getAuditLogs,
   importWorkspaceArchive,
   getLinkReport,
-  publishWorkspace
+  publishWorkspace,
+  getNotifications,
+  markNotificationRead,
+  deleteNotification
 } from './services/api'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport } from './services/types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem } from './services/types'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -198,6 +204,8 @@ const auditLogLoading = ref(false)
 const isLinkReportActive = ref(false)
 const linkReport = ref<LinkReport>({ broken_links: [], orphans: [] })
 const linkReportLoading = ref(false)
+
+const notifications = ref<NotificationItem[]>([])
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -243,8 +251,39 @@ async function initWorkspace() {
       activeWorkspaceId.value = list[0].id
     }
     await refreshNotesList()
+    await refreshNotifications()
   } catch (err) {
     console.error('Failed to initialize workspace:', err)
+  }
+}
+
+async function refreshNotifications() {
+  if (!activeWorkspaceId.value) return
+  try {
+    notifications.value = await getNotifications(activeWorkspaceId.value)
+  } catch (err) {
+    console.error('Failed to load notifications:', err)
+  }
+}
+
+async function handleMarkNotificationRead(notificationId: number) {
+  if (!activeWorkspaceId.value) return
+  try {
+    const updated = await markNotificationRead(activeWorkspaceId.value, notificationId)
+    const idx = notifications.value.findIndex(n => n.id === notificationId)
+    if (idx !== -1) notifications.value[idx] = updated
+  } catch (err) {
+    console.error('Failed to mark notification as read:', err)
+  }
+}
+
+async function handleDeleteNotification(notificationId: number) {
+  if (!activeWorkspaceId.value) return
+  try {
+    await deleteNotification(activeWorkspaceId.value, notificationId)
+    notifications.value = notifications.value.filter(n => n.id !== notificationId)
+  } catch (err) {
+    console.error('Failed to delete notification:', err)
   }
 }
 

--- a/frontend/src/SidebarNotifications.spec.ts
+++ b/frontend/src/SidebarNotifications.spec.ts
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Sidebar from './components/Sidebar.vue'
+
+const baseProps = { notes: [], selectedNoteId: null, currentUser: null }
+
+const notifications = [
+  { id: 1, workspace_id: 1, user_id: 1, type: 'mention', title: 'You were mentioned', data: { comment_snippet: 'hey check this' }, read_at: null, created_at: '2026-07-01T00:00:00Z' },
+  { id: 2, workspace_id: 1, user_id: 1, type: 'mention', title: 'Another mention', data: null, read_at: '2026-07-02T00:00:00Z', created_at: '2026-07-01T00:00:00Z' }
+]
+
+describe('Sidebar notifications', () => {
+  it('does not show a badge when there are no unread notifications', () => {
+    const wrapper = mount(Sidebar, { props: { ...baseProps, notifications: [notifications[1]] } })
+    expect(wrapper.find('[data-testid="notification-badge"]').exists()).toBe(false)
+  })
+
+  it('shows the unread count badge', () => {
+    const wrapper = mount(Sidebar, { props: { ...baseProps, notifications } })
+    expect(wrapper.get('[data-testid="notification-badge"]').text()).toBe('1')
+  })
+
+  it('lists notifications when the bell is clicked', async () => {
+    const wrapper = mount(Sidebar, { props: { ...baseProps, notifications } })
+    await wrapper.get('[data-testid="notifications-btn"]').trigger('click')
+    expect(wrapper.findAll('[data-testid="notification-item"]')).toHaveLength(2)
+  })
+
+  it('emits mark-notification-read when an unread notification body is clicked', async () => {
+    const wrapper = mount(Sidebar, { props: { ...baseProps, notifications } })
+    await wrapper.get('[data-testid="notifications-btn"]').trigger('click')
+    await wrapper.get('.notification-body').trigger('click')
+    expect(wrapper.emitted('mark-notification-read')![0]).toEqual([1])
+  })
+
+  it('emits delete-notification when dismiss is clicked', async () => {
+    const wrapper = mount(Sidebar, { props: { ...baseProps, notifications } })
+    await wrapper.get('[data-testid="notifications-btn"]').trigger('click')
+    await wrapper.findAll('[data-testid="notification-delete-btn"]')[0].trigger('click')
+    expect(wrapper.emitted('delete-notification')![0]).toEqual([1])
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -45,6 +45,29 @@ describe('Accessibility Audit (axe-core)', () => {
     expect(seriousOrCritical).toEqual([])
   })
 
+  it('Sidebar with the notifications dropdown open has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(Sidebar, {
+      attachTo: document.body,
+      props: {
+        notes: [],
+        selectedNoteId: null,
+        currentUser: null,
+        notifications: [
+          { id: 1, workspace_id: 1, user_id: 1, type: 'mention', title: 'You were mentioned', data: { comment_snippet: 'hey @you check this' }, read_at: null, created_at: '2026-07-01T00:00:00Z' },
+        ],
+      },
+    })
+    await wrapper.get('[data-testid="notifications-btn"]').trigger('click')
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
   it('LoginModal has no serious or critical structural accessibility violations', async () => {
     const wrapper = mount(LoginModal, {
       attachTo: document.body,

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -16,6 +16,53 @@
         <div class="more-menu-wrapper">
           <button
             class="btn-icon"
+            data-testid="notifications-btn"
+            title="Notifications"
+            :aria-expanded="showNotifications"
+            aria-haspopup="true"
+            @click="showNotifications = !showNotifications"
+          >
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
+              <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+            </svg>
+            <span v-if="unreadNotificationCount > 0" class="notification-badge" data-testid="notification-badge">
+              {{ unreadNotificationCount > 9 ? '9+' : unreadNotificationCount }}
+            </span>
+          </button>
+          <div v-if="showNotifications" class="more-menu-backdrop" @click="showNotifications = false"></div>
+          <div v-if="showNotifications" class="more-menu notifications-menu" role="region" aria-label="Notifications">
+            <p v-if="notifications.length === 0" class="notifications-empty">No notifications yet.</p>
+            <div
+              v-for="notification in notifications"
+              :key="notification.id"
+              class="notification-item"
+              :class="{ unread: !notification.read_at }"
+              data-testid="notification-item"
+            >
+              <div class="notification-body" @click="!notification.read_at && $emit('mark-notification-read', notification.id)">
+                <span class="notification-title">{{ notification.title }}</span>
+                <span v-if="notification.data?.comment_snippet" class="notification-snippet">{{ notification.data.comment_snippet }}</span>
+                <span class="notification-time">{{ formatNotificationTime(notification.created_at) }}</span>
+              </div>
+              <button
+                class="btn-delete-notification"
+                data-testid="notification-delete-btn"
+                :aria-label="`Dismiss notification: ${notification.title}`"
+                title="Dismiss"
+                @click="$emit('delete-notification', notification.id)"
+              >
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="more-menu-wrapper">
+          <button
+            class="btn-icon"
             data-testid="more-actions-btn"
             title="More actions"
             :aria-expanded="showMoreMenu"
@@ -282,7 +329,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { NoteMeta, AuthUser } from '../services/types'
+import type { NoteMeta, AuthUser, NotificationItem } from '../services/types'
 import NoteTreeNode from './NoteTreeNode.vue'
 import type { TreeFolder, TreeNode } from './NoteTreeNode.vue'
 
@@ -290,6 +337,7 @@ const props = defineProps<{
   notes: NoteMeta[]
   selectedNoteId: number | null
   currentUser?: AuthUser | null
+  notifications?: NotificationItem[]
 }>()
 
 const emit = defineEmits<{
@@ -299,6 +347,8 @@ const emit = defineEmits<{
   (e: 'delete-note', noteId: number): void
   (e: 'search', query: string): void
   (e: 'logout'): void
+  (e: 'mark-notification-read', notificationId: number): void
+  (e: 'delete-notification', notificationId: number): void
   (e: 'toggle-attachments'): void
   (e: 'daily-note'): void
   (e: 'toggle-audit-log'): void
@@ -316,6 +366,19 @@ const newNotePath = ref('')
 const newNoteTemplatePath = ref('')
 const showImportModal = ref(false)
 const showMoreMenu = ref(false)
+const showNotifications = ref(false)
+const notifications = computed(() => props.notifications ?? [])
+const unreadNotificationCount = computed(() => notifications.value.filter(n => !n.read_at).length)
+
+function formatNotificationTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+    })
+  } catch {
+    return iso
+  }
+}
 
 function closeMoreMenuAnd(action: () => void) {
   showMoreMenu.value = false
@@ -538,7 +601,106 @@ function handleImportSubmit() {
   background: var(--color-surface-emphasis);
 }
 
+.notification-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: var(--color-status-danger);
+  color: #ffffff;
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.15rem 0.3rem;
+  border-radius: var(--radius-pill);
+  min-width: 16px;
+  text-align: center;
+}
+
+.notifications-menu {
+  left: 0;
+  right: auto;
+  min-width: 280px;
+  max-width: 340px;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: var(--space-2);
+}
+
+.notifications-empty {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  font-style: italic;
+  padding: var(--space-3);
+}
+
+.notification-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.notification-item.unread {
+  background: color-mix(in srgb, var(--color-action) 12%, transparent);
+}
+
+.notification-item:hover {
+  background: var(--color-surface-emphasis);
+}
+
+.notification-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.notification-title {
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.notification-snippet {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notification-time {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+.btn-delete-notification {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 24px;
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-delete-notification:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
+}
+
 .btn-icon {
+  position: relative;
   background: transparent;
   border: none;
   color: var(--color-text-muted);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -233,6 +233,20 @@ export interface PublishResult {
 export async function publishWorkspace(workspaceId: number): Promise<PublishResult> {
   const response = await api.post<PublishResult>(`/workspaces/${workspaceId}/publish`)
   return response.data
+}
+
+export async function getNotifications(workspaceId: number): Promise<NotificationItem[]> {
+  const response = await api.get<{ data: NotificationItem[] }>(`/workspaces/${workspaceId}/notifications`)
+  return response.data.data
+}
+
+export async function markNotificationRead(workspaceId: number, notificationId: number): Promise<NotificationItem> {
+  const response = await api.post<{ data: NotificationItem }>(`/workspaces/${workspaceId}/notifications/${notificationId}/read`)
+  return response.data.data
+}
+
+export async function deleteNotification(workspaceId: number, notificationId: number): Promise<void> {
+  await api.delete(`/workspaces/${workspaceId}/notifications/${notificationId}`)
 }
 
 export async function getLinkReport(workspaceId: number): Promise<LinkReport> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -112,6 +112,17 @@ export interface LinkReport {
   orphans: OrphanNote[]
 }
 
+export interface NotificationItem {
+  id: number
+  workspace_id: number
+  user_id: number
+  type: string
+  title: string
+  data: { actor_id?: string; comment_snippet?: string; [key: string]: unknown } | null
+  read_at: string | null
+  created_at: string
+}
+
 export interface AttachmentItem {
   id: number
   workspace_id: number


### PR DESCRIPTION
## Summary
- Fixes #159. `WorkspaceNotificationController` (list/mark-read/delete) and the `Notification` model existed with no SPA UI — mentions created via comments (`WorkspaceEventEmitter::emitMention()`) were silently invisible to their recipients.
- New bell icon with an unread-count badge in the sidebar header, opening a dropdown listing notifications (title, snippet, timestamp), click-to-mark-read, and a dismiss button. Notifications load once on workspace init alongside notes.

**Two things caught and fixed while verifying:**
- The dropdown's `role="menu"` required `role="menuitem"` children per WCAG, but each row is a compound click-to-read + separate delete button — not a valid menu-item shape. Caught by a new axe a11y test; changed to `role="region"`.
- The dropdown reused `.more-menu`'s `right: 0` positioning (correct for the More-actions button at the right edge of the header) but the notifications bell sits at the *left* — the dropdown overflowed off-screen. Caught via a real browser screenshot; fixed with an explicit `left: 0` override.

## Test plan
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 70/70 passing (new `SidebarNotifications.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: posted a self-`@mention` comment, confirmed the unread badge appears, opened the dropdown and confirmed correct rendering (screenshot), marked it read (badge clears), dismissed it (list empties). Also re-confirmed the sidebar header's icon buttons still fit within the 280px width with the new bell added (regression check against the #164 overflow bug).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
