### PR TITLE
fix: exclude stale bootstrap/cache/*.php from release builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ node_modules
 public/build
 storage/logs/*
 vendor
+bootstrap/cache/*.php

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -61,6 +61,12 @@ RUN cd /release/app \
         STATUS.md \
         BACKLOG.md \
     && rm -f .env .env.backup .env.production auth.json \
+    # Defense in depth on top of .dockerignore: a stale bootstrap/cache/*.php
+    # from the build context (e.g. a local `artisan optimize` run with dev
+    # dependencies installed) would hardcode dev-only service providers
+    # (e.g. laravel/pail) into the release, fataling on the --no-dev vendor
+    # at runtime. Guarantee an empty cache regardless of build-context state.
+    && rm -f bootstrap/cache/*.php \
     && mkdir -p storage/app/private storage/framework/cache/data \
         storage/framework/sessions storage/framework/views storage/logs bootstrap/cache \
     && find storage bootstrap/cache -type d -exec chmod 775 {} \;


### PR DESCRIPTION
## Summary
- The release Dockerfile's `COPY . .` step pulled in `bootstrap/cache/*.php` from the build context. `.dockerignore` didn't exclude it, so a local working directory with cached provider manifests leaked those stale caches into the `--no-dev` release
- `bootstrap/cache/services.php` hardcoded `Laravel\Pail\PailServiceProvider` (a `require-dev`-only package, correctly absent from the `--no-dev` vendor), so every artisan invocation and web request against the built release fataled with `Class "Laravel\Pail\PailServiceProvider" not found`
- **Reproduced live during a production deploy**: swapping in a freshly built release took `https://hub.taskconnect.com.br/` down with a 500 until rolled back
- Fix: exclude `bootstrap/cache/*.php` via `.dockerignore`, plus a defense-in-depth `rm` in the release Dockerfile itself so the release is guaranteed to ship with an empty cache regardless of build-context state

Fixes #229

## Test plan
- [x] Full suite green: `./scripts/jt.sh test` -- 132 passed
- [x] Fresh `jt release` build confirmed to ship with no `bootstrap/cache/*.php`
- [x] `php artisan --version` succeeds against the built `--no-dev` vendor in an isolated `php:8.3-cli-alpine` container (previously fataled the same way as the live production 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)