### PR TITLE
feat: unlinked mentions panel

### DIFF
--- a/app/Domain/Search/UnlinkedMentionsFinder.php
+++ b/app/Domain/Search/UnlinkedMentionsFinder.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Domain\Search;
+
+use App\Models\Note;
+use App\Models\NoteLink;
+use App\Models\Workspace;
+
+/**
+ * Finds notes in a workspace whose text mentions a target note's title/alias
+ * without an explicit [[wikilink]] to it -- Obsidian's "unlinked mentions".
+ * Bounded to a single workspace-scoped, indexed query (spec §4): no per-request
+ * filesystem/vault scan.
+ */
+final class UnlinkedMentionsFinder
+{
+    private const RESULT_LIMIT = 50;
+
+    private const MIN_PHRASE_LENGTH = 2;
+
+    /**
+     * @return list<array{id: int, path: string, title: string, matched_phrase: string, snippet: string}>
+     */
+    public function find(Workspace $workspace, Note $target): array
+    {
+        $phrases = $this->candidatePhrases($target);
+        if ($phrases === []) {
+            return [];
+        }
+
+        $alreadyLinkedSourceIds = NoteLink::query()
+            ->where('target_note_id', $target->id)
+            ->where('type', 'wikilink')
+            ->pluck('source_note_id')
+            ->all();
+
+        $candidates = Note::query()
+            ->where('workspace_id', $workspace->id)
+            ->where('id', '!=', $target->id)
+            ->whereNotIn('id', $alreadyLinkedSourceIds)
+            ->where(function ($query) use ($phrases): void {
+                foreach ($phrases as $phrase) {
+                    $query->orWhere('title', 'LIKE', '%'.$this->escapeLike($phrase).'%')
+                        ->orWhere('search_content', 'LIKE', '%'.$this->escapeLike($phrase).'%');
+                }
+            })
+            ->limit(self::RESULT_LIMIT)
+            ->get(['id', 'path', 'title', 'search_content']);
+
+        $results = [];
+        foreach ($candidates as $note) {
+            $matchedPhrase = $this->firstMatchingPhrase($note, $phrases);
+            if ($matchedPhrase === null) {
+                continue;
+            }
+
+            $results[] = [
+                'id' => $note->id,
+                'path' => $note->path,
+                'title' => $note->title,
+                'matched_phrase' => $matchedPhrase,
+                'snippet' => $this->snippet((string) $note->search_content, $matchedPhrase),
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidatePhrases(Note $target): array
+    {
+        $phrases = [trim((string) $target->title)];
+
+        $frontmatter = $target->frontmatter ?? [];
+        if (array_key_exists('aliases', $frontmatter)) {
+            $raw = $frontmatter['aliases'];
+            if (is_string($raw)) {
+                foreach (preg_split('/\s*,\s*/', $raw) ?: [] as $part) {
+                    $phrases[] = $part;
+                }
+            } elseif (is_array($raw)) {
+                foreach ($raw as $part) {
+                    if (is_string($part) || is_numeric($part)) {
+                        $phrases[] = (string) $part;
+                    }
+                }
+            }
+        }
+
+        $normalized = [];
+        foreach ($phrases as $phrase) {
+            $phrase = trim($phrase);
+            if (mb_strlen($phrase, 'UTF-8') < self::MIN_PHRASE_LENGTH) {
+                continue;
+            }
+            $normalized[mb_strtolower($phrase, 'UTF-8')] = $phrase;
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  list<string>  $phrases
+     */
+    private function firstMatchingPhrase(Note $note, array $phrases): ?string
+    {
+        $haystack = mb_strtolower($note->title.' '.($note->search_content ?? ''), 'UTF-8');
+
+        foreach ($phrases as $phrase) {
+            if (mb_stripos($haystack, mb_strtolower($phrase, 'UTF-8'), 0, 'UTF-8') !== false) {
+                return $phrase;
+            }
+        }
+
+        return null;
+    }
+
+    private function snippet(string $content, string $phrase): string
+    {
+        $content = trim((string) preg_replace('/\s+/u', ' ', $content));
+        $position = mb_stripos($content, $phrase);
+        if ($position === false) {
+            return mb_strimwidth($content, 0, 240, '…');
+        }
+
+        $start = max(0, $position - 80);
+        $prefix = $start > 0 ? '…' : '';
+
+        return $prefix.mb_strimwidth(mb_substr($content, $start), 0, 240 - mb_strlen($prefix), '…');
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+    }
+}

--- a/app/Http/Controllers/WorkspaceUnlinkedMentionsController.php
+++ b/app/Http/Controllers/WorkspaceUnlinkedMentionsController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Search\UnlinkedMentionsFinder;
+use App\Models\Note;
+use App\Models\Workspace;
+use Illuminate\Http\JsonResponse;
+
+final class WorkspaceUnlinkedMentionsController extends Controller
+{
+    public function index(Workspace $workspace, int $note, UnlinkedMentionsFinder $finder): JsonResponse
+    {
+        /** @var Note $target */
+        $target = $workspace->notes()->findOrFail($note);
+
+        return response()->json([
+            'data' => $finder->find($workspace, $target),
+        ]);
+    }
+}

--- a/frontend/src/UnlinkedMentionsPanel.spec.ts
+++ b/frontend/src/UnlinkedMentionsPanel.spec.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import UnlinkedMentionsPanel from './components/UnlinkedMentionsPanel.vue'
+
+const mention = {
+  id: 2,
+  path: 'meeting-notes.md',
+  title: 'Meeting Notes',
+  matched_phrase: 'Project Alpha',
+  snippet: 'We discussed Project Alpha today.'
+}
+
+describe('UnlinkedMentionsPanel', () => {
+  it('shows the empty state when there are no mentions', () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
+    expect(wrapper.text()).toContain('No unlinked mentions found.')
+  })
+
+  it('renders one entry per mention with title and snippet', () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [mention] } })
+    expect(wrapper.text()).toContain('Meeting Notes')
+    expect(wrapper.text()).toContain('We discussed Project Alpha today.')
+  })
+
+  it('emits select-note when the mention body is clicked', async () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [mention] } })
+    await wrapper.get('.mention-main').trigger('click')
+    expect(wrapper.emitted('select-note')![0]).toEqual([2])
+  })
+
+  it('emits convert-to-link with the full mention when the Link button is clicked', async () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [mention] } })
+    await wrapper.get('[data-testid="convert-to-link-btn"]').trigger('click')
+    expect(wrapper.emitted('convert-to-link')![0]).toEqual([mention])
+  })
+})

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -179,6 +179,13 @@
       @select-note="$emit('select-note', $event)"
     />
 
