### PR TITLE
Fix #197: collections board/calendar views

### DIFF
--- a/app/Domain/Vault/MarkdownDocument.php
+++ b/app/Domain/Vault/MarkdownDocument.php
@@ -83,7 +83,12 @@ final class MarkdownDocument
         }
 
         try {
-            $parsed = Yaml::parse($yamlBlock);
+            // PARSE_DATETIME: without this flag, Symfony's YAML parser resolves bare
+            // ISO date/datetime scalars (the natural, unquoted way to write them) to a
+            // Unix timestamp int rather than a date value — indistinguishable from a
+            // plain numeric property downstream. Forcing DateTimeImmutable here lets
+            // NotePropertyProjector classify them correctly as NotePropertyType::DATETIME.
+            $parsed = Yaml::parse($yamlBlock, Yaml::PARSE_DATETIME);
         } catch (ParseException) {
             return [[], $normalized];
         }

--- a/app/Domain/Vault/NotePropertyProjector.php
+++ b/app/Domain/Vault/NotePropertyProjector.php
@@ -65,7 +65,10 @@ final class NotePropertyProjector
             'value_json' => null,
         ];
 
-        if (is_bool($value)) {
+        if ($value instanceof \DateTimeInterface) {
+            $result['type'] = NotePropertyType::DATETIME;
+            $result['value_datetime'] = $value->format('Y-m-d H:i:s');
+        } elseif (is_bool($value)) {
             $result['type'] = NotePropertyType::BOOLEAN;
             $result['value_boolean'] = $value;
         } elseif (is_int($value) || is_float($value)) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,6 +22,8 @@
       @toggle-link-report="handleToggleLinkReport"
       @publish-workspace="handlePublishWorkspace"
       @toggle-table-view="handleToggleTableView"
+      @toggle-board-view="handleToggleBoardView"
+      @toggle-calendar-view="handleToggleCalendarView"
     />
 
     <!-- Main Content Area -->
@@ -69,6 +71,28 @@
         @page-change="handleCollectionPageChange"
         @filter-change="handleCollectionFilterChange"
         @sort="handleCollectionSort"
+      />
+
+      <!-- Board (Collections) View Mode -->
+      <CollectionsBoardView
+        v-else-if="isBoardViewActive"
+        :page="collectionPage"
+        :loading="collectionLoading"
+        :group-property="collectionGroupProperty"
+        @select-note="handleSelectNote"
+        @page-change="handleCollectionPageChange"
+        @group-change="handleCollectionGroupChange"
+      />
+
+      <!-- Calendar (Collections) View Mode -->
+      <CollectionsCalendarView
+        v-else-if="isCalendarViewActive"
+        :page="collectionPage"
+        :loading="collectionLoading"
+        :date-property="collectionDateProperty"
+        @select-note="handleSelectNote"
+        @page-change="handleCollectionPageChange"
+        @date-property-change="handleCollectionDatePropertyChange"
       />
 
       <!-- Search View Mode -->
@@ -168,6 +192,8 @@ import AttachmentsPanel from './components/AttachmentsPanel.vue'
 import AuditLogViewer from './components/AuditLogViewer.vue'
 import LinkReportViewer from './components/LinkReportViewer.vue'
 import CollectionsTableView from './components/CollectionsTableView.vue'
+import CollectionsBoardView from './components/CollectionsBoardView.vue'
+import CollectionsCalendarView from './components/CollectionsCalendarView.vue'
 import {
   getWorkspaces,
   getNotes,
@@ -224,12 +250,16 @@ const linkReportLoading = ref(false)
 const notifications = ref<NotificationItem[]>([])
 
 const isTableViewActive = ref(false)
+const isBoardViewActive = ref(false)
+const isCalendarViewActive = ref(false)
 const collectionPage = ref<CollectionPage>({ data: [], current_page: 1, last_page: 1, per_page: 50, total: 0 })
 const collectionLoading = ref(false)
 const collectionFilterProperty = ref('')
 const collectionFilterValue = ref('')
 const collectionSortKey = ref<string | null>(null)
 const collectionSortDir = ref<'asc' | 'desc'>('asc')
+const collectionGroupProperty = ref<string | null>(null)
+const collectionDateProperty = ref<string | null>(null)
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -372,6 +402,8 @@ async function handleSelectNote(noteId: number) {
   isAuditLogActive.value = false
   isLinkReportActive.value = false
   isTableViewActive.value = false
+  isBoardViewActive.value = false
+  isCalendarViewActive.value = false
   await loadActiveNote(noteId)
 }
 
@@ -382,6 +414,8 @@ async function handleToggleAttachments() {
     isAuditLogActive.value = false
     isLinkReportActive.value = false
     isTableViewActive.value = false
+    isBoardViewActive.value = false
+    isCalendarViewActive.value = false
     await refreshAttachments()
   }
 }
@@ -393,6 +427,8 @@ async function handleToggleAuditLog() {
     isAttachmentsActive.value = false
     isLinkReportActive.value = false
     isTableViewActive.value = false
+    isBoardViewActive.value = false
+    isCalendarViewActive.value = false
     await refreshAuditLog()
   }
 }
