### PR TITLE
feat: rewrite inbound wikilinks on note rename/move

### DIFF
--- a/app/Domain/Vault/VaultStorage.php
+++ b/app/Domain/Vault/VaultStorage.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Vault;
 
 use App\Models\Note;
+use App\Models\NoteLink;
 use App\Models\Workspace;
 
 /**
@@ -106,14 +107,22 @@ final class VaultStorage
 
         $this->ensureParentDirectory($workspace, $newAbsolute);
 
-        if (! rename($oldAbsolute, $newAbsolute)) {
-            throw new \RuntimeException("Unable to move vault note from [{$oldPath}] to [{$newPath}].");
-        }
-
         $note = Note::query()
             ->where('workspace_id', $workspace->id)
             ->where('path', $oldPath)
             ->first();
+
+        // Capture who links to this note, and what old keys their links use to
+        // reach it, before the rename changes path/title resolution.
+        $oldKeys = $note ? $this->wikilinkKeys($oldPath, (string) $note->title) : $this->wikilinkKeys($oldPath, null);
+        $referencingNoteIds = $note
+            ? NoteLink::query()->where('target_note_id', $note->id)->where('type', 'wikilink')
+                ->pluck('source_note_id')->unique()->all()
+            : [];
+
+        if (! rename($oldAbsolute, $newAbsolute)) {
+            throw new \RuntimeException("Unable to move vault note from [{$oldPath}] to [{$newPath}].");
+        }
 
         $contents = file_get_contents($newAbsolute) ?: '';
         $document = MarkdownDocument::parse($contents, $this->fallbackTitle($newRelative));
@@ -122,7 +131,83 @@ final class VaultStorage
             $note->delete();
         }
 
-        return $this->projector->project($workspace, $newRelative, $document);
+        $movedNote = $this->projector->project($workspace, $newRelative, $document);
+
+        if ($referencingNoteIds !== []) {
+            // Obsidian wikilinks address notes by filename, not by H1/front-matter
+            // title, so rewrite to the new file's basename -- consistent with
+            // resolveWorkspaceLinks() matching against note path first.
+            $newKey = $this->fallbackTitle($newRelative);
+            $this->rewriteInboundWikilinks($workspace, $referencingNoteIds, $oldKeys, $newKey, $movedNote->id);
+        }
+
+        return $movedNote;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function wikilinkKeys(string $relativePath, ?string $title): array
+    {
+        $path = trim(str_replace('\\', '/', $relativePath), '/');
+        $keys = [$path];
+        if (str_ends_with(strtolower($path), '.md')) {
+            $keys[] = substr($path, 0, -3);
+        }
+
+        $title = trim((string) $title);
+        if ($title !== '') {
+            $keys[] = $title;
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * Rewrites `[[oldKey]]` / `[[oldKey|label]]` / `[[oldKey#fragment]]` wikilinks
+     * to the moved note's new title, in every referencing note's on-disk content.
+     * Disk is the source of truth (spec §1); the note index is rebuilt as a
+     * side effect of the write, same as any other edit.
+     *
+     * @param  list<int>  $referencingNoteIds
+     * @param  list<string>  $oldKeys
+     */
+    private function rewriteInboundWikilinks(
+        Workspace $workspace,
+        array $referencingNoteIds,
+        array $oldKeys,
+        string $newTitle,
+        int $movedNoteId,
+    ): void {
+        if ($oldKeys === []) {
+            return;
+        }
+
+        $alternation = implode('|', array_map(
+            static fn (string $key): string => preg_quote($key, '/'),
+            $oldKeys,
+        ));
+        $pattern = '/\[\[('.$alternation.')((?:#[^\]|]*)?(?:\|[^\]]*)?)\]\]/iu';
+
+        $referencingNotes = Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->whereIn('id', $referencingNoteIds)
+            ->where('id', '!=', $movedNoteId)
+            ->get(['id', 'path']);
+
+        foreach ($referencingNotes as $referencingNote) {
+            $contents = $this->readContents($workspace, (string) $referencingNote->path);
+
+            $rewritten = preg_replace_callback(
+                $pattern,
+                static fn (array $matches): string => sprintf('[[%s%s]]', $newTitle, $matches[2]),
+                $contents,
+            );
+
+            if ($rewritten !== null && $rewritten !== $contents) {
+                $this->write($workspace, (string) $referencingNote->path, $rewritten);
+            }
+        }
     }
 
     private function ensureParentDirectory(Workspace $workspace, string $absolute): void

