### PR TITLE
Add collections table view, fix property-value filter bug (#161 — table view slice)

### DIFF
--- a/app/Http/Controllers/WorkspaceCollectionController.php
+++ b/app/Http/Controllers/WorkspaceCollectionController.php
@@ -36,7 +36,30 @@ final class WorkspaceCollectionController extends Controller
             $query->whereHas('properties', function ($pQuery) use ($propertyKey, $propertyValue) {
                 $pQuery->where('name', $propertyKey);
                 if ($propertyValue !== null && $propertyValue !== '') {
-                    $pQuery->where('value_string', $propertyValue);
+                    // A property's actual value lives in one of several typed
+                    // columns (value_string/numeric/boolean/datetime) depending
+                    // on its type — matching only value_string meant filtering
+                    // could never find a match on any non-string property.
+                    // Each alternate column is only compared when the filter
+                    // value actually looks like that type, to avoid false
+                    // positives from loose coercion (e.g. a non-numeric string
+                    // matching value_numeric = 0, or any non-boolean string
+                    // matching value_boolean = false).
+                    $pQuery->where(function ($vQuery) use ($propertyValue) {
+                        $vQuery->where('value_string', $propertyValue);
+
+                        if (is_numeric($propertyValue)) {
+                            $vQuery->orWhere('value_numeric', $propertyValue);
+                        }
+
+                        if (in_array(strtolower($propertyValue), ['true', 'false'], true)) {
+                            $vQuery->orWhere('value_boolean', strtolower($propertyValue) === 'true');
+                        }
+
+                        if (strtotime($propertyValue) !== false) {
+                            $vQuery->orWhere('value_datetime', $propertyValue);
+                        }
+                    });
                 }
             });
         }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -21,6 +21,7 @@
       @export-workspace="handleExportWorkspace"
       @toggle-link-report="handleToggleLinkReport"
       @publish-workspace="handlePublishWorkspace"
+      @toggle-table-view="handleToggleTableView"
     />
 
     <!-- Main Content Area -->
@@ -55,6 +56,19 @@
         :report="linkReport"
         :loading="linkReportLoading"
         @select-note="handleSelectNote"
+      />
+
+      <!-- Table (Collections) View Mode -->
+      <CollectionsTableView
+        v-else-if="isTableViewActive"
+        :page="collectionPage"
+        :loading="collectionLoading"
+        :sort-key="collectionSortKey"
+        :sort-dir="collectionSortDir"
+        @select-note="handleSelectNote"
+        @page-change="handleCollectionPageChange"
+        @filter-change="handleCollectionFilterChange"
+        @sort="handleCollectionSort"
       />
 
       <!-- Search View Mode -->
@@ -153,6 +167,7 @@ import GraphView from './components/GraphView.vue'
 import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import AuditLogViewer from './components/AuditLogViewer.vue'
 import LinkReportViewer from './components/LinkReportViewer.vue'
+import CollectionsTableView from './components/CollectionsTableView.vue'
 import {
   getWorkspaces,
   getNotes,
@@ -172,11 +187,12 @@ import {
   importWorkspaceArchive,
   getLinkReport,
   publishWorkspace,
+  getCollection,
   getNotifications,
   markNotificationRead,
   deleteNotification
 } from './services/api'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem } from './services/types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage } from './services/types'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -206,6 +222,14 @@ const linkReport = ref<LinkReport>({ broken_links: [], orphans: [] })
 const linkReportLoading = ref(false)
 
 const notifications = ref<NotificationItem[]>([])
+
+const isTableViewActive = ref(false)
+const collectionPage = ref<CollectionPage>({ data: [], current_page: 1, last_page: 1, per_page: 50, total: 0 })
+const collectionLoading = ref(false)
+const collectionFilterProperty = ref('')
+const collectionFilterValue = ref('')
+const collectionSortKey = ref<string | null>(null)
+const collectionSortDir = ref<'asc' | 'desc'>('asc')
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -347,6 +371,7 @@ async function handleSelectNote(noteId: number) {
   isAttachmentsActive.value = false
   isAuditLogActive.value = false
   isLinkReportActive.value = false
+  isTableViewActive.value = false
   await loadActiveNote(noteId)
 }
 