@@ -404,6 +440,8 @@ async function handleToggleLinkReport() {
     isAttachmentsActive.value = false
     isAuditLogActive.value = false
     isTableViewActive.value = false
+    isBoardViewActive.value = false
+    isCalendarViewActive.value = false
     await refreshLinkReport()
   }
 }
@@ -415,6 +453,34 @@ async function handleToggleTableView() {
     isAttachmentsActive.value = false
     isAuditLogActive.value = false
     isLinkReportActive.value = false
+    isBoardViewActive.value = false
+    isCalendarViewActive.value = false
+    await refreshCollection()
+  }
+}
+
+async function handleToggleBoardView() {
+  isBoardViewActive.value = !isBoardViewActive.value
+  if (isBoardViewActive.value) {
+    isSearchActive.value = false
+    isAttachmentsActive.value = false
+    isAuditLogActive.value = false
+    isLinkReportActive.value = false
+    isTableViewActive.value = false
+    isCalendarViewActive.value = false
+    await refreshCollection()
+  }
+}
+
+async function handleToggleCalendarView() {
+  isCalendarViewActive.value = !isCalendarViewActive.value
+  if (isCalendarViewActive.value) {
+    isSearchActive.value = false
+    isAttachmentsActive.value = false
+    isAuditLogActive.value = false
+    isLinkReportActive.value = false
+    isTableViewActive.value = false
+    isBoardViewActive.value = false
     await refreshCollection()
   }
 }
@@ -452,6 +518,14 @@ function handleCollectionSort(key: string) {
     collectionSortKey.value = key
     collectionSortDir.value = 'asc'
   }
+}
+
+function handleCollectionGroupChange(property: string) {
+  collectionGroupProperty.value = property || null
+}
+
+function handleCollectionDatePropertyChange(property: string) {
+  collectionDateProperty.value = property || null
 }
 
 async function refreshLinkReport() {
@@ -628,6 +702,8 @@ async function handleSearch(query: string) {
   isAuditLogActive.value = false
   isLinkReportActive.value = false
   isTableViewActive.value = false
+  isBoardViewActive.value = false
+  isCalendarViewActive.value = false
   searchQuery.value = query
   await runSearch(query, searchFilters.value)
 }

--- a/frontend/src/CollectionsBoardView.spec.ts
+++ b/frontend/src/CollectionsBoardView.spec.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CollectionsBoardView from './components/CollectionsBoardView.vue'
+import type { CollectionPage } from './services/types'
+
+const emptyPage: CollectionPage = { data: [], current_page: 1, last_page: 1, per_page: 50, total: 0 }
+
+const page: CollectionPage = {
+  data: [
+    {
+      id: 1, path: 'a.md', title: 'A',
+      properties: [
+        { id: 1, note_id: 1, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
+      ]
+    },
+    {
+      id: 2, path: 'b.md', title: 'B',
+      properties: [
+        { id: 2, note_id: 2, name: 'status', type: 'string', value_string: 'done', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
+      ]
+    },
+    {
+      id: 3, path: 'c.md', title: 'C',
+      properties: []
+    }
+  ],
+  current_page: 1,
+  last_page: 1,
+  per_page: 50,
+  total: 3
+}
+
+describe('CollectionsBoardView', () => {
+  it('shows the empty state when there are no notes', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page: emptyPage } })
+    expect(wrapper.text()).toContain('No notes match this view.')
+  })
+
+  it('prompts for a group property when none is chosen', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page } })
+    expect(wrapper.text()).toContain('Choose a property above')
+  })
+
+  it('groups notes into columns by the chosen property, with a column for missing values', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    const columns = wrapper.findAll('[data-testid="board-column"]')
+    expect(columns).toHaveLength(3)
+    expect(wrapper.text()).toContain('draft')
+    expect(wrapper.text()).toContain('done')
+    expect(wrapper.text()).toContain('No value')
+  })
+
+  it('emits select-note when a card is clicked', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    await wrapper.findAll('[data-testid="board-card"]')[0].trigger('click')
+    expect(wrapper.emitted('select-note')).toBeTruthy()
+  })
+
+  it('emits group-change with the trimmed property name on submit', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page } })
+    await wrapper.get('[data-testid="board-group-property"]').setValue('  status  ')
+    await wrapper.get('.group-bar').trigger('submit')
+    expect(wrapper.emitted('group-change')![0]).toEqual(['status'])
+  })
+
+  it('shows pagination controls only when there is more than one page', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    expect(wrapper.find('[data-testid="collection-next-page"]').exists()).toBe(false)
+
+    const multiPage = { ...page, last_page: 3 }
+    const wrapper2 = mount(CollectionsBoardView, { props: { page: multiPage, groupProperty: 'status' } })
+    expect(wrapper2.find('[data-testid="collection-next-page"]').exists()).toBe(true)
+  })
+
+  it('emits page-change when next is clicked', async () => {
+    const multiPage = { ...page, last_page: 3, current_page: 1 }
+    const wrapper = mount(CollectionsBoardView, { props: { page: multiPage, groupProperty: 'status' } })
+    await wrapper.get('[data-testid="collection-next-page"]').trigger('click')
+    expect(wrapper.emitted('page-change')![0]).toEqual([2])
+  })
+})

