### PR TITLE
feat: support block references (^block-id, [[note#^block]])

### DIFF
--- a/app/Domain/Links/WikilinkExtractor.php
+++ b/app/Domain/Links/WikilinkExtractor.php
@@ -8,7 +8,7 @@ namespace App\Domain\Links;
 final class WikilinkExtractor
 {
     /**
-     * @return list<array{target_ref: string, target_key: string}>
+     * @return list<array{target_ref: string, target_key: string, target_block: ?string}>
      */
     public function extract(string $body): array
     {
@@ -25,6 +25,7 @@ final class WikilinkExtractor
             $references[$targetRef] = [
                 'target_ref' => $targetRef,
                 'target_key' => $targetKey,
+                'target_block' => $this->targetBlock($targetRef),
             ];
         }
 
@@ -36,5 +37,29 @@ final class WikilinkExtractor
         $target = trim(explode('|', $targetRef, 2)[0]);
 
         return trim(explode('#', $target, 2)[0]);
+    }
+
+    /**
+     * A fragment introduced with `^` (e.g. `[[note#^myblock]]`) is a block
+     * reference, distinct from a `#heading` anchor. Returns the block id
+     * without its leading `^`, or null when the reference is not a block ref.
+     */
+    public function targetBlock(string $targetRef): ?string
+    {
+        $target = trim(explode('|', $targetRef, 2)[0]);
+        $parts = explode('#', $target, 2);
+
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $fragment = trim($parts[1]);
+        if (! str_starts_with($fragment, '^')) {
+            return null;
+        }
+
+        $blockId = trim(substr($fragment, 1));
+
+        return $blockId === '' ? null : $blockId;
     }
 }

--- a/app/Domain/Links/WikilinkProjector.php
+++ b/app/Domain/Links/WikilinkProjector.php
@@ -25,6 +25,7 @@ final class WikilinkProjector
             NoteLink::query()->create([
                 'source_note_id' => $sourceNote->id,
                 'target_ref' => $reference['target_ref'],
+                'target_block' => $reference['target_block'],
                 'target_note_id' => null,
                 'type' => self::TYPE,
             ]);

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -40,6 +40,11 @@ class Note extends Model
         return $this->hasMany(NoteLink::class, 'target_note_id');
     }
 
+    public function incomingBlockReferences(string $blockId): HasMany
+    {
+        return $this->incomingLinks()->where('target_block', $blockId);
+    }
+
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany(Tag::class, 'note_tags');

--- a/app/Models/NoteLink.php
+++ b/app/Models/NoteLink.php
@@ -10,6 +10,7 @@ class NoteLink extends Model
     protected $fillable = [
         'source_note_id',
         'target_ref',
+        'target_block',
         'target_note_id',
         'type',
     ];

--- a/database/migrations/2026_07_29_000001_add_target_block_to_note_links_table.php
+++ b/database/migrations/2026_07_29_000001_add_target_block_to_note_links_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('note_links', 'target_block')) {
+            Schema::table('note_links', function (Blueprint $table) {
+                $table->string('target_block', 255)->nullable()->after('target_ref');
+                $table->index(['target_note_id', 'target_block'], 'note_links_target_block_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('note_links', 'target_block')) {
+            Schema::table('note_links', function (Blueprint $table) {
+                $table->dropIndex('note_links_target_block_index');
+                $table->dropColumn('target_block');
+            });
+        }
+    }
+};

--- a/tests/Feature/WikilinkProjectionTest.php
+++ b/tests/Feature/WikilinkProjectionTest.php
@@ -109,6 +109,37 @@ class WikilinkProjectionTest extends TestCase
         $this->assertSame($target->id, $source->outgoingLinks()->sole()->target_note_id);
     }
 
+    public function test_block_reference_is_persisted_and_queryable_via_backlinks(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'note.md', "Paragraph text\n^myblock\n\nAnother paragraph.\n");
+        $source = $storage->write($workspace, 'current.md', "See [[note#^myblock]] for details.\n");
+
+        $link = $source->outgoingLinks()->where('type', 'wikilink')->sole();
+        $this->assertSame('myblock', $link->target_block);
+        $this->assertSame($target->id, $link->target_note_id);
+
+        $blockBacklinks = $target->incomingBlockReferences('myblock');
+        $this->assertSame([$source->id], $blockBacklinks->pluck('source_note_id')->all());
+
+        $this->assertSame(0, $target->incomingBlockReferences('other-block')->count());
+    }
+
+    public function test_heading_fragment_is_not_treated_as_a_block_reference(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'note.md', "# Heading\n\nBody.\n");
+        $source = $storage->write($workspace, 'current.md', "[[note#Heading]]\n");
+
+        $link = $source->outgoingLinks()->where('type', 'wikilink')->sole();
+        $this->assertNull($link->target_block);
+        $this->assertSame($target->id, $link->target_note_id);
+    }
+
     private function makeWorkspace(): Workspace
     {
         $tenant = Tenant::query()->create([

--- a/tests/Unit/WikilinkExtractorTest.php
+++ b/tests/Unit/WikilinkExtractorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Links\WikilinkExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class WikilinkExtractorTest extends TestCase
+{
+    public function test_block_reference_is_distinguished_from_heading_anchor(): void
+    {
+        $extractor = new WikilinkExtractor;
+
+        $this->assertSame('myblock', $extractor->targetBlock('note#^myblock'));
+        $this->assertNull($extractor->targetBlock('note#heading'));
+        $this->assertNull($extractor->targetBlock('note'));
+    }
+
+    public function test_extract_captures_target_block_alongside_target_key(): void
+    {
+        $extractor = new WikilinkExtractor;
+
+        $references = $extractor->extract('[[note#^myblock]] and [[note#heading]] and [[note]]');
+
+        $byRef = [];
+        foreach ($references as $reference) {
+            $byRef[$reference['target_ref']] = $reference;
+        }
+
+        $this->assertSame('note', $byRef['note#^myblock']['target_key']);
+        $this->assertSame('myblock', $byRef['note#^myblock']['target_block']);
+
+        $this->assertSame('note', $byRef['note#heading']['target_key']);
+        $this->assertNull($byRef['note#heading']['target_block']);
+
+        $this->assertSame('note', $byRef['note']['target_key']);
+        $this->assertNull($byRef['note']['target_block']);
+    }
+}


### PR DESCRIPTION
## Summary
- `WikilinkExtractor` treated every `#fragment` as a heading anchor, so Obsidian block citations like `[[note#^myblock]]` silently collapsed to a plain note-level link, with no way to distinguish or query them
- Recognize a fragment starting with `^` as a block reference; extract the block id separately from the note-resolution key via new `WikilinkExtractor::targetBlock()`
- New migration adds `note_links.target_block` (nullable, indexed with `target_note_id`) -- block id is parsed from disk content on each index, per spec §1 (no separate block table needed)
- `WikilinkProjector` persists `target_block` on every wikilink row; note-level resolution (`target_note_id`) is unchanged, so block refs still resolve to the correct note
- `Note::incomingBlockReferences(string $blockId)` gives block-level backlinks alongside the existing note-level `incomingLinks()`

Fixes #205

## Out of scope
Block-reference UI affordances (e.g. "copy block link" button) -- backend/data-layer only, per the issue.

## Test plan
- [x] `tests/Unit/WikilinkExtractorTest.php` -- block ref vs heading anchor distinction, extract() shape
- [x] `tests/Feature/WikilinkProjectionTest.php` -- block reference persisted + queryable via `incomingBlockReferences()`, heading fragments still resolve without a block id
- [x] Full suite green: `./scripts/jt.sh test` -- 117 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)