### PR TITLE
feat: add GrandpaSSOn login option alongside local auth

### DIFF
--- a/app/Console/Commands/PromoteAdmin.php
+++ b/app/Console/Commands/PromoteAdmin.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class PromoteAdmin extends Command
+{
+    protected $signature = 'platform:promote-admin {email}';
+
+    protected $description = 'Flip is_admin=true for an existing user, regardless of how they authenticate (local password or SSO-provisioned)';
+
+    public function handle(): int
+    {
+        $email = Str::lower(trim((string) $this->argument('email')));
+
+        /** @var User|null $user */
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user) {
+            $this->error("No user found for {$email}. SSO-provisioned users are created on their first successful login; ask them to sign in once first.");
+
+            return self::FAILURE;
+        }
+
+        if ($user->is_admin) {
+            $this->info("{$email} is already an administrator.");
+
+            return self::SUCCESS;
+        }
+
+        $user->update(['is_admin' => true]);
+
+        $this->info("{$email} promoted to administrator.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -38,6 +38,41 @@ final class AuthController extends Controller
         ]);
     }
 
+    /**
+     * Unauthenticated: tells the SPA which auth mode is active and, for
+     * grandpasson, where to send the user to sign in. GrandpaSSOn's
+     * AUTHSESSID cookie is host-wide (path=/, no explicit domain), so once
+     * login completes there, GrandpaSSOnIdentityProvider recognizes the
+     * session on the next request here -- no callback/token exchange
+     * needed, so redirect_uri just points back at this app's own root and
+     * the code/state query params GrandpaSSOn appends go unused.
+     */
+    public function config(): JsonResponse
+    {
+        $provider = (string) config('jotter.auth_provider', 'local');
+
+        $ssoLoginUrl = null;
+        if ($provider === 'grandpasson') {
+            $brokerBaseUrl = config('jotter.sso.broker_base_url');
+            $clientId = config('jotter.sso.client_id');
+
+            if ($brokerBaseUrl && $clientId) {
+                $ssoLoginUrl = rtrim((string) $brokerBaseUrl, '/').'/login/email?'.http_build_query([
+                    'client_id' => $clientId,
+                    'redirect_uri' => config('app.url'),
+                    'state' => bin2hex(random_bytes(16)),
+                ]);
+            }
+        }
+
+        return response()->json([
+            'data' => [
+                'provider' => $provider,
+                'sso_login_url' => $ssoLoginUrl,
+            ],
+        ]);
+    }
+
     public function logout(Request $request): JsonResponse
     {
         $this->identityProvider->logout($request);

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -32,6 +32,14 @@ return [
     // must match GrandpaSSOn's own DB_PREFIX, not Jotter's (JOTTER_DB_PREFIX/DB_PREFIX).
     'sso' => [
         'db_prefix' => env('JOTTER_SSO_DB_PREFIX', 'sso_'),
+        // Used to build the "Sign in with GrandpaSSOn" redirect URL when
+        // auth_provider=grandpasson. broker_base_url is GrandpaSSOn's own
+        // mount point (e.g. https://hub.taskconnect.com.br/sso); client_id
+        // must match a client registered in GrandpaSSOn's oauth_clients
+        // table (via cron/seed_oauth_client.php) with a redirect_uri
+        // allowing this app's URL.
+        'broker_base_url' => env('JOTTER_SSO_BROKER_BASE_URL'),
+        'client_id' => env('JOTTER_SSO_CLIENT_ID'),
     ],
 
     'attachments' => [

--- a/frontend/src/LoginModal.spec.ts
+++ b/frontend/src/LoginModal.spec.ts
@@ -1,0 +1,48 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginModal from './components/LoginModal.vue'
+import { getAuthConfig } from './services/api'
+
+vi.mock('./services/api', () => ({
+  login: vi.fn(),
+  getAuthConfig: vi.fn(),
+}))
+
+describe('LoginModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not show the SSO link when the provider is local', async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({ provider: 'local', sso_login_url: null })
+
+    const wrapper = mount(LoginModal, { props: { show: true } })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="sso-login-link"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="login-email"]').exists()).toBe(true)
+  })
+
+  it('shows a GrandpaSSOn link above the local form when configured', async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      provider: 'grandpasson',
+      sso_login_url: 'https://hub.taskconnect.com.br/sso/login/email?client_id=jotter&redirect_uri=x&state=y',
+    })
+
+    const wrapper = mount(LoginModal, { props: { show: true } })
+    await flushPromises()
+
+    const ssoLink = wrapper.find('[data-testid="sso-login-link"]')
+    expect(ssoLink.exists()).toBe(true)
+    expect(ssoLink.attributes('href')).toBe(
+      'https://hub.taskconnect.com.br/sso/login/email?client_id=jotter&redirect_uri=x&state=y',
+    )
+    // Local form stays available as a fallback, not replaced.
+    expect(wrapper.find('[data-testid="login-email"]').exists()).toBe(true)
+  })
+
+  it('does not fetch auth config when the modal is not shown', () => {
+    mount(LoginModal, { props: { show: false } })
+    expect(getAuthConfig).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/LoginModal.vue
+++ b/frontend/src/components/LoginModal.vue
@@ -15,6 +15,13 @@
         <p class="login-subtitle">Enter your administrator credentials to access your notes vault.</p>
       </div>
 
+      <div v-if="ssoLoginUrl" class="sso-section">
+        <a :href="ssoLoginUrl" class="btn-sso" data-testid="sso-login-link">
+          Sign in with GrandpaSSOn
+        </a>
+        <div class="sso-divider"><span>or</span></div>
+      </div>
+
       <form @submit.prevent="handleLogin" class="login-form">
         <div v-if="errorMessage" class="login-error" data-testid="login-error">
           {{ errorMessage }}
@@ -61,11 +68,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { login } from '../services/api'
+import { ref, watch } from 'vue'
+import { login, getAuthConfig } from '../services/api'
 import type { AuthUser } from '../services/types'
 
-defineProps<{
+const props = defineProps<{
   show: boolean
 }>()
 
@@ -77,6 +84,21 @@ const email = ref('')
 const password = ref('')
 const isSubmitting = ref(false)
 const errorMessage = ref('')
+const ssoLoginUrl = ref<string | null>(null)
+
+watch(
+  () => props.show,
+  async (visible) => {
+    if (!visible) return
+    try {
+      const config = await getAuthConfig()
+      ssoLoginUrl.value = config.sso_login_url
+    } catch (err) {
+      console.error('Failed to load auth config:', err)
+    }
+  },
+  { immediate: true },
+)
 
 async function handleLogin() {
   if (!email.value.trim() || !password.value) return
@@ -152,6 +174,48 @@ async function handleLogin() {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+}
+
+.sso-section {
+  margin-bottom: var(--space-4);
+}
+
+.btn-sso {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  min-height: 44px;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.btn-sso:hover {
+  border-color: var(--color-action);
+}
+
+.sso-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.sso-divider::before,
+.sso-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
 }
 
 .login-error {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,6 +53,16 @@ export async function getMe(): Promise<AuthUser | null> {
   }
 }
 
+export interface AuthConfig {
+  provider: 'local' | 'grandpasson'
+  sso_login_url: string | null
+}
+
+export async function getAuthConfig(): Promise<AuthConfig> {
+  const response = await api.get<{ data: AuthConfig }>('/auth/config')
+  return response.data.data
+}
+
 export async function getWorkspaces(): Promise<Workspace[]> {
   const response = await api.get<{ data: Workspace[] }>('/workspaces')
   return response.data.data

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route;
 Route::post('/auth/login', [AuthController::class, 'login']);
 Route::post('/auth/logout', [AuthController::class, 'logout']);
 Route::get('/auth/me', [AuthController::class, 'me']);
+Route::get('/auth/config', [AuthController::class, 'config']);
 Route::post('/auth/change-password', [\App\Http\Controllers\AdminUserController::class, 'changePassword']);
 Route::post('/mcp', [\App\Http\Controllers\McpController::class, 'handle']);
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -191,6 +191,104 @@ class AuthTest extends TestCase
             ->assertUnauthorized();
     }
 
+    public function test_grandpasson_auth_provider_still_accepts_real_local_login(): void
+    {
+        // #231: switching to the grandpasson provider must not lock out
+        // existing local accounts (e.g. the bootstrap admin). authenticate()
+        // delegates to LocalIdentityProvider and flags the session so
+        // resolveIdentity() recognizes it on subsequent requests -- verify
+        // that end-to-end through the real /api/auth/login endpoint, not
+        // just via actingAs() (which bypasses session state entirely and is
+        // why the fails-closed test above correctly 401s).
+        config(['jotter.auth_provider' => 'grandpasson']);
+
+        $user = User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password12345'),
+            'is_admin' => true,
+        ]);
+        $tenant = Tenant::create(['slug' => 'default', 'name' => 'Default']);
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'main',
+            'name' => 'Main',
+            'vault_path' => storage_path('app/vaults/test'),
+        ]);
+
+        $this->postJson('/api/auth/login', [
+            'email' => 'admin@example.com',
+            'password' => 'password12345',
+        ])->assertOk();
+
+        $this->getJson("/api/workspaces/{$workspace->id}/notes")->assertOk();
+        $this->getJson('/api/auth/me')->assertOk()->assertJsonPath('data.email', 'admin@example.com');
+    }
+
+    public function test_promote_admin_command_flips_is_admin_for_existing_user(): void
+    {
+        $user = User::factory()->create(['email' => 'sso-user@example.com', 'is_admin' => false]);
+
+        $exitCode = Artisan::call('platform:promote-admin', ['email' => 'sso-user@example.com']);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($user->fresh()->is_admin);
+    }
+
+    public function test_promote_admin_command_is_idempotent_for_an_existing_admin(): void
+    {
+        User::factory()->create(['email' => 'already-admin@example.com', 'is_admin' => true]);
+
+        $exitCode = Artisan::call('platform:promote-admin', ['email' => 'already-admin@example.com']);
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function test_promote_admin_command_fails_for_unknown_email(): void
+    {
+        $exitCode = Artisan::call('platform:promote-admin', ['email' => 'nobody@example.com']);
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    public function test_auth_config_endpoint_reports_local_provider_with_no_sso_url(): void
+    {
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJson(['data' => ['provider' => 'local', 'sso_login_url' => null]]);
+    }
+
+    public function test_auth_config_endpoint_reports_grandpasson_provider_and_builds_sso_login_url(): void
+    {
+        config([
+            'jotter.auth_provider' => 'grandpasson',
+            'jotter.sso.broker_base_url' => 'https://hub.taskconnect.com.br/sso',
+            'jotter.sso.client_id' => 'jotter',
+            'app.url' => 'https://hub.taskconnect.com.br',
+        ]);
+
+        $response = $this->getJson('/api/auth/config')->assertOk();
+
+        $response->assertJsonPath('data.provider', 'grandpasson');
+        $url = $response->json('data.sso_login_url');
+        $this->assertStringStartsWith('https://hub.taskconnect.com.br/sso/login/email?', $url);
+        $this->assertStringContainsString('client_id=jotter', $url);
+        $this->assertStringContainsString('redirect_uri=https%3A%2F%2Fhub.taskconnect.com.br', $url);
+        $this->assertStringContainsString('state=', $url);
+    }
+
+    public function test_auth_config_endpoint_omits_sso_url_when_grandpasson_client_not_configured(): void
+    {
+        config([
+            'jotter.auth_provider' => 'grandpasson',
+            'jotter.sso.broker_base_url' => null,
+            'jotter.sso.client_id' => null,
+        ]);
+
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJson(['data' => ['provider' => 'grandpasson', 'sso_login_url' => null]]);
+    }
+
     public function test_logout_endpoint_invalidates_session_and_writes_audit_log(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- \`JOTTER_AUTH_PROVIDER=grandpasson\` was architecturally supported but had no way for a user to actually *initiate* SSO login -- nothing in the SPA offered a path to reach GrandpaSSOn's login page
- **Verified safe to enable first**: \`GrandpaSSOnIdentityProvider::authenticate()\` delegates to \`LocalIdentityProvider\`, so existing local accounts (including the bootstrap admin) keep working via the existing email/password form after switching providers -- confirmed with a regression test exercising the real \`/api/auth/login\` endpoint end-to-end
- \`GET /api/auth/config\` (unauthenticated): \`{ provider, sso_login_url }\`
- New config: \`jotter.sso.broker_base_url\` / \`jotter.sso.client_id\`
- Design leans on the existing shared-cookie architecture rather than a full OAuth token-exchange callback -- GrandpaSSOn's \`AUTHSESSID\` cookie is host-wide (\`path=/\`, no explicit domain), so once login completes there, \`GrandpaSSOnIdentityProvider\` recognizes the session on the next Jotter request; \`redirect_uri\` just points back at Jotter's own root
- \`platform:promote-admin {email}\`: flips \`is_admin=true\` for an existing user regardless of auth method -- the missing admin-bootstrap path for SSO-provisioned users
- \`LoginModal.vue\`: "Sign in with GrandpaSSOn" link shown above the existing local form when configured, not replacing it -- both paths stay usable

Fixes #231

## Test plan
- [x] \`test_grandpasson_auth_provider_still_accepts_real_local_login\` -- proves local login survives the provider switch via the real endpoint
- [x] \`test_auth_config_endpoint_*\` (3 tests) -- provider/URL shape for local, grandpasson-configured, grandpasson-unconfigured
- [x] \`test_promote_admin_command_*\` (3 tests) -- promote, idempotent, unknown-email failure
- [x] \`frontend/src/LoginModal.spec.ts\` -- SSO link hidden for local, shown+correct href for grandpasson, local form always present, no fetch when modal closed
- [x] Full suite green: \`./scripts/jt.sh test\` -- 139 passed (PHP), 22/22 test files (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)