--- a/frontend/src/CollectionsCalendarView.spec.ts
+++ b/frontend/src/CollectionsCalendarView.spec.ts
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CollectionsCalendarView from './components/CollectionsCalendarView.vue'
+import type { CollectionPage } from './services/types'
+
+const emptyPage: CollectionPage = { data: [], current_page: 1, last_page: 1, per_page: 50, total: 0 }
+
+const page: CollectionPage = {
+  data: [
+    {
+      id: 1, path: 'a.md', title: 'A',
+      properties: [
+        { id: 1, note_id: 1, name: 'due_date', type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: '2026-08-01T00:00:00Z', value_json: null }
+      ]
+    },
+    {
+      id: 2, path: 'b.md', title: 'B',
+      properties: [
+        { id: 2, note_id: 2, name: 'due_date', type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: '2026-08-01T09:00:00Z', value_json: null }
+      ]
+    },
+    {
+      id: 3, path: 'c.md', title: 'C',
+      properties: [
+        { id: 3, note_id: 3, name: 'due_date', type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: '2026-08-03T00:00:00Z', value_json: null }
+      ]
+    },
+    {
+      id: 4, path: 'd.md', title: 'D',
+      properties: []
+    }
+  ],
+  current_page: 1,
+  last_page: 1,
+  per_page: 50,
+  total: 4
+}
+
+describe('CollectionsCalendarView', () => {
+  it('shows the empty state when there are no notes', () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page: emptyPage } })
+    expect(wrapper.text()).toContain('No notes match this view.')
+  })
+
+  it('prompts for a date property when none is chosen', () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page } })
+    expect(wrapper.text()).toContain('Choose a datetime property above')
+  })
+
+  it('groups notes by day for the chosen property, in date order, with a "No date" bucket', () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page, dateProperty: 'due_date' } })
+    const days = wrapper.findAll('[data-testid="calendar-day"]')
+    expect(days).toHaveLength(3)
+    expect(days[0].text()).toContain('2026-08-01')
+    expect(days[1].text()).toContain('2026-08-03')
+    expect(days[2].text()).toContain('No date')
+  })
+
+  it('emits select-note when a card is clicked', async () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page, dateProperty: 'due_date' } })
+    await wrapper.findAll('[data-testid="calendar-card"]')[0].trigger('click')
+    expect(wrapper.emitted('select-note')).toBeTruthy()
+  })
+
+  it('emits date-property-change with the trimmed property name on submit', async () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page } })
+    await wrapper.get('[data-testid="calendar-date-property"]').setValue('  due_date  ')
+    await wrapper.get('.group-bar').trigger('submit')
+    expect(wrapper.emitted('date-property-change')![0]).toEqual(['due_date'])
+  })
+
+  it('shows pagination controls only when there is more than one page', () => {
+    const wrapper = mount(CollectionsCalendarView, { props: { page, dateProperty: 'due_date' } })
+    expect(wrapper.find('[data-testid="collection-next-page"]').exists()).toBe(false)
+
+    const multiPage = { ...page, last_page: 3 }
+    const wrapper2 = mount(CollectionsCalendarView, { props: { page: multiPage, dateProperty: 'due_date' } })
+    expect(wrapper2.find('[data-testid="collection-next-page"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -14,6 +14,8 @@ import CommentsPanel from './components/CommentsPanel.vue'
 import AuditLogViewer from './components/AuditLogViewer.vue'
 import LinkReportViewer from './components/LinkReportViewer.vue'
 import CollectionsTableView from './components/CollectionsTableView.vue'
+import CollectionsBoardView from './components/CollectionsBoardView.vue'
+import CollectionsCalendarView from './components/CollectionsCalendarView.vue'
 
 /*
  * Accessibility Audit Spec (Issue #109 / Spec §10 / WCAG 2.2 AA)
@@ -283,6 +285,58 @@ describe('Accessibility Audit (axe-core)', () => {
           per_page: 50,
           total: 51,
         },
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('CollectionsBoardView has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(CollectionsBoardView, {
+      attachTo: document.body,
+      props: {
+        page: {
+          data: [
+            { id: 1, path: 'a.md', title: 'A', properties: [{ id: 1, note_id: 1, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }] },
+          ],
+          current_page: 1,
+          last_page: 2,
+          per_page: 50,
+          total: 51,
+        },
+        groupProperty: 'status',
+      },
+    })
+    const results = await axe.run(wrapper.element, {
+      rules: {
+        'color-contrast': { enabled: false },
+      },
+    })
+    wrapper.unmount()
+    const seriousOrCritical = results.violations.filter(v => ['serious', 'critical'].includes(v.impact || ''))
+    expect(seriousOrCritical).toEqual([])
+  })
+
+  it('CollectionsCalendarView has no serious or critical structural accessibility violations', async () => {
+    const wrapper = mount(CollectionsCalendarView, {
+      attachTo: document.body,
+      props: {
+        page: {
+          data: [
+            { id: 1, path: 'a.md', title: 'A', properties: [{ id: 1, note_id: 1, name: 'due_date', type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: '2026-08-01T00:00:00Z', value_json: null }] },
+          ],
+          current_page: 1,
+          last_page: 2,
+          per_page: 50,
+          total: 51,
+        },
+        dateProperty: 'due_date',
       },
     })
     const results = await axe.run(wrapper.element, {

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -1,0 +1,305 @@
+<template>
+  <div class="collections-board-view">
+    <div class="panel-header">
+      <h2>Board View</h2>
+      <span class="count-badge">{{ page.total }}</span>
+    </div>
+    <p class="panel-hint">Notes grouped by a property, arranged as columns.</p>
+
+    <form class="group-bar" @submit.prevent="applyGroupProperty">
+      <input
+        v-model="groupPropertyInput"
+        type="text"
+        placeholder="Property to group by (e.g. status)"
+        aria-label="Group by property name"
+        data-testid="board-group-property"
+        class="group-input"
+        :list="'board-property-options'"
+      />
+      <datalist id="board-property-options">
+        <option v-for="col in propertyColumns" :key="col" :value="col" />
+      </datalist>
+      <button type="submit" class="btn-group-apply" data-testid="board-group-apply">Group</button>
+    </form>
+
+    <div v-if="loading" class="panel-empty">
+      <p>Loading notes…</p>
+    </div>
+
+    <div v-else-if="page.data.length === 0" class="panel-empty">
+      <p>No notes match this view.</p>
+    </div>
+
+    <div v-else-if="!groupProperty" class="panel-empty">
+      <p>Choose a property above to group notes into columns.</p>
+    </div>
+
+    <div v-else class="board-scroll">
+      <div v-for="column in columns" :key="column.key" class="board-column" data-testid="board-column">
+        <div class="board-column-header">
+          <span class="board-column-title">{{ column.label }}</span>
+          <span class="count-badge">{{ column.notes.length }}</span>
+        </div>
+        <div class="board-column-body">
+          <button
+            v-for="note in column.notes"
+            :key="note.id"
+            type="button"
+            class="board-card"
+            data-testid="board-card"
+            @click="$emit('select-note', note.id)"
+          >
+            <span class="board-card-title">{{ note.title || note.path }}</span>
+            <span class="board-card-path">{{ note.path }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="page.last_page > 1" class="pagination-bar">
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-prev-page"
+        :disabled="page.current_page <= 1"
+        @click="$emit('page-change', page.current_page - 1)"
+      >
+        Previous
+      </button>
+      <span class="page-indicator">Page {{ page.current_page }} of {{ page.last_page }}</span>
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-next-page"
+        :disabled="page.current_page >= page.last_page"
+        @click="$emit('page-change', page.current_page + 1)"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { CollectionPage } from '../services/types'
+import { formatPropertyValue, propertyColumns as computePropertyColumns } from '../services/collectionUtils'
+
+const props = defineProps<{
+  page: CollectionPage
+  loading?: boolean
+  groupProperty?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'page-change', page: number): void
+  (e: 'group-change', property: string): void
+}>()
+
+const groupPropertyInput = ref(props.groupProperty || '')
+
+watch(() => props.groupProperty, (value) => {
+  groupPropertyInput.value = value || ''
+})
+
+function applyGroupProperty() {
+  emit('group-change', groupPropertyInput.value.trim())
+}
+
+const propertyColumns = computed(() => computePropertyColumns(props.page))
+
+const UNGROUPED_LABEL = 'No value'
+
+const columns = computed(() => {
+  if (!props.groupProperty) return []
+  const groups = new Map<string, typeof props.page.data>()
+  for (const note of props.page.data) {
+    const label = formatPropertyValue(note, props.groupProperty)
+    const key = label === '—' ? UNGROUPED_LABEL : label
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(note)
+  }
+  const sortedKeys = Array.from(groups.keys()).sort((a, b) => {
+    if (a === UNGROUPED_LABEL) return 1
+    if (b === UNGROUPED_LABEL) return -1
+    return a.localeCompare(b)
+  })
+  return sortedKeys.map(key => ({ key, label: key, notes: groups.get(key)! }))
+})
+</script>
+
+<style scoped>
+.collections-board-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.panel-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.panel-hint {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+
+.group-bar {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.group-input {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+  min-width: 220px;
+}
+
+.btn-group-apply,
+.btn-page {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-group-apply:hover,
+.btn-page:hover:not(:disabled) {
+  background: var(--color-action-hover);
+}
+
+.btn-page:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.panel-empty {
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
+}
+
+.board-scroll {
+  display: flex;
+  gap: var(--space-4);
+  overflow-x: auto;
+  flex: 1;
+  align-items: flex-start;
+  padding-bottom: var(--space-2);
+}
+
+.board-column {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  min-width: 240px;
+  max-width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+}
+
+.board-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.board-column-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-column-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  overflow-y: auto;
+}
+
+.board-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.board-card:hover {
+  background: var(--color-surface-emphasis);
+}
+
+.board-card-title {
+  font-weight: 500;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+}
+
+.board-card-path {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+}
+
+.pagination-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.page-indicator {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/components/CollectionsCalendarView.vue
+++ b/frontend/src/components/CollectionsCalendarView.vue
@@ -1,0 +1,304 @@
+<template>
+  <div class="collections-calendar-view">
+    <div class="panel-header">
+      <h2>Calendar View</h2>
+      <span class="count-badge">{{ page.total }}</span>
+    </div>
+    <p class="panel-hint">Notes grouped by a datetime property, in date order.</p>
+
+    <form class="group-bar" @submit.prevent="applyDateProperty">
+      <input
+        v-model="datePropertyInput"
+        type="text"
+        placeholder="Datetime property (e.g. due_date)"
+        aria-label="Group by datetime property"
+        data-testid="calendar-date-property"
+        class="group-input"
+        :list="'calendar-property-options'"
+      />
+      <datalist id="calendar-property-options">
+        <option v-for="col in propertyColumns" :key="col" :value="col" />
+      </datalist>
+      <button type="submit" class="btn-group-apply" data-testid="calendar-date-apply">Group</button>
+    </form>
+
+    <div v-if="loading" class="panel-empty">
+      <p>Loading notes…</p>
+    </div>
+
+    <div v-else-if="page.data.length === 0" class="panel-empty">
+      <p>No notes match this view.</p>
+    </div>
+
+    <div v-else-if="!dateProperty" class="panel-empty">
+      <p>Choose a datetime property above to lay notes out by date.</p>
+    </div>
+
+    <div v-else class="calendar-scroll">
+      <div v-for="day in days" :key="day.key" class="calendar-day" data-testid="calendar-day">
+        <div class="calendar-day-header">
+          <span class="calendar-day-title">{{ day.label }}</span>
+          <span class="count-badge">{{ day.notes.length }}</span>
+        </div>
+        <div class="calendar-day-body">
+          <button
+            v-for="note in day.notes"
+            :key="note.id"
+            type="button"
+            class="calendar-card"
+            data-testid="calendar-card"
+            @click="$emit('select-note', note.id)"
+          >
+            <span class="calendar-card-title">{{ note.title || note.path }}</span>
+            <span class="calendar-card-path">{{ note.path }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="page.last_page > 1" class="pagination-bar">
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-prev-page"
+        :disabled="page.current_page <= 1"
+        @click="$emit('page-change', page.current_page - 1)"
+      >
+        Previous
+      </button>
+      <span class="page-indicator">Page {{ page.current_page }} of {{ page.last_page }}</span>
+      <button
+        type="button"
+        class="btn-page"
+        data-testid="collection-next-page"
+        :disabled="page.current_page >= page.last_page"
+        @click="$emit('page-change', page.current_page + 1)"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { CollectionNote, CollectionPage } from '../services/types'
+import { findProperty, rawValue, propertyColumns as computePropertyColumns } from '../services/collectionUtils'
+
+const props = defineProps<{
+  page: CollectionPage
+  loading?: boolean
+  dateProperty?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'page-change', page: number): void
+  (e: 'date-property-change', property: string): void
+}>()
+
+const datePropertyInput = ref(props.dateProperty || '')
+
+watch(() => props.dateProperty, (value) => {
+  datePropertyInput.value = value || ''
+})
+
+function applyDateProperty() {
+  emit('date-property-change', datePropertyInput.value.trim())
+}
+
+const propertyColumns = computed(() => computePropertyColumns(props.page))
+
+const NO_DATE_LABEL = 'No date'
+
+function dayKeyFor(note: CollectionNote, propertyName: string): string {
+  const prop = findProperty(note, propertyName)
+  if (!prop) return NO_DATE_LABEL
+  const value = rawValue(prop)
+  if (typeof value !== 'string') return NO_DATE_LABEL
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return NO_DATE_LABEL
+  return parsed.toISOString().slice(0, 10)
+}
+
+const days = computed(() => {
+  if (!props.dateProperty) return []
+  const groups = new Map<string, CollectionNote[]>()
+  for (const note of props.page.data) {
+    const key = dayKeyFor(note, props.dateProperty)
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(note)
+  }
+  const sortedKeys = Array.from(groups.keys()).sort((a, b) => {
+    if (a === NO_DATE_LABEL) return 1
+    if (b === NO_DATE_LABEL) return -1
+    return a.localeCompare(b)
+  })
+  return sortedKeys.map(key => ({
+    key,
+    label: key === NO_DATE_LABEL ? NO_DATE_LABEL : key,
+    notes: groups.get(key)!
+  }))
+})
+</script>
+
+<style scoped>
+.collections-calendar-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.panel-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.panel-hint {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+
+.group-bar {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.group-input {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+  min-width: 220px;
+}
+
+.btn-group-apply,
+.btn-page {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-group-apply:hover,
+.btn-page:hover:not(:disabled) {
+  background: var(--color-action-hover);
+}
+
+.btn-page:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.panel-empty {
+  color: var(--color-text-muted);
+  padding: var(--space-8) 0;
+}
+
+.calendar-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.calendar-day {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.calendar-day-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.calendar-day-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+}
+
+.calendar-day-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.calendar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.calendar-card:hover {
+  background: var(--color-surface-emphasis);
+}
+
+.calendar-card-title {
+  font-weight: 500;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+}
+
+.calendar-card-path {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+}
+
+.pagination-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.page-indicator {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/components/CollectionsTableView.vue
+++ b/frontend/src/components/CollectionsTableView.vue
@@ -102,7 +102,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import type { CollectionPage, CollectionNote, RawNoteProperty } from '../services/types'
+import type { CollectionPage, CollectionNote } from '../services/types'
+import { rawValue, formatPropertyValue, propertyColumns as computePropertyColumns } from '../services/collectionUtils'
 
 const props = defineProps<{
   page: CollectionPage
@@ -127,34 +128,7 @@ function clearFilter() {
   emit('filter-change', '', '')
 }
 
-const propertyColumns = computed(() => {
-  const names = new Set<string>()
-  for (const note of props.page.data) {
-    for (const prop of note.properties) names.add(prop.name)
-  }
-  return Array.from(names).sort()
-})
-
-function rawValue(prop: RawNoteProperty): string | number | boolean | unknown | null {
-  switch (prop.type) {
-    case 'numeric': return prop.value_numeric
-    case 'boolean': return prop.value_boolean
-    case 'datetime': return prop.value_datetime
-    case 'list':
-    case 'json': return prop.value_json
-    default: return prop.value_string
-  }
-}
-
-function formatPropertyValue(note: CollectionNote, column: string): string {
-  const prop = note.properties.find(p => p.name === column)
-  if (!prop) return '—'
-  const value = rawValue(prop)
-  if (value === null || value === undefined) return '—'
-  if (Array.isArray(value)) return value.join(', ')
-  if (typeof value === 'object') return JSON.stringify(value)
-  return String(value)
-}
+const propertyColumns = computed(() => computePropertyColumns(props.page))
 
 function sortableValue(note: CollectionNote, key: string): string | number | null {
   if (key === 'title') return (note.title || note.path).toLowerCase()

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -181,6 +181,32 @@
               </svg>
               <span>Table View</span>
             </button>
+            <button
+              class="more-menu-item"
+              data-testid="board-view-btn"
+              role="menuitem"
+              @click="closeMoreMenuAnd(() => $emit('toggle-board-view'))"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="3" width="7" height="18" rx="1"></rect>
+                <rect x="14" y="3" width="7" height="10" rx="1"></rect>
+              </svg>
+              <span>Board View</span>
+            </button>
+            <button
+              class="more-menu-item"
+              data-testid="calendar-view-btn"
+              role="menuitem"
+              @click="closeMoreMenuAnd(() => $emit('toggle-calendar-view'))"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                <line x1="16" y1="2" x2="16" y2="6"></line>
+                <line x1="8" y1="2" x2="8" y2="6"></line>
+                <line x1="3" y1="10" x2="21" y2="10"></line>
+              </svg>
+              <span>Calendar View</span>
+            </button>
           </div>
         </div>
         <button class="btn-icon" data-testid="new-note-btn" title="New Note" @click="showNewNoteModal = true">
@@ -370,6 +396,8 @@ const emit = defineEmits<{
   (e: 'toggle-link-report'): void
   (e: 'publish-workspace'): void
   (e: 'toggle-table-view'): void
+  (e: 'toggle-board-view'): void
+  (e: 'toggle-calendar-view'): void
 }>()
 
 const searchQuery = ref('')

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -1,0 +1,34 @@
+import type { CollectionNote, CollectionPage, RawNoteProperty } from './types'
+
+export function rawValue(prop: RawNoteProperty): string | number | boolean | unknown | null {
+  switch (prop.type) {
+    case 'numeric': return prop.value_numeric
+    case 'boolean': return prop.value_boolean
+    case 'datetime': return prop.value_datetime
+    case 'list':
+    case 'json': return prop.value_json
+    default: return prop.value_string
+  }
+}
+
+export function findProperty(note: CollectionNote, name: string): RawNoteProperty | undefined {
+  return note.properties.find(p => p.name === name)
+}
+
+export function formatPropertyValue(note: CollectionNote, column: string): string {
+  const prop = findProperty(note, column)
+  if (!prop) return '—'
+  const value = rawValue(prop)
+  if (value === null || value === undefined) return '—'
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+export function propertyColumns(page: CollectionPage): string[] {
+  const names = new Set<string>()
+  for (const note of page.data) {
+    for (const prop of note.properties) names.add(prop.name)
+  }
+  return Array.from(names).sort()
+}

--- a/tests/Feature/NotePropertyProjectionTest.php
+++ b/tests/Feature/NotePropertyProjectionTest.php
@@ -91,4 +91,41 @@ MARKDOWN;
             $this->assertEquals($row['value_boolean'], $afterState[$index]['value_boolean']);
         }
     }
+
+    public function test_unquoted_yaml_date_is_projected_as_datetime_not_numeric(): void
+    {
+        // Regression: the previous test only ever wrote due_date as a *quoted*
+        // YAML string ("2026-12-31"), which coincidentally masked this bug —
+        // quoting suppresses YAML's core-schema timestamp detection, so it
+        // reached NotePropertyProjector as a plain string. The natural,
+        // unquoted way to write a YAML date (due_date: 2026-12-31, with no
+        // quotes) is resolved by Symfony's YAML parser to a Unix timestamp
+        // int unless Yaml::PARSE_DATETIME is passed, which the projector then
+        // classified as NUMERIC instead of DATETIME.
+        $tenant = Tenant::create(['slug' => 'unquoted-date', 'name' => 'Unquoted Date']);
+        $vaultPath = storage_path('app/vaults/prop_unquoted_'.uniqid());
+        @mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'unquoted-date',
+            'name' => 'Unquoted Date Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        $storage = new VaultStorage();
+        $note = $storage->write($workspace, 'unquoted.md', <<<'MARKDOWN'
+---
+due_date: 2026-12-31
+---
+# Unquoted Date Note
+MARKDOWN);
+
+        $this->assertDatabaseHas('note_properties', [
+            'note_id' => $note->id,
+            'name' => 'due_date',
+            'type' => 'datetime',
+            'value_datetime' => '2026-12-31 00:00:00',
+        ]);
+    }
 }


### PR DESCRIPTION
Closes #197.

Adds the two remaining collection views from #161's original scope, building on the `GET .../collections` endpoint and `CollectionsTableView.vue` patterns from PR #196:

- **Board view** (`CollectionsBoardView.vue`): groups notes into kanban-style columns by a chosen property (typed values formatted the same way as the table view; notes missing the property go in a "No value" column). Reachable from the sidebar's More-actions menu ("Board View").
- **Calendar view** (`CollectionsCalendarView.vue`): groups notes into date buckets (agenda-style, sorted chronologically) by a chosen datetime property, with a "No date" bucket for notes missing it. The collections endpoint only supports equality filters, not date ranges, so a true month-grid calendar isn't feasible without a new endpoint — this is the minimal-viable slice. Reachable via "Calendar View" in the same menu.
- Extracted the property-column/value-formatting logic shared across all three collection views (table/board/calendar) into `frontend/src/services/collectionUtils.ts`, and refactored `CollectionsTableView.vue` to use it instead of duplicating it a third time.

**Real bug found and fixed while verifying live:** Symfony's YAML parser resolves a bare (unquoted) ISO date scalar — e.g. `due_date: 2026-08-01`, the natural way to write a YAML date — to a Unix timestamp `int`, not a string, unless `Yaml::PARSE_DATETIME` is passed. `NotePropertyProjector::inferTypeAndValues()` only checked `is_string()` for its datetime branch, so every unquoted date property was silently misclassified as `NUMERIC` with a timestamp value instead of `DATETIME`. This broke the new calendar view (nothing ever grouped by date) and would have equally broken date-based sorting/filtering in the table view and #161's collections filter. The existing `NotePropertyProjectionTest` only ever exercised a *quoted* date string, which coincidentally suppressed YAML's timestamp detection and masked this. Fixed by parsing front-matter with `Yaml::PARSE_DATETIME` and handling `DateTimeInterface` explicitly in the projector. Added `test_unquoted_yaml_date_is_projected_as_datetime_not_numeric`, confirmed to fail without the fix (`git stash` before/after).

## Test plan
- `vue-tsc -b` — clean
- `npx vitest run` — 94/94 passing (15 new: 7 board + 7 calendar unit tests, 2 a11y axe checks)
- `./scripts/jt.sh artisan test` — 108/108 passing (1 new regression test, confirmed fails without the fix)
- `npm run build` — clean
- Manual Playwright run against the dev server: created notes with `status`/`due_date` frontmatter, grouped the board view by `status` (2 correct columns), grouped the calendar view by `due_date` (correct day buckets + "No date" bucket), clicked into a note from each view.