### PR TITLE
feat: expose outgoing links from a note (API + SPA panel)

### DIFF
--- a/app/Http/Controllers/WorkspaceNoteController.php
+++ b/app/Http/Controllers/WorkspaceNoteController.php
@@ -117,6 +117,28 @@ final class WorkspaceNoteController extends Controller
         ]);
     }
 
+    public function outgoingLinks(Workspace $workspace, int $note): JsonResponse
+    {
+        $note = $this->scopedNote($workspace, $note);
+
+        $links = $note->outgoingLinks()
+            ->where('type', 'wikilink')
+            ->with('targetNote')
+            ->get()
+            ->map(fn ($link) => [
+                'id' => $link->targetNote?->id,
+                'path' => $link->targetNote?->path,
+                'title' => $link->targetNote?->title,
+                'target_ref' => $link->target_ref,
+                'target_block' => $link->target_block,
+                'resolved' => $link->targetNote !== null,
+            ])
+            ->values()
+            ->all();
+
+        return response()->json(['data' => $links]);
+    }
+
     private function scopedNote(Workspace $workspace, int $noteId): Note
     {
         return $workspace->notes()->findOrFail($noteId);

--- a/frontend/src/OutgoingLinksPanel.spec.ts
+++ b/frontend/src/OutgoingLinksPanel.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import OutgoingLinksPanel from './components/OutgoingLinksPanel.vue'
+
+const resolvedLink = {
+  id: 5,
+  path: 'note-b.md',
+  title: 'Note B',
+  target_ref: 'note-b',
+  target_block: null,
+  resolved: true
+}
+
+const blockLink = {
+  id: 5,
+  path: 'note-b.md',
+  title: 'Note B',
+  target_ref: 'note-b#^myblock',
+  target_block: 'myblock',
+  resolved: true
+}
+
+const unresolvedLink = {
+  id: null,
+  path: null,
+  title: null,
+  target_ref: 'missing-note',
+  target_block: null,
+  resolved: false
+}
+
+describe('OutgoingLinksPanel', () => {
+  it('shows the empty state when there are no outgoing links', () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
+    expect(wrapper.text()).toContain("doesn't link to any other notes yet")
+  })
+
+  it('renders a resolved link with its title and path', () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [resolvedLink] } })
+    expect(wrapper.text()).toContain('Note B')
+    expect(wrapper.text()).toContain('note-b.md')
+  })
+
+  it('renders a block-reference badge for block links', () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [blockLink] } })
+    expect(wrapper.text()).toContain('^myblock')
+  })
+
+  it('renders an unresolved badge and falls back to the target_ref for unresolved links', () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [unresolvedLink] } })
+    expect(wrapper.text()).toContain('missing-note')
+    expect(wrapper.text()).toContain('unresolved')
+  })
+
+  it('emits select-note when a resolved link is clicked', async () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [resolvedLink] } })
+    await wrapper.get('.outgoing-link-item').trigger('click')
+    expect(wrapper.emitted('select-note')![0]).toEqual([5])
+  })
+
+  it('does not emit select-note when an unresolved link is clicked', async () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [unresolvedLink] } })
+    await wrapper.get('.outgoing-link-item').trigger('click')
+    expect(wrapper.emitted('select-note')).toBeFalsy()
+  })
+})

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -179,6 +179,12 @@
       @select-note="$emit('select-note', $event)"
     />
 
+    <!-- Outgoing Links Panel -->
+    <OutgoingLinksPanel
+      :links="outgoingLinks"
+      @select-note="$emit('select-note', $event)"
+    />
+
     <!-- Unlinked Mentions Panel -->
     <UnlinkedMentionsPanel
       :mentions="unlinkedMentions"
@@ -203,16 +209,18 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from 'vue'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, UnlinkedMention } from '../services/types'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, UnlinkedMention, OutgoingLink } from '../services/types'
 import {
   uploadAttachment,
   getNoteRevisions, getNoteRevision, restoreNoteRevision,
   setNoteProperty, deleteNoteProperty,
   getNoteComments, addNoteComment, deleteNoteComment,
-  getUnlinkedMentions, getNote, updateNote
+  getUnlinkedMentions, getNote, updateNote,
+  getOutgoingLinks
 } from '../services/api'
 import MarkdownPreview from './MarkdownPreview.vue'
 import BacklinksPanel from './BacklinksPanel.vue'
+import OutgoingLinksPanel from './OutgoingLinksPanel.vue'
 import UnlinkedMentionsPanel from './UnlinkedMentionsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import PropertiesPanel from './PropertiesPanel.vue'
