### PR TITLE
fix: render GFM task-list checkboxes in server-rendered HTML

### DIFF
--- a/app/Domain/Vault/MarkdownServerRenderer.php
+++ b/app/Domain/Vault/MarkdownServerRenderer.php
@@ -5,6 +5,7 @@ namespace App\Domain\Vault;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\Extension\TaskList\TaskListExtension;
 use League\CommonMark\MarkdownConverter;
 
 final class MarkdownServerRenderer
@@ -19,6 +20,7 @@ final class MarkdownServerRenderer
         ]);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new TableExtension());
+        $environment->addExtension(new TaskListExtension());
 
         $this->converter = new MarkdownConverter($environment);
     }

--- a/tests/Feature/MarkdownServerRendererTest.php
+++ b/tests/Feature/MarkdownServerRendererTest.php
@@ -119,16 +119,33 @@ final class MarkdownServerRendererTest extends TestCase
         $markdown = "- [ ] Do thing \u{1F4C5} 2026-08-01 \u{1F501} every week\n- [x] Done thing \u{2705} 2026-07-01";
         $html = $renderer->render($markdown);
 
-        // MarkdownServerRenderer has no GFM task-list extension registered (see
-        // constructor), so `- [ ]` prints as literal list-item text rather than a
-        // checkbox input -- a separate, tracked gap (#216), not a crash or dropped
-        // content. This test's contract is: no exception, and every character of
-        // the line -- including the Tasks-plugin emoji annotations -- survives.
-        $this->assertStringContainsString('<li>', $html);
+        // No exception, and every character of the line -- including the
+        // Tasks-plugin emoji annotations -- survives. Checkbox rendering itself
+        // is covered by test_renders_gfm_task_list_checkboxes below.
+        $this->assertStringContainsString('<li', $html);
         $this->assertStringContainsString('Do thing', $html);
         $this->assertStringContainsString("\u{1F4C5}", $html);
         $this->assertStringContainsString('2026-08-01', $html);
         $this->assertStringContainsString('every week', $html);
         $this->assertStringContainsString("\u{2705}", $html);
+    }
+
+    public function test_renders_gfm_task_list_checkboxes(): void
+    {
+        $renderer = new MarkdownServerRenderer();
+
+        $html = $renderer->render("- [ ] Open task\n- [x] Done task");
+
+        $this->assertStringContainsString('type="checkbox"', $html);
+        $this->assertStringContainsString('Open task', $html);
+        $this->assertStringContainsString('Done task', $html);
+        $this->assertMatchesRegularExpression(
+            '/<input checked="" disabled="" type="checkbox">\s*Done task/',
+            $html,
+        );
+        $this->assertMatchesRegularExpression(
+            '/<input disabled="" type="checkbox">\s*Open task/',
+            $html,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `MarkdownServerRenderer` only registered `CommonMarkCoreExtension` and `TableExtension`, so `- [ ]` rendered as literal `[ ]` text instead of a checkbox on the *server*-rendered path -- used by `WorkspaceNoteController::show()`'s `html_rendered` field and `WorkspacePublishController`'s published static site
- The SPA's client-side preview already renders checkboxes correctly (`marked` with `gfm: true`), so this was a client/server rendering-parity gap, discovered while verifying #207
- Registers `league/commonmark`'s bundled `TaskListExtension` -- already vendored as part of `league/commonmark` 2.8, no new Composer dependency -- checkboxes render `disabled`/read-only, matching GFM and Obsidian's own rendered (non-interactive) convention

Fixes #216

## Test plan
- [x] `test_renders_gfm_task_list_checkboxes` -- confirms `type="checkbox"` + `checked` state for both open and done tasks (failed before the fix -- literal `[ ]`/`[x]` text -- passes after)
- [x] Full suite green: `./scripts/jt.sh test` -- 123 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)