### PR TITLE
feat: add opt-in LaTeX/Mermaid hydration markup

### DIFF
--- a/app/Domain/Vault/MarkdownServerRenderer.php
+++ b/app/Domain/Vault/MarkdownServerRenderer.php
@@ -33,6 +33,15 @@ final class MarkdownServerRenderer
         // they must never leak into rendered SPA or published output.
         $processed = preg_replace('/%%.*?%%/s', '', $markdown);
 
+        // Optional LaTeX/Mermaid hydration markup (off by default). Placeholders
+        // survive the CommonMark pass untouched (plain alnum tokens), then get
+        // swapped for the real, escaped markup after conversion so CommonMark
+        // never has a chance to mangle or re-escape it.
+        $mathMermaidBlocks = [];
+        if ((bool) config('jotter.rendering.katex_mermaid_enabled', false)) {
+            $processed = $this->extractMathAndMermaid($processed ?? $markdown, $mathMermaidBlocks);
+        }
+
         // Convert Wikilinks [[target|alias]] into safe anchor tags
         $processed = preg_replace_callback(
             '/\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|([^\]]+))?\]\]/',
@@ -65,8 +74,50 @@ final class MarkdownServerRenderer
             $html
         );
 
+        if ($mathMermaidBlocks !== []) {
+            $html = strtr($html, $mathMermaidBlocks);
+        }
+
         // Server-side XSS sanitization pass
         return $this->sanitizeHtml($html);
+    }
+
+    /**
+     * Replaces $$LaTeX$$ and ```mermaid fenced blocks with plain-text
+     * placeholder tokens (so CommonMark cannot mangle them) and records the
+     * real, escaped hydration markup to swap back in after conversion.
+     *
+     * @param  array<string, string>  $blocks
+     */
+    private function extractMathAndMermaid(string $markdown, array &$blocks): string
+    {
+        $index = 0;
+
+        $markdown = preg_replace_callback(
+            '/```mermaid\s*\n(.*?)```/s',
+            function (array $matches) use (&$blocks, &$index): string {
+                $token = sprintf('JOTTERMERMAIDBLOCK%dTOKEN', $index++);
+                $source = htmlspecialchars(trim($matches[1]), ENT_QUOTES, 'UTF-8');
+                $blocks[$token] = sprintf('<pre class="mermaid">%s</pre>', $source);
+
+                return $token;
+            },
+            $markdown
+        ) ?? $markdown;
+
+        $markdown = preg_replace_callback(
+            '/\$\$(.+?)\$\$/s',
+            function (array $matches) use (&$blocks, &$index): string {
+                $token = sprintf('JOTTERMATHBLOCK%dTOKEN', $index++);
+                $source = htmlspecialchars(trim($matches[1]), ENT_QUOTES, 'UTF-8');
+                $blocks[$token] = sprintf('<span class="jotter-math" data-tex="%s">%s</span>', $source, $source);
+
+                return $token;
+            },
+            $markdown
+        ) ?? $markdown;
+
+        return $markdown;
     }
 
     private function sanitizeHtml(string $html): string

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -14,6 +14,15 @@ return [
         'reindex_batch_size' => (int) env('JOTTER_VAULT_REINDEX_BATCH', 50),
     ],
 
+    'rendering' => [
+        // Off by default: emits <span class="jotter-math">/<pre class="mermaid">
+        // markup for $$LaTeX$$ and ```mermaid blocks instead of plain code, for a
+        // client-side library (KaTeX/mermaid.js) to hydrate. When off, both
+        // constructs render as plain code, matching Obsidian's own fallback when
+        // the corresponding plugin/feature is unavailable.
+        'katex_mermaid_enabled' => (bool) env('JOTTER_ENABLE_MATH_MERMAID', false),
+    ],
+
     'auth_provider' => env('JOTTER_AUTH_PROVIDER', env('AUTH_PROVIDER', 'local')),
     'auth_bypass' => (bool) env('JOTTER_AUTH_BYPASS', false),
 