@@ -249,6 +257,7 @@ const revisionPreviewLoading = ref(false)
 const comments = ref<NoteComment[]>([])
 const commentsError = ref<string | null>(null)
 const unlinkedMentions = ref<UnlinkedMention[]>([])
+const outgoingLinks = ref<OutgoingLink[]>([])
 
 // Live Statistics
 const charCount = computed(() => editableContent.value.length)
@@ -305,6 +314,7 @@ watch(() => props.note, (newNote) => {
   showHistory.value = false
   loadComments(newNote.id)
   loadUnlinkedMentions(newNote.id)
+  loadOutgoingLinks(newNote.id)
 }, { immediate: true })
 
 async function loadComments(noteId: number) {
@@ -314,6 +324,15 @@ async function loadComments(noteId: number) {
     comments.value = await getNoteComments(props.workspaceId, noteId)
   } catch (err) {
     console.error('Failed to load comments:', err)
+  }
+}
+
+async function loadOutgoingLinks(noteId: number) {
+  if (!props.workspaceId) return
+  try {
+    outgoingLinks.value = await getOutgoingLinks(props.workspaceId, noteId)
+  } catch (err) {
+    console.error('Failed to load outgoing links:', err)
   }
 }
 

--- a/frontend/src/components/OutgoingLinksPanel.vue
+++ b/frontend/src/components/OutgoingLinksPanel.vue
@@ -1,0 +1,143 @@
+<template>
+  <aside class="outgoing-links-panel" aria-label="Outgoing links">
+    <div class="outgoing-links-header">
+      <div class="header-title">
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <line x1="7" y1="17" x2="17" y2="7"></line>
+          <polyline points="7 7 17 7 17 17"></polyline>
+        </svg>
+        <span>Outgoing Links</span>
+      </div>
+      <span class="count-badge">{{ links.length }}</span>
+    </div>
+
+    <div v-if="links.length === 0" class="outgoing-links-empty">
+      <p>This note doesn't link to any other notes yet.</p>
+    </div>
+
+    <ul v-else class="outgoing-links-list">
+      <li
+        v-for="(link, index) in links"
+        :key="`${link.target_ref}-${index}`"
+        class="outgoing-link-item"
+        :class="{ 'is-unresolved': !link.resolved }"
+        @click="link.resolved && link.id !== null && $emit('select-note', link.id)"
+      >
+        <div class="outgoing-link-title">{{ link.title || link.target_ref }}</div>
+        <div class="outgoing-link-meta">
+          <span v-if="link.target_block" class="block-badge">^{{ link.target_block }}</span>
+          <span v-if="!link.resolved" class="unresolved-badge">unresolved</span>
+          <span v-else class="outgoing-link-path">{{ link.path }}</span>
+        </div>
+      </li>
+    </ul>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import type { OutgoingLink } from '../services/types'
+
+defineProps<{
+  links: OutgoingLink[]
+}>()
+
+defineEmits<{
+  (e: 'select-note', noteId: number): void
+}>()
+</script>
+
+<style scoped>
+.outgoing-links-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.outgoing-links-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.count-badge {
+  background: var(--color-surface-emphasis);
+  color: var(--color-action);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+}
+
+.outgoing-links-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.outgoing-links-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.outgoing-link-item {
+  background: var(--color-surface-emphasis);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+              border-color var(--duration-fast) var(--ease-standard);
+}
+
+.outgoing-link-item.is-unresolved {
+  cursor: default;
+  opacity: 0.75;
+}
+
+.outgoing-link-item:not(.is-unresolved):hover {
+  border-color: var(--color-action);
+}
+
+.outgoing-link-title {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.outgoing-link-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-top: 0.125rem;
+}
+
+.block-badge {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0 0.375rem;
+  font-family: monospace;
+}
+
+.unresolved-badge {
+  color: var(--color-status-warning);
+}
+</style>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention } from './types'
+import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -89,6 +89,11 @@ export async function deleteNote(workspaceId: number, noteId: number): Promise<v
 
 export async function getUnlinkedMentions(workspaceId: number, noteId: number): Promise<UnlinkedMention[]> {
   const response = await api.get<{ data: UnlinkedMention[] }>(`/workspaces/${workspaceId}/notes/${noteId}/unlinked-mentions`)
+  return response.data.data
+}
+
+export async function getOutgoingLinks(workspaceId: number, noteId: number): Promise<OutgoingLink[]> {
+  const response = await api.get<{ data: OutgoingLink[] }>(`/workspaces/${workspaceId}/notes/${noteId}/outgoing-links`)
   return response.data.data
 }
 

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -20,6 +20,15 @@ export interface Backlink {
   target_ref?: string
 }
 