+    <!-- Unlinked Mentions Panel -->
+    <UnlinkedMentionsPanel
+      :mentions="unlinkedMentions"
+      @select-note="$emit('select-note', $event)"
+      @convert-to-link="handleConvertToLink"
+    />
+
     <!-- Version History Panel -->
     <HistoryPanel
       v-if="showHistory"
@@ -196,15 +203,17 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from 'vue'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment } from '../services/types'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, UnlinkedMention } from '../services/types'
 import {
   uploadAttachment,
   getNoteRevisions, getNoteRevision, restoreNoteRevision,
   setNoteProperty, deleteNoteProperty,
-  getNoteComments, addNoteComment, deleteNoteComment
+  getNoteComments, addNoteComment, deleteNoteComment,
+  getUnlinkedMentions, getNote, updateNote
 } from '../services/api'
 import MarkdownPreview from './MarkdownPreview.vue'
 import BacklinksPanel from './BacklinksPanel.vue'
+import UnlinkedMentionsPanel from './UnlinkedMentionsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import PropertiesPanel from './PropertiesPanel.vue'
 import CommentsPanel from './CommentsPanel.vue'
@@ -239,6 +248,7 @@ const revisionPreviewLoading = ref(false)
 
 const comments = ref<NoteComment[]>([])
 const commentsError = ref<string | null>(null)
+const unlinkedMentions = ref<UnlinkedMention[]>([])
 
 // Live Statistics
 const charCount = computed(() => editableContent.value.length)
@@ -294,6 +304,7 @@ watch(() => props.note, (newNote) => {
   showAutocomplete.value = false
   showHistory.value = false
   loadComments(newNote.id)
+  loadUnlinkedMentions(newNote.id)
 }, { immediate: true })
 
 async function loadComments(noteId: number) {
@@ -303,6 +314,33 @@ async function loadComments(noteId: number) {
     comments.value = await getNoteComments(props.workspaceId, noteId)
   } catch (err) {
     console.error('Failed to load comments:', err)
+  }
+}
+
+async function loadUnlinkedMentions(noteId: number) {
+  if (!props.workspaceId) return
+  try {
+    unlinkedMentions.value = await getUnlinkedMentions(props.workspaceId, noteId)
+  } catch (err) {
+    console.error('Failed to load unlinked mentions:', err)
+  }
+}
+
+async function handleConvertToLink(mention: UnlinkedMention) {
+  if (!props.workspaceId) return
+  try {
+    const mentioningNote = await getNote(props.workspaceId, mention.id)
+    const escapedPhrase = mention.matched_phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const pattern = new RegExp(escapedPhrase, 'i')
+    const rewritten = mentioningNote.content.replace(pattern, `[[${props.note.title}]]`)
+
+    if (rewritten !== mentioningNote.content) {
+      await updateNote(props.workspaceId, mention.id, rewritten)
+    }
+
+    await loadUnlinkedMentions(props.note.id)
+  } catch (err) {
+    console.error('Failed to convert mention to link:', err)
   }
 }
 