--- a/tests/Feature/WikilinkProjectionTest.php
+++ b/tests/Feature/WikilinkProjectionTest.php
@@ -140,6 +140,46 @@ class WikilinkProjectionTest extends TestCase
         $this->assertSame($target->id, $link->target_note_id);
     }
 
+    public function test_rename_rewrites_inbound_wikilinks_on_disk(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $storage->write($workspace, 'note-b.md', "# Note B\n");
+        $storage->write($workspace, 'note-a.md', "See [[note-b]] and [[Note B|display label]] for details.\n");
+
+        $storage->move($workspace, 'note-b.md', 'note-c.md');
+
+        // Verify on disk, not the API/DB -- the index can be correct while disk is
+        // wrong, and disk is what Obsidian reads over WebDAV.
+        $onDisk = file_get_contents($this->vaultRoot.'/note-a.md');
+        $this->assertStringNotContainsString('[[note-b]]', $onDisk);
+        $this->assertStringContainsString('[[note-c]]', $onDisk);
+        $this->assertStringContainsString('[[note-c|display label]]', $onDisk);
+
+        $source = Note::query()->where('workspace_id', $workspace->id)->where('path', 'note-a.md')->sole();
+        $target = Note::query()->where('workspace_id', $workspace->id)->where('path', 'note-c.md')->sole();
+        $this->assertSame(
+            [$target->id, $target->id],
+            $source->outgoingLinks()->where('type', 'wikilink')->orderBy('id')->pluck('target_note_id')->all(),
+        );
+    }
+
+    public function test_rename_does_not_rewrite_links_to_unrelated_notes(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $storage->write($workspace, 'note-b.md', "# Note B\n");
+        $storage->write($workspace, 'note-d.md', "# Note D\n");
+        $storage->write($workspace, 'note-a.md', "[[note-b]] and [[note-d]]\n");
+
+        $storage->move($workspace, 'note-b.md', 'note-c.md');
+
+        $onDisk = file_get_contents($this->vaultRoot.'/note-a.md');
+        $this->assertStringContainsString('[[note-d]]', $onDisk);
+    }
+
     private function makeWorkspace(): Workspace
     {
         $tenant = Tenant::query()->create([


### PR DESCRIPTION
## Summary
- `VaultStorage::move()` relocated the file and re-projected the moved note, but left inbound `[[wikilinks]]` in *other* notes pointing at the old name -- stale on disk, which is what Obsidian reads over WebDAV (spec §1: disk is the source of truth)
- `move()` now captures which notes reference the target (via existing `note_links` resolution) before renaming, then rewrites `[[oldKey]]` / `[[oldKey|label]]` / `[[oldKey#fragment]]` to the new filename-derived key in each referencing note, writing through the normal `write()` path so it re-indexes like any other edit
- The replacement key is the moved file's **basename**, matching Obsidian's filename-based addressing -- not the H1/front-matter title, which is unrelated to the filename and doesn't change on a rename (caught by a test failure during TDD: a note titled "Note B" via its `# Note B` heading kept that title after moving `note-b.md` -> `note-c.md`, so using `document->title` as the replacement produced the wrong, unchanged key)

Fixes #220

## Test plan
- [x] `test_rename_rewrites_inbound_wikilinks_on_disk` -- reads the referencing note's file content from disk (not API/DB) after a rename, confirms `[[note-b]]` and `[[note-b|display label]]` both rewrite to `[[note-c]]` / `[[note-c|display label]]`, and that `target_note_id` re-resolves correctly
- [x] `test_rename_does_not_rewrite_links_to_unrelated_notes` -- confirms an unrelated `[[note-d]]` link is untouched
- [x] Full suite green: `./scripts/jt.sh test` -- 125 passed / 1 skipped (PHP), 19/19 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)