@@ -356,6 +381,7 @@ async function handleToggleAttachments() {
     isSearchActive.value = false
     isAuditLogActive.value = false
     isLinkReportActive.value = false
+    isTableViewActive.value = false
     await refreshAttachments()
   }
 }
@@ -366,6 +392,7 @@ async function handleToggleAuditLog() {
     isSearchActive.value = false
     isAttachmentsActive.value = false
     isLinkReportActive.value = false
+    isTableViewActive.value = false
     await refreshAuditLog()
   }
 }
@@ -376,7 +403,54 @@ async function handleToggleLinkReport() {
     isSearchActive.value = false
     isAttachmentsActive.value = false
     isAuditLogActive.value = false
+    isTableViewActive.value = false
     await refreshLinkReport()
+  }
+}
+
+async function handleToggleTableView() {
+  isTableViewActive.value = !isTableViewActive.value
+  if (isTableViewActive.value) {
+    isSearchActive.value = false
+    isAttachmentsActive.value = false
+    isAuditLogActive.value = false
+    isLinkReportActive.value = false
+    await refreshCollection()
+  }
+}
+
+async function refreshCollection(page = 1) {
+  if (!activeWorkspaceId.value) return
+  collectionLoading.value = true
+  try {
+    collectionPage.value = await getCollection(activeWorkspaceId.value, {
+      property: collectionFilterProperty.value || undefined,
+      value: collectionFilterValue.value || undefined,
+      page
+    })
+  } catch (err) {
+    console.error('Failed to load collection:', err)
+  } finally {
+    collectionLoading.value = false
+  }
+}
+
+async function handleCollectionPageChange(page: number) {
+  await refreshCollection(page)
+}
+
+async function handleCollectionFilterChange(propertyName: string, value: string) {
+  collectionFilterProperty.value = propertyName
+  collectionFilterValue.value = value
+  await refreshCollection(1)
+}
+
+function handleCollectionSort(key: string) {
+  if (collectionSortKey.value === key) {
+    collectionSortDir.value = collectionSortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    collectionSortKey.value = key
+    collectionSortDir.value = 'asc'
   }
 }
 
@@ -553,6 +627,7 @@ async function handleSearch(query: string) {
   isAttachmentsActive.value = false
   isAuditLogActive.value = false
   isLinkReportActive.value = false
+  isTableViewActive.value = false
   searchQuery.value = query
   await runSearch(query, searchFilters.value)
 }

