### PR TITLE
fix: undefined --font-body/--font-heading tokens fell back to serif

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -766,7 +766,7 @@ async function handleWikilinkNavigation(target: string) {
 }
 
 body {
-  font-family: var(--font-body);
+  font-family: var(--font-sans);
   background-color: var(--color-canvas);
   color: var(--color-text);
   height: 100vh;
@@ -919,7 +919,7 @@ body {
 }
 
 .empty-card h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   color: var(--color-text);
   font-size: 1.5rem;
   font-weight: 600;

--- a/frontend/src/components/AttachmentsPanel.vue
+++ b/frontend/src/components/AttachmentsPanel.vue
@@ -103,7 +103,7 @@ function formatDate(iso: string): string {
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }

--- a/frontend/src/components/AuditLogViewer.vue
+++ b/frontend/src/components/AuditLogViewer.vue
@@ -94,7 +94,7 @@ function formatDate(iso: string | null): string {
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -146,7 +146,7 @@ const columns = computed(() => {
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }

--- a/frontend/src/components/CollectionsCalendarView.vue
+++ b/frontend/src/components/CollectionsCalendarView.vue
@@ -157,7 +157,7 @@ const days = computed(() => {
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }

--- a/frontend/src/components/CollectionsTableView.vue
+++ b/frontend/src/components/CollectionsTableView.vue
@@ -174,7 +174,7 @@ const sortedNotes = computed(() => {
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }

--- a/frontend/src/components/LinkReportViewer.vue
+++ b/frontend/src/components/LinkReportViewer.vue
@@ -87,7 +87,7 @@ defineEmits<{
 }
 
 .panel-header h2 {
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- `App.vue`'s global `body` rule used `font-family: var(--font-body)`, and 6 page-title headers (Attachments, AuditLog, LinkReport, CollectionsTableView/BoardView/CalendarView) used `var(--font-heading)`. Neither token was ever defined in `tokens.css` — only `--font-sans`/`--font-mono` exist.
- An undefined custom property makes the `font-family` declaration invalid at computed-value time, so the (inherited) property falls back to the value inherited from `:root` — which `style.css` (the separate pre-auth landing stylesheet) sets to `Georgia, 'Times New Roman', serif`.
- Net effect: the entire app has been silently rendering in serif instead of the intended sans-serif since `b522846a` (2026-07-27) — well before the Notion-redesign PR (#233). Confirmed live on `hub.taskconnect.com.br` via a Playwright check against production (`getComputedStyle(document.body).fontFamily` → Georgia).
- Fix: both tokens map to the one font-family the design system actually defines, `--font-sans`.

## Test plan
- [x] `./scripts/check-design-tokens.sh` — all 5 guards pass
- [x] `./scripts/jt.sh npm -- test` — 117 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
