### PR TITLE
fix: exclude .excalidraw.md files from vault indexing

### DIFF
--- a/app/Domain/Vault/VaultReindexer.php
+++ b/app/Domain/Vault/VaultReindexer.php
@@ -83,8 +83,14 @@ final class VaultReindexer
                 continue;
             }
 
-            $name = $file->getFilename();
-            if (! str_ends_with(strtolower($name), '.md')) {
+            $name = strtolower($file->getFilename());
+            if (! str_ends_with($name, '.md')) {
+                continue;
+            }
+
+            // Excalidraw diagrams are stored as `*.excalidraw.md` (JSON payload,
+            // not readable Markdown). Never index them as notes; leave on disk.
+            if (str_ends_with($name, '.excalidraw.md')) {
                 continue;
             }
 

--- a/tests/Feature/VaultReindexerTest.php
+++ b/tests/Feature/VaultReindexerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultReindexer;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class VaultReindexerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reindex_excludes_excalidraw_md_files_from_notes(): void
+    {
+        $tenant = Tenant::create(['slug' => 'test', 'name' => 'Test']);
+
+        $vaultPath = storage_path('app/vaults/excalidraw_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'main',
+            'name' => 'Main Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        file_put_contents($vaultPath.'/regular.md', "# Regular note\n\nBody text.");
+        file_put_contents($vaultPath.'/diagram.excalidraw.md', json_encode(['type' => 'excalidraw', 'elements' => []]));
+
+        /** @var VaultReindexer $reindexer */
+        $reindexer = $this->app->make(VaultReindexer::class);
+        $result = $reindexer->reindex($workspace);
+
+        $this->assertSame(1, $result['scanned']);
+        $this->assertSame(1, $result['upserted']);
+        $this->assertDatabaseHas('notes', [
+            'workspace_id' => $workspace->id,
+            'path' => 'regular.md',
+        ]);
+        $this->assertDatabaseMissing('notes', [
+            'workspace_id' => $workspace->id,
+            'path' => 'diagram.excalidraw.md',
+        ]);
+        $this->assertSame(1, Note::query()->where('workspace_id', $workspace->id)->count());
+
+        // The file itself must be preserved on disk, never deleted by reindex.
+        $this->assertFileExists($vaultPath.'/diagram.excalidraw.md');
+    }
+}


### PR DESCRIPTION
## Summary
- `VaultReindexer::iterateMarkdownFiles()` yielded any file ending in `.md`, so Excalidraw diagram files (`*.excalidraw.md`, JSON payload) were indexed as regular notes -- corrupted search, backlinks, and the SPA note list
- Skip `*.excalidraw.md` during reindex; file stays on disk untouched (per spec §1, disk is source of truth -- this is exclusion from indexing, not deletion)

Fixes #203

## Test plan
- [x] Added `tests/Feature/VaultReindexerTest.php::test_reindex_excludes_excalidraw_md_files_from_notes` (failed before the fix -- 2 files indexed instead of 1 -- passes after)
- [x] Full suite green: `./scripts/jt.sh test` -- 111 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)