--- a/frontend/src/CollectionsTableView.spec.ts
+++ b/frontend/src/CollectionsTableView.spec.ts
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CollectionsTableView from './components/CollectionsTableView.vue'
+import type { CollectionPage } from './services/types'
+
+const emptyPage: CollectionPage = { data: [], current_page: 1, last_page: 1, per_page: 50, total: 0 }
+
+const page: CollectionPage = {
+  data: [
+    {
+      id: 1, path: 'a.md', title: 'A',
+      properties: [
+        { id: 1, note_id: 1, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+        { id: 2, note_id: 1, name: 'priority', type: 'numeric', value_string: null, value_numeric: 3, value_boolean: null, value_datetime: null, value_json: null }
+      ]
+    },
+    {
+      id: 2, path: 'b.md', title: 'B',
+      properties: [
+        { id: 3, note_id: 2, name: 'status', type: 'string', value_string: 'done', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
+      ]
+    }
+  ],
+  current_page: 1,
+  last_page: 1,
+  per_page: 50,
+  total: 2
+}
+
+describe('CollectionsTableView', () => {
+  it('shows the empty state when there are no notes', () => {
+    const wrapper = mount(CollectionsTableView, { props: { page: emptyPage } })
+    expect(wrapper.text()).toContain('No notes match this view.')
+  })
+
+  it('derives property columns as the union of all notes\' property names', () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    const headerText = wrapper.get('thead').text()
+    expect(headerText).toContain('priority')
+    expect(headerText).toContain('status')
+  })
+
+  it('renders a dash for a note missing a given property column', () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    const rows = wrapper.findAll('[data-testid="collection-row"]')
+    expect(rows[1].text()).toContain('—')
+  })
+
+  it('emits select-note when a row is clicked', async () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    await wrapper.findAll('[data-testid="collection-row"]')[0].trigger('click')
+    expect(wrapper.emitted('select-note')![0]).toEqual([1])
+  })
+
+  it('emits sort with the clicked column key', async () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    const priorityHeaderBtn = wrapper.findAll('.sort-btn').find(b => b.text().includes('priority'))
+    await priorityHeaderBtn!.trigger('click')
+    expect(wrapper.emitted('sort')![0]).toEqual(['priority'])
+  })
+
+  it('emits filter-change with trimmed property/value on submit', async () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    await wrapper.get('[data-testid="collection-filter-property"]').setValue('  status  ')
+    await wrapper.get('[data-testid="collection-filter-value"]').setValue('  draft  ')
+    await wrapper.get('.filter-bar').trigger('submit')
+    expect(wrapper.emitted('filter-change')![0]).toEqual(['status', 'draft'])
+  })
+
+  it('shows pagination controls only when there is more than one page', () => {
+    const wrapper = mount(CollectionsTableView, { props: { page } })
+    expect(wrapper.find('[data-testid="collection-next-page"]').exists()).toBe(false)
+
+    const multiPage = { ...page, last_page: 3 }
+    const wrapper2 = mount(CollectionsTableView, { props: { page: multiPage } })
+    expect(wrapper2.find('[data-testid="collection-next-page"]').exists()).toBe(true)
+  })
+
+  it('emits page-change when next is clicked', async () => {
+    const multiPage = { ...page, last_page: 3, current_page: 1 }
+    const wrapper = mount(CollectionsTableView, { props: { page: multiPage } })
+    await wrapper.get('[data-testid="collection-next-page"]').trigger('click')
+    expect(wrapper.emitted('page-change')![0]).toEqual([2])
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -13,6 +13,7 @@ import PropertiesPanel from './components/PropertiesPanel.vue'
 import CommentsPanel from './components/CommentsPanel.vue'
 import AuditLogViewer from './components/AuditLogViewer.vue'
 import LinkReportViewer from './components/LinkReportViewer.vue'
+import CollectionsTableView from './components/CollectionsTableView.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -256,6 +257,31 @@ describe('Accessibility Audit (axe-core)', () => {
             { target_ref: 'missing-note', count: 2, sources: [{ id: 1, path: 'a.md', title: 'A' }] },
           ],
           orphans: [{ id: 2, path: 'b.md', title: 'B' }],
+        },
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('CollectionsTableView has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(CollectionsTableView, {
+      attachTo: document.body,
+      props: {
+        page: {
+          data: [
+            { id: 1, path: 'a.md', title: 'A', properties: [{ id: 1, note_id: 1, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }] },
+          ],
+          current_page: 1,
+          last_page: 2,
+          per_page: 50,
+          total: 51,
         },
       },
     })