--- a/frontend/src/components/UnlinkedMentionsPanel.vue
+++ b/frontend/src/components/UnlinkedMentionsPanel.vue
@@ -1,0 +1,154 @@
+<template>
+  <aside class="unlinked-mentions-panel" aria-label="Unlinked mentions">
+    <div class="unlinked-mentions-header">
+      <div class="header-title">
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <circle cx="12" cy="12" r="10"></circle>
+          <line x1="12" y1="8" x2="12" y2="12"></line>
+          <line x1="12" y1="16" x2="12.01" y2="16"></line>
+        </svg>
+        <span>Unlinked Mentions</span>
+      </div>
+      <span class="count-badge">{{ mentions.length }}</span>
+    </div>
+
+    <div v-if="mentions.length === 0" class="unlinked-mentions-empty">
+      <p>No unlinked mentions found.</p>
+    </div>
+
+    <ul v-else class="unlinked-mentions-list">
+      <li v-for="mention in mentions" :key="mention.id" class="mention-item">
+        <div class="mention-main" @click="$emit('select-note', mention.id)">
+          <div class="mention-title">{{ mention.title || mention.path }}</div>
+          <div class="mention-snippet">{{ mention.snippet }}</div>
+        </div>
+        <button
+          type="button"
+          class="convert-link-btn"
+          data-testid="convert-to-link-btn"
+          :title="`Convert &quot;${mention.matched_phrase}&quot; into a wikilink`"
+          @click="$emit('convert-to-link', mention)"
+        >
+          Link
+        </button>
+      </li>
+    </ul>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import type { UnlinkedMention } from '../services/types'
+
+defineProps<{
+  mentions: UnlinkedMention[]
+}>()
+
+defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'convert-to-link', mention: UnlinkedMention): void
+}>()
+</script>
+
+<style scoped>
+.unlinked-mentions-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.unlinked-mentions-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-action);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+}
+
+.unlinked-mentions-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.unlinked-mentions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.mention-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+}
+
+.mention-main {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.mention-main:hover .mention-title {
+  color: var(--color-action);
+}
+
+.mention-title {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.mention-snippet {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-top: 0.125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.convert-link-btn {
+  flex-shrink: 0;
+  background: var(--color-surface);
+  color: var(--color-action);
+  border: 1px solid var(--color-action);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  min-height: 36px;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.convert-link-btn:hover {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+}
+</style>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -85,6 +85,11 @@ export async function updateNote(workspaceId: number, noteId: number, content: s
 
 export async function deleteNote(workspaceId: number, noteId: number): Promise<void> {
   await api.delete(`/workspaces/${workspaceId}/notes/${noteId}`)
+}
+
+export async function getUnlinkedMentions(workspaceId: number, noteId: number): Promise<UnlinkedMention[]> {
+  const response = await api.get<{ data: UnlinkedMention[] }>(`/workspaces/${workspaceId}/notes/${noteId}/unlinked-mentions`)
+  return response.data.data
 }
 
 export async function searchNotes(

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -20,6 +20,14 @@ export interface Backlink {
   target_ref?: string
 }
 
+export interface UnlinkedMention {
+  id: number
+  path: string
+  title: string
+  matched_phrase: string
+  snippet: string
+}
+
 export type NotePropertyType = 'string' | 'numeric' | 'boolean' | 'datetime' | 'list' | 'json'
 
 export interface NoteProperty {

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,6 +52,7 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::get('/workspaces/{workspace}/sync', [WorkspaceSyncController::class, 'sync']);
     Route::get('/workspaces/{workspace}/search', WorkspaceSearchController::class);
     Route::get('/workspaces/{workspace}/link-report', [\App\Http\Controllers\WorkspaceLinkReportController::class, 'report']);
+    Route::get('/workspaces/{workspace}/notes/{note}/unlinked-mentions', [\App\Http\Controllers\WorkspaceUnlinkedMentionsController::class, 'index']);
     Route::get('/workspaces/{workspace}/notes', [WorkspaceNoteController::class, 'index']);
     Route::get('/workspaces/{workspace}/notes/{note}/comments', [\App\Http\Controllers\WorkspaceCommentController::class, 'index']);
     Route::post('/workspaces/{workspace}/notes/{note}/comments', [\App\Http\Controllers\WorkspaceCommentController::class, 'store']);

--- a/tests/Feature/UnlinkedMentionsTest.php
+++ b/tests/Feature/UnlinkedMentionsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultReindexer;
+use App\Domain\Vault\VaultStorage;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class UnlinkedMentionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_finds_notes_that_mention_the_title_without_a_wikilink(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'project-alpha.md', "# Project Alpha\n\nThe flagship effort.");
+        $mentioning = $storage->write($workspace, 'meeting-notes.md', "We discussed Project Alpha today, no link yet.");
+        $storage->write($workspace, 'unrelated.md', "Nothing to do with it.");
+
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$target->id}/unlinked-mentions");
+
+        $response->assertOk()->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $mentioning->id);
+        $response->assertJsonPath('data.0.path', 'meeting-notes.md');
+        $response->assertJsonPath('data.0.matched_phrase', 'Project Alpha');
+    }
+
+    public function test_excludes_notes_that_already_have_a_resolved_wikilink(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'project-alpha.md', "# Project Alpha\n\nThe flagship effort.");
+        $storage->write($workspace, 'linked.md', "See [[project-alpha]] for the plan on Project Alpha.");
+
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$target->id}/unlinked-mentions");
+
+        $response->assertOk()->assertJsonCount(0, 'data');
+    }
+
+    public function test_matches_via_frontmatter_alias(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'research.md', "---\naliases: [Deep Research]\n---\n# Research\n");
+        $mentioning = $storage->write($workspace, 'notes.md', "Reading up on Deep Research this week.");
+
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$target->id}/unlinked-mentions");
+
+        $response->assertOk()->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $mentioning->id);
+    }
+
+    public function test_converting_the_mention_into_a_wikilink_removes_it_from_results(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'project-alpha.md', "# Project Alpha\n\nThe flagship effort.");
+        $storage->write($workspace, 'meeting-notes.md', "We discussed Project Alpha today.");
+
+        /** @var VaultReindexer $reindexer */
+        $reindexer = $this->app->make(VaultReindexer::class);
+        $reindexer->reindex($workspace);
+
+        $admin = User::factory()->create(['is_admin' => true]);
+        $before = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$target->id}/unlinked-mentions");
+        $before->assertJsonCount(1, 'data');
+
+        $storage->write($workspace, 'meeting-notes.md', "We discussed [[Project Alpha]] today.");
+        $reindexer->reindex($workspace);
+
+        $after = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$target->id}/unlinked-mentions");
+        $after->assertJsonCount(0, 'data');
+    }
+
+    private function makeWorkspace(): Workspace
+    {
+        $tenant = Tenant::query()->create([
+            'slug' => 'unlinked-tenant-'.uniqid(),
+            'name' => 'Unlinked Mentions Tenant',
+        ]);
+
+        $vaultPath = storage_path('app/vaults/unlinked_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        return Workspace::query()->create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'unlinked-ws-'.uniqid(),
+            'name' => 'Unlinked Mentions Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Obsidian's "unlinked mentions" finds notes whose text mentions another note's title/alias without an explicit `[[wikilink]]`, useful for knowledge-base curation. Jotter only exposed backlinks (explicit links); this adds the missing half.
- `UnlinkedMentionsFinder`: bounded, workspace-scoped query over `title`/`search_content` (title + front-matter aliases, per #204, as candidate phrases), excluding notes that already have a resolved wikilink to the target -- a single indexed query, no per-request filesystem/vault scan (spec §4)
- `GET /api/workspaces/{w}/notes/{n}/unlinked-mentions`
- SPA: `UnlinkedMentionsPanel.vue` alongside the existing `BacklinksPanel.vue`, with a one-click "Link" button that rewrites the matched phrase into a `[[wikilink]]` in the mentioning note and re-syncs the list

Fixes #221

## Test plan
- [x] `tests/Feature/UnlinkedMentionsTest.php` -- finds a mention, excludes already-linked notes, matches via front-matter alias, and confirms converting a mention to a link removes it from subsequent results
- [x] `frontend/src/UnlinkedMentionsPanel.spec.ts` -- empty state, entry rendering, `select-note` and `convert-to-link` emits
- [x] Full suite green: `./scripts/jt.sh test` -- 129 passed / 1 skipped (PHP), 20/20 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)