### PR TITLE
feat: resolve wikilinks via front-matter aliases

### DIFF
--- a/app/Domain/Links/WikilinkProjector.php
+++ b/app/Domain/Links/WikilinkProjector.php
@@ -41,7 +41,7 @@ final class WikilinkProjector
     {
         $notes = Note::query()
             ->where('workspace_id', $workspace->id)
-            ->get(['id', 'path', 'title']);
+            ->get(['id', 'path', 'title', 'frontmatter']);
 
         if ($notes->isEmpty()) {
             return;
@@ -49,6 +49,7 @@ final class WikilinkProjector
 
         $pathCandidates = [];
         $titleCandidates = [];
+        $aliasCandidates = [];
 
         foreach ($notes as $note) {
             foreach ($this->pathKeys((string) $note->path) as $key) {
@@ -61,15 +62,20 @@ final class WikilinkProjector
                 $lowerTitle = mb_strtolower($title, 'UTF-8');
                 $titleCandidates[$lowerTitle][] = $note->id;
             }
+
+            foreach ($this->extractAliases($note->frontmatter) as $alias) {
+                $lowerAlias = mb_strtolower($alias, 'UTF-8');
+                $aliasCandidates[$lowerAlias][] = $note->id;
+            }
         }
 
         NoteLink::query()
             ->where('type', self::TYPE)
             ->whereIn('source_note_id', $notes->pluck('id'))
             ->orderBy('id')
-            ->each(function (NoteLink $link) use ($pathCandidates, $titleCandidates): void {
+            ->each(function (NoteLink $link) use ($pathCandidates, $titleCandidates, $aliasCandidates): void {
                 $targetKey = mb_strtolower($this->extractor->targetKey($link->target_ref), 'UTF-8');
-                $candidates = $pathCandidates[$targetKey] ?? $titleCandidates[$targetKey] ?? [];
+                $candidates = $pathCandidates[$targetKey] ?? $titleCandidates[$targetKey] ?? $aliasCandidates[$targetKey] ?? [];
                 $candidateIds = array_values(array_unique($candidates));
                 $targetNoteId = count($candidateIds) === 1 ? $candidateIds[0] : null;
 
@@ -77,6 +83,43 @@ final class WikilinkProjector
                     $link->update(['target_note_id' => $targetNoteId]);
                 }
             });
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $frontmatter
+     * @return list<string>
+     */
+    private function extractAliases(?array $frontmatter): array
+    {
+        if ($frontmatter === null || ! array_key_exists('aliases', $frontmatter)) {
+            return [];
+        }
+
+        $raw = $frontmatter['aliases'];
+        $aliases = [];
+
+        if (is_string($raw)) {
+            foreach (preg_split('/\s*,\s*/', $raw) ?: [] as $part) {
+                $aliases[] = $part;
+            }
+        } elseif (is_array($raw)) {
+            foreach ($raw as $part) {
+                if (is_string($part) || is_numeric($part)) {
+                    $aliases[] = (string) $part;
+                }
+            }
+        }
+
+        $normalized = [];
+        foreach ($aliases as $alias) {
+            $alias = trim($alias);
+            if ($alias === '') {
+                continue;
+            }
+            $normalized[$alias] = $alias;
+        }
+
+        return array_values($normalized);
     }
 
     /**

--- a/tests/Feature/WikilinkProjectionTest.php
+++ b/tests/Feature/WikilinkProjectionTest.php
@@ -80,6 +80,35 @@ class WikilinkProjectionTest extends TestCase
         $this->assertSame($target->id, $source->outgoingLinks()->sole()->fresh()->target_note_id);
     }
 
+    public function test_wikilink_resolves_via_frontmatter_alias(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'research.md', "---\naliases: [research, study]\n---\n# Research\n");
+        $source = $storage->write($workspace, 'current.md', "See [[research]] and [[study]].\n");
+
+        $links = $source->outgoingLinks()->where('type', 'wikilink')->get();
+        $this->assertCount(2, $links);
+        $this->assertSame([$target->id, $target->id], $links->pluck('target_note_id')->all());
+
+        $this->assertSame(
+            [$source->id],
+            $target->incomingLinks()->where('type', 'wikilink')->pluck('source_note_id')->unique()->all(),
+        );
+    }
+
+    public function test_alias_resolution_accepts_comma_separated_string_form(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'glossary.md', "---\naliases: \"Glossary, Terms\"\n---\n# Glossary\n");
+        $source = $storage->write($workspace, 'current.md', "[[Terms]]\n");
+
+        $this->assertSame($target->id, $source->outgoingLinks()->sole()->target_note_id);
+    }
+
     private function makeWorkspace(): Workspace
     {
         $tenant = Tenant::query()->create([


### PR DESCRIPTION
## Summary
- `WikilinkProjector::resolveWorkspaceLinks()` only matched targets by note path or title, so `[[alias]]` links to a note with `aliases: [alias, ...]` in front-matter stayed unresolved -- inflating the broken-link report with false positives
- Aliases are read from the note's existing `frontmatter` JSON column (no migration needed) and merged into the same lowercase candidate map used for path/title resolution -- alias links resolve, and backlinks-by-alias work automatically since they share the resolution path
- Supports both YAML list form (`aliases: [a, b]`) and comma-separated string form (`aliases: "a, b"`), mirroring the existing `tags:` parsing convention in `MarkdownDocument`

Fixes #204

## Test plan
- [x] Added `test_wikilink_resolves_via_frontmatter_alias` and `test_alias_resolution_accepts_comma_separated_string_form` to `tests/Feature/WikilinkProjectionTest.php` (both failed before the fix, pass after)
- [x] Full suite green: `./scripts/jt.sh test` -- 113 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)