+export interface OutgoingLink {
+  id: number | null
+  path: string | null
+  title: string | null
+  target_ref: string
+  target_block: string | null
+  resolved: boolean
+}
+
 export interface UnlinkedMention {
   id: number
   path: string

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,7 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::post('/workspaces/{workspace}/notes/from-template', [\App\Http\Controllers\WorkspaceTemplateController::class, 'createFromTemplate']);
     Route::match(['get', 'post'], '/workspaces/{workspace}/daily/{date?}', [\App\Http\Controllers\WorkspaceTemplateController::class, 'dailyNote']);
     Route::get('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'show']);
+    Route::get('/workspaces/{workspace}/notes/{note}/outgoing-links', [WorkspaceNoteController::class, 'outgoingLinks']);
     Route::put('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'update']);
     Route::post('/workspaces/{workspace}/notes/{note}/move', [WorkspaceNoteController::class, 'move']);
     Route::delete('/workspaces/{workspace}/notes/{note}', [WorkspaceNoteController::class, 'destroy']);

--- a/tests/Feature/OutgoingLinksTest.php
+++ b/tests/Feature/OutgoingLinksTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class OutgoingLinksTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_outgoing_links_including_resolved_target_and_block_reference(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+
+        $target = $storage->write($workspace, 'note-b.md', "Paragraph.\n^myblock\n");
+        $source = $storage->write(
+            $workspace,
+            'note-a.md',
+            "See [[note-b]] and [[note-b#^myblock]] and [[missing-note]].\n",
+        );
+
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/notes/{$source->id}/outgoing-links");
+
+        $response->assertOk()->assertJsonCount(3, 'data');
+
+        $byRef = collect($response->json('data'))->keyBy('target_ref');
+
+        $this->assertSame($target->id, $byRef['note-b']['id']);
+        $this->assertTrue($byRef['note-b']['resolved']);
+        $this->assertNull($byRef['note-b']['target_block']);
+
+        $this->assertSame($target->id, $byRef['note-b#^myblock']['id']);
+        $this->assertSame('myblock', $byRef['note-b#^myblock']['target_block']);
+
+        $this->assertFalse($byRef['missing-note']['resolved']);
+        $this->assertNull($byRef['missing-note']['id']);
+    }
+
+    public function test_outgoing_links_endpoint_requires_authentication(): void
+    {
+        $workspace = $this->makeWorkspace();
+        $storage = new VaultStorage;
+        $source = $storage->write($workspace, 'note-a.md', "No links here.\n");
+
+        $response = $this->getJson("/api/workspaces/{$workspace->id}/notes/{$source->id}/outgoing-links");
+
+        $response->assertUnauthorized();
+    }
+
+    private function makeWorkspace(): Workspace
+    {
+        $tenant = Tenant::query()->create([
+            'slug' => 'outgoing-tenant-'.uniqid(),
+            'name' => 'Outgoing Links Tenant',
+        ]);
+
+        $vaultPath = storage_path('app/vaults/outgoing_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        return Workspace::query()->create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'outgoing-ws-'.uniqid(),
+            'name' => 'Outgoing Links Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- `Note::outgoingLinks()` already existed as an Eloquent relation, but nothing surfaced it via API or UI -- only backlinks (incoming) were exposed, so Jotter shipped half of Obsidian's bidirectional link graph
- `GET /api/workspaces/{w}/notes/{n}/outgoing-links` -- workspace-scoped, authenticated like every other notes endpoint. Includes unresolved links (`id`/`path`/`title` null, `resolved: false`) and block references (#205's `target_block`), matching the existing broken-link report's convention of surfacing unresolved refs rather than hiding them
- SPA: `OutgoingLinksPanel.vue` alongside the existing `BacklinksPanel.vue`, with a block-reference badge and an unresolved-link indicator; unresolved links are inert (no navigation target)

Fixes #222

## Test plan
- [x] `tests/Feature/OutgoingLinksTest.php` -- resolved link, block reference, unresolved link all returned correctly; endpoint requires authentication
- [x] `frontend/src/OutgoingLinksPanel.spec.ts` -- empty state, resolved/block/unresolved rendering, `select-note` emitted only for resolved links
- [x] Full suite green: `./scripts/jt.sh test` -- 131 passed / 1 skipped (PHP), 21/21 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)