### PR TITLE
test: verify dataview/Tasks plugin output degrades gracefully

### DIFF
--- a/frontend/src/markdown.spec.ts
+++ b/frontend/src/markdown.spec.ts
@@ -37,6 +37,28 @@ describe('Markdown rendering & XSS security', () => {
     expect(html).not.toContain('href="javascript:')
   })
 
+  it('renders a dataview code block as readable code without crashing', () => {
+    const md = '# Notes\n\n```dataview\nLIST FROM #project WHERE status = "active"\n```\n\nAfter.'
+    const html = renderMarkdown(md)
+
+    expect(html).toContain('class="code-block-wrapper"')
+    expect(html).toContain('LIST FROM')
+    expect(html).toContain('#project')
+    expect(html).toContain('After.')
+  })
+
+  it('renders Tasks-plugin emoji syntax as readable checkbox text without crashing', () => {
+    const md = '- [ ] Do thing \u{1F4C5} 2026-08-01 \u{1F501} every week\n- [x] Done thing \u{2705} 2026-07-01'
+    const html = renderMarkdown(md)
+
+    expect(html).toContain('type="checkbox"')
+    expect(html).toContain('Do thing')
+    expect(html).toContain('\u{1F4C5}')
+    expect(html).toContain('2026-08-01')
+    expect(html).toContain('every week')
+    expect(html).toContain('\u{2705}')
+  })
+
   it('renders callouts, toggles, tables, and dividers', () => {
     const md = '> [!NOTE] Callout body\n\n<details><summary>Summary</summary>Body</details>\n\n| H1 | H2 |\n| --- | --- |\n| C1 | C2 |\n\n---'
     const html = renderMarkdown(md)

--- a/tests/Feature/MarkdownServerRendererTest.php
+++ b/tests/Feature/MarkdownServerRendererTest.php
@@ -98,4 +98,37 @@ final class MarkdownServerRendererTest extends TestCase
         $this->assertStringNotContainsString('<script>', $html);
         $this->assertStringContainsString('class="jotter-math"', $html);
     }
+
+    public function test_dataview_code_block_degrades_to_readable_code_without_crashing(): void
+    {
+        $renderer = new MarkdownServerRenderer();
+
+        $markdown = "# Notes\n\n```dataview\nLIST FROM #project WHERE status = \"active\"\n```\n\nAfter.";
+        $html = $renderer->render($markdown);
+
+        $this->assertStringContainsString('<pre><code', $html);
+        $this->assertStringContainsString('LIST FROM', $html);
+        $this->assertStringContainsString('#project', $html);
+        $this->assertStringContainsString('After.', $html);
+    }
+
+    public function test_tasks_plugin_emoji_syntax_renders_as_readable_text_without_crashing(): void
+    {
+        $renderer = new MarkdownServerRenderer();
+
+        $markdown = "- [ ] Do thing \u{1F4C5} 2026-08-01 \u{1F501} every week\n- [x] Done thing \u{2705} 2026-07-01";
+        $html = $renderer->render($markdown);
+
+        // MarkdownServerRenderer has no GFM task-list extension registered (see
+        // constructor), so `- [ ]` prints as literal list-item text rather than a
+        // checkbox input -- a separate, tracked gap (#216), not a crash or dropped
+        // content. This test's contract is: no exception, and every character of
+        // the line -- including the Tasks-plugin emoji annotations -- survives.
+        $this->assertStringContainsString('<li>', $html);
+        $this->assertStringContainsString('Do thing', $html);
+        $this->assertStringContainsString("\u{1F4C5}", $html);
+        $this->assertStringContainsString('2026-08-01', $html);
+        $this->assertStringContainsString('every week', $html);
+        $this->assertStringContainsString("\u{2705}", $html);
+    }
 }


### PR DESCRIPTION
## Summary
#207 was `[UNVERIFIED]`: the expectation that unknown Obsidian-plugin syntax (dataview code blocks, Tasks-plugin emoji annotations) degrades to readable text rather than crashing the renderer, but nothing exercised that path server- or client-side.

**Verification result: confirmed, on both paths.**
- Server (`MarkdownServerRenderer`): dataview fences render as a plain code block, Tasks emoji syntax renders as readable list-item text -- no exceptions, no dropped characters (verified with actual emoji/date content)
- Client (`frontend/src/services/markdown.ts`, `marked` + DOMPurify): same, plus task-list checkboxes render correctly since `marked` has `gfm: true`

**One real gap surfaced during verification, filed separately as #216 (per this issue's own instruction to not fold discovered defects into the verification task):** `MarkdownServerRenderer` has no GFM task-list extension registered, so `- [ ]` prints as literal `[ ]` text instead of a checkbox on the *server*-rendered path (API `html_rendered` field, published static site) -- a client/server rendering-parity gap, not a crash or content loss.

Fixes #207

## Test plan
- [x] `tests/Feature/MarkdownServerRendererTest.php` -- dataview block and Tasks emoji syntax, both confirm no crash + full content preserved
- [x] `frontend/src/markdown.spec.ts` -- same two cases client-side, plus confirms checkbox rendering already works there
- [x] Full suite green: `./scripts/jt.sh test` -- 122 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)