--- a/frontend/src/components/CollectionsTableView.vue
+++ b/frontend/src/components/CollectionsTableView.vue
@@ -1,0 +1,351 @@
+<template>
+  <div class="collections-table-view">
+    <div class="panel-header">
+      <h2>Table View</h2>
+      <span class="count-badge">{{ page.total }}</span>
+    </div>
+    <p class="panel-hint">All notes in this workspace with their typed properties as columns.</p>
+
+    <form class="filter-bar" @submit.prevent="$emit('filter-change', filterProperty.trim(), filterValue.trim())">
+      <input
+        v-model="filterProperty"
+        type="text"
+        placeholder="Property name"
+        aria-label="Filter by property name"
+        data-testid="collection-filter-property"
+        class="filter-input"
+      />
+      <input
+        v-model="filterValue"
+        type="text"
+        placeholder="Value (optional)"
+        aria-label="Filter by property value"
+        data-testid="collection-filter-value"
+        class="filter-input"
+      />
+      <button type="submit" class="btn-filter-apply" data-testid="collection-filter-apply">Filter</button>
+      <button
+        v-if="filterProperty || filterValue"
+        type="button"
+        class="btn-filter-clear"
+        data-testid="collection-filter-clear"
+        @click="clearFilter"
+      >
+        Clear
+      </button>
+    </form>
+
+    <div v-if="loading" class="panel-empty">
+      <p>Loading notes…</p>
+    </div>
+
+    <div v-else-if="page.data.length === 0" class="panel-empty">
+      <p>No notes match this view.</p>
+    </div>
+
+    <div v-else class="table-scroll">
+      <table class="collections-table">
+        <thead>
+          <tr>
+            <th scope="col">
+              <button type="button" class="sort-btn" @click="$emit('sort', 'title')">
+                Title <span v-if="sortKey === 'title'">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+              </button>
+            </th>
+            <th scope="col">Path</th>
+            <th v-for="col in propertyColumns" :key="col" scope="col">
+              <button type="button" class="sort-btn" @click="$emit('sort', col)">
+                {{ col }} <span v-if="sortKey === col">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="note in sortedNotes"
+            :key="note.id"
+            class="note-row"
+            data-testid="collection-row"
+            @click="$emit('select-note', note.id)"
+          >
+            <td class="note-title-cell">{{ note.title || note.path }}</td>
+            <td class="note-path-cell">{{ note.path }}</td>
+            <td v-for="col in propertyColumns" :key="col">{{ formatPropertyValue(note, col) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="page.last_page > 1" class="pagination-bar">
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-prev-page"
+        :disabled="page.current_page <= 1"
+        @click="$emit('page-change', page.current_page - 1)"
+      >
+        Previous
+      </button>
+      <span class="page-indicator">Page {{ page.current_page }} of {{ page.last_page }}</span>
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-next-page"
+        :disabled="page.current_page >= page.last_page"
+        @click="$emit('page-change', page.current_page + 1)"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { CollectionPage, CollectionNote, RawNoteProperty } from '../services/types'
+
+const props = defineProps<{
+  page: CollectionPage
+  loading?: boolean
+  sortKey?: string | null
+  sortDir?: 'asc' | 'desc'
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'page-change', page: number): void
+  (e: 'filter-change', property: string, value: string): void
+  (e: 'sort', key: string): void
+}>()
+
+const filterProperty = ref('')
+const filterValue = ref('')
+
+function clearFilter() {
+  filterProperty.value = ''
+  filterValue.value = ''
+  emit('filter-change', '', '')
+}
+
+const propertyColumns = computed(() => {
+  const names = new Set<string>()
+  for (const note of props.page.data) {
+    for (const prop of note.properties) names.add(prop.name)
+  }
+  return Array.from(names).sort()
+})
+
+function rawValue(prop: RawNoteProperty): string | number | boolean | unknown | null {
+  switch (prop.type) {
+    case 'numeric': return prop.value_numeric
+    case 'boolean': return prop.value_boolean
+    case 'datetime': return prop.value_datetime
+    case 'list':
+    case 'json': return prop.value_json
+    default: return prop.value_string
+  }
+}
+
+function formatPropertyValue(note: CollectionNote, column: string): string {
+  const prop = note.properties.find(p => p.name === column)
+  if (!prop) return '—'
+  const value = rawValue(prop)
+  if (value === null || value === undefined) return '—'
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function sortableValue(note: CollectionNote, key: string): string | number | null {
+  if (key === 'title') return (note.title || note.path).toLowerCase()
+  const prop = note.properties.find(p => p.name === key)
+  if (!prop) return null
+  const value = rawValue(prop)
+  if (typeof value === 'number' || typeof value === 'string') return value
+  if (typeof value === 'boolean') return value ? 1 : 0
+  return null
+}
+
+const sortedNotes = computed(() => {
+  if (!props.sortKey) return props.page.data
+  const dir = props.sortDir === 'desc' ? -1 : 1
+  return [...props.page.data].sort((a, b) => {
+    const va = sortableValue(a, props.sortKey!)
+    const vb = sortableValue(b, props.sortKey!)
+    // Notes missing this property always sort to the end, regardless of
+    // direction — treating a missing value as the numeric minimum (the
+    // previous behavior) meant it jumped to the front on ascending sort.
+    if (va === null && vb === null) return 0
+    if (va === null) return 1
+    if (vb === null) return -1
+    if (va < vb) return -1 * dir
+    if (va > vb) return 1 * dir
+    return 0
+  })
+})
+</script>
+
+<style scoped>
+.collections-table-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.panel-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.panel-hint {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+
+.filter-bar {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.filter-input {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.btn-filter-apply,
+.btn-page {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-filter-apply:hover,
+.btn-page:hover:not(:disabled) {
+  background: var(--color-action-hover);
+}
+
+.btn-page:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-filter-clear {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.panel-empty {
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.collections-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.collections-table th {
+  text-align: left;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.sort-btn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  min-height: 36px;
+}
+
+.note-row td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.note-row {
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.note-row:hover {
+  background: var(--color-surface-emphasis);
+}
+
+.note-title-cell {
+  font-weight: 500;
+}
+
+.note-path-cell {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+}
+
+.pagination-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.page-indicator {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -168,6 +168,19 @@
               </svg>
               <span>Publish Static Site</span>
             </button>
+            <button
+              class="more-menu-item"
+              data-testid="table-view-btn"
+              role="menuitem"
+              @click="closeMoreMenuAnd(() => $emit('toggle-table-view'))"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                <line x1="3" y1="9" x2="21" y2="9"></line>
+                <line x1="9" y1="9" x2="9" y2="21"></line>
+              </svg>
+              <span>Table View</span>
+            </button>
           </div>
         </div>
         <button class="btn-icon" data-testid="new-note-btn" title="New Note" @click="showNewNoteModal = true">
@@ -356,6 +369,7 @@ const emit = defineEmits<{
   (e: 'export-workspace'): void
   (e: 'toggle-link-report'): void
   (e: 'publish-workspace'): void
+  (e: 'toggle-table-view'): void
 }>()
 
 const searchQuery = ref('')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -247,6 +247,20 @@ export async function markNotificationRead(workspaceId: number, notificationId: 
 
 export async function deleteNotification(workspaceId: number, notificationId: number): Promise<void> {
   await api.delete(`/workspaces/${workspaceId}/notifications/${notificationId}`)
+}
+
+export async function getCollection(
+  workspaceId: number,
+  filters: { property?: string; value?: string; page?: number } = {}
+): Promise<CollectionPage> {
+  const params = new URLSearchParams()
+  if (filters.property) params.set('property', filters.property)
+  if (filters.value) params.set('value', filters.value)
+  if (filters.page) params.set('page', String(filters.page))
+  params.set('per_page', '50')
+
+  const response = await api.get<CollectionPage>(`/workspaces/${workspaceId}/collections?${params.toString()}`)
+  return response.data
 }
 
 export async function getLinkReport(workspaceId: number): Promise<LinkReport> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -123,6 +123,33 @@ export interface NotificationItem {
   created_at: string
 }
 
+export interface RawNoteProperty {
+  id: number
+  note_id: number
+  name: string
+  type: NotePropertyType
+  value_string: string | null
+  value_numeric: number | null
+  value_boolean: boolean | null
+  value_datetime: string | null
+  value_json: unknown | null
+}
+
+export interface CollectionNote {
+  id: number
+  path: string
+  title: string
+  properties: RawNoteProperty[]
+}
+
+export interface CollectionPage {
+  data: CollectionNote[]
+  current_page: number
+  last_page: number
+  per_page: number
+  total: number
+}
+
 export interface AttachmentItem {
   id: number
   workspace_id: number

--- a/tests/Feature/MilestoneCFinalTest.php
+++ b/tests/Feature/MilestoneCFinalTest.php
@@ -76,4 +76,36 @@ final class MilestoneCFinalTest extends TestCase
         $collectionRes = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/collections?property=status&value=active");
         $collectionRes->assertOk()->assertJsonPath('total', 1);
     }
+
+    public function test_collections_filter_matches_non_string_property_types(): void
+    {
+        // Regression: filtering only ever compared against value_string, so a
+        // filter on a numeric/boolean/datetime property (whose value lives in
+        // a different column) could never match — the previous test only
+        // ever used a string property ("status"), which coincidentally
+        // masked this for every other type.
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'test-numeric', 'name' => 'Test Numeric']);
+        $vaultPath = storage_path('app/vaults/m_c_numeric_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'numeric',
+            'name' => 'Numeric Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+        $storage->write($workspace, 'high.md', "---\npriority: 5\n---\n# High Priority");
+        $storage->write($workspace, 'low.md', "---\npriority: 1\n---\n# Low Priority");
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/collections?property=priority&value=5");
+
+        $response->assertOk()
+            ->assertJsonPath('total', 1)
+            ->assertJsonPath('data.0.title', 'High Priority');
+    }
 }


### PR DESCRIPTION
## Summary

**Scope note**: this ships the table-view slice of #161 only, per the issue's own stated sequencing ("start with table view... board/calendar only after table view is stable"). Board/calendar views will be tracked as separate follow-up work, not silently dropped.

`WorkspaceCollectionController` (`GET .../collections`, #63) existed server-side with zero UI. Adds `CollectionsTableView.vue`: a workspace-wide table of every note, one column per distinct property name found on the current page (union), click-to-sort per column, a property/value filter form, and pagination — all driven by the existing endpoint. New "Table View" item in the sidebar's More-actions menu.

**Two real bugs found and fixed while verifying end-to-end:**

1. **Backend filter bug.** The property-value filter always compared `value_string`, but a property's actual value lives in whichever typed column matches its type (`value_numeric`/`boolean`/`datetime`). Filtering a numeric property by its value always returned zero rows. The existing test only ever used a string property (`status`), coincidentally masking this for every other type — same pattern as #160/#165. Fixed by comparing against whichever typed column plausibly matches the filter value's shape, guarding each branch to avoid false positives from loose coercion (e.g. a non-numeric string incidentally matching `value_numeric = 0`). Added a regression test using a numeric property; confirmed it fails without the fix (`0` vs expected `1`, via `git stash`) and passes with it.
2. **Frontend sort bug.** Notes missing a given property column sorted as if their value were the numeric minimum (`0`), jumping them to the front on ascending sort regardless of the actual data. Caught live via a real multi-note browser test. Fixed so missing values always sort to the end regardless of direction.

## Test plan
- [x] `./scripts/jt.sh artisan test` — 107 passed (full backend suite, incl. new regression test)
- [x] `npx vue-tsc -b` clean
- [x] `npx vitest run` — 79/79 passing (new `CollectionsTableView.spec.ts` + new axe a11y case)
- [x] Manual Playwright check against dev server: created two notes with a numeric `priority` property, confirmed sort asc/desc order is correct, confirmed the property/value filter correctly narrows to the matching row (previously always returned zero), confirmed row click navigates to the note.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