--- a/tests/Feature/MarkdownServerRendererTest.php
+++ b/tests/Feature/MarkdownServerRendererTest.php
@@ -58,4 +58,44 @@ final class MarkdownServerRendererTest extends TestCase
         $this->assertStringContainsString('Before.', $html);
         $this->assertStringContainsString('After.', $html);
     }
+
+    public function test_latex_and_mermaid_render_as_plain_code_by_default(): void
+    {
+        config(['jotter.rendering.katex_mermaid_enabled' => false]);
+        $renderer = new MarkdownServerRenderer();
+
+        $markdown = '$$E=mc^2$$'."\n\n```mermaid\ngraph TD; A-->B;\n```";
+        $html = $renderer->render($markdown);
+
+        $this->assertStringNotContainsString('class="jotter-math"', $html);
+        $this->assertStringNotContainsString('class="mermaid"', $html);
+        $this->assertStringContainsString('E=mc^2', $html);
+        $this->assertStringContainsString('<pre><code', $html);
+        $this->assertStringContainsString('graph TD', $html);
+    }
+
+    public function test_latex_and_mermaid_render_with_hydration_markup_when_enabled(): void
+    {
+        config(['jotter.rendering.katex_mermaid_enabled' => true]);
+        $renderer = new MarkdownServerRenderer();
+
+        $markdown = '$$E=mc^2$$'."\n\n```mermaid\ngraph TD; A-->B;\n```";
+        $html = $renderer->render($markdown);
+
+        $this->assertStringContainsString('class="jotter-math"', $html);
+        $this->assertStringContainsString('E=mc^2', $html);
+        $this->assertStringContainsString('class="mermaid"', $html);
+        $this->assertStringContainsString('graph TD', $html);
+    }
+
+    public function test_math_and_mermaid_markup_is_escaped_when_enabled(): void
+    {
+        config(['jotter.rendering.katex_mermaid_enabled' => true]);
+        $renderer = new MarkdownServerRenderer();
+
+        $html = $renderer->render('$$<script>alert(1)</script>$$');
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('class="jotter-math"', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- `$$LaTeX$$` and ```` ```mermaid ```` fenced blocks aren't in `league/commonmark`'s core extension set, so they always rendered as plain code -- acceptable degradation per the audit, but no path existed to render them for workspaces that want it
- New `JOTTER_ENABLE_MATH_MERMAID` env flag (`jotter.rendering.katex_mermaid_enabled`, **off by default** -- no bundle/asset weight unless opted in, per spec §4)
- When enabled, `MarkdownServerRenderer` swaps plain-code rendering for `<span class="jotter-math" data-tex="...">` and `<pre class="mermaid">` markup, ready for a client-side library (KaTeX / mermaid.js) to hydrate -- these are the exact conventions those libraries auto-detect
- Raw source is carried through the CommonMark pass as plain-text placeholder tokens (so CommonMark can't mangle or re-escape it), then swapped for the real, `htmlspecialchars`-escaped markup afterward

Fixes #206

## Out of scope (explicit follow-up)
This PR ships the server-side flag + hydration-ready markup. It does **not** add the client-side KaTeX/mermaid.js bundle or wire up hydration in the SPA/published-site JS -- that's a separate frontend-dependency decision (bundle size, license, lazy-loading strategy) better scoped on its own. With the flag off (default), behavior is unchanged from before this PR.

## Test plan
- [x] `test_latex_and_mermaid_render_as_plain_code_by_default` -- confirms unchanged fallback behavior
- [x] `test_latex_and_mermaid_render_with_hydration_markup_when_enabled` -- confirms markup swap when flag is on
- [x] `test_math_and_mermaid_markup_is_escaped_when_enabled` -- confirms no script injection via math content
- [x] Full suite green: `./scripts/jt.sh test` -- 120 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)