### PR TITLE
docs: fix stale theme-token references in assets/brand/README.md

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -4,7 +4,7 @@ This directory contains the official brand assets for Jotter.
 
 ## Asset Inventory
 
-- `mark.svg`: Primary brand mark (dark theme & purple palette).
+- `mark.svg`: Primary brand mark. Carries its own embedded dark (`#000000`) backdrop and `#814DDE` purple fill baked into the file — it does not adapt to the app's light/dark theme toggle, by design (see Approved Backgrounds below).
 - `mark-monochrome.svg`: Single-color fallback mark.
 - `wordmark.svg`: Official wordmark incorporating the brand title and mark.
 - `favicon.svg`: Vector favicon optimized for 16×16px to 32×32px rendering.
@@ -20,13 +20,13 @@ Maintain clear space around the mark equal to at least 50% of its width/height (
 - **Wordmark**: Minimum rendered height 24px.
 
 ### Approved Backgrounds
-- **Primary Mark (`mark.svg`)**: Designed for dark backgrounds (`--color-canvas: #000000` or `--color-surface: #1a0a3e`).
-- **Monochrome Mark (`mark-monochrome.svg`)**: Approved for high-contrast light or dark backgrounds.
+- **Primary Mark (`mark.svg`)**: Self-contained — it ships with its own `#000000` backdrop rect baked into the file, so it stays legible on any page background regardless of Jotter's light/dark theme (`docs/visual-identity.md` §2–3). Do not place it directly on a light `--color-canvas`/`--color-surface` expecting it to blend in; it is meant to read as a fixed dark badge, not a theme-aware element.
+- **Monochrome Mark (`mark-monochrome.svg`)**: Uses `fill="currentColor"` — the caller sets one ink color via CSS `color`. Approved for both light and high-contrast dark backgrounds, since it has no embedded backdrop of its own.
 
 ### Prohibited Treatments
 - Do not stretch, warp, or distort the aspect ratio.
 - Do not apply unapproved drop shadows, glows, or gradients to the vector geometry.
-- Do not alter the purple palette tokens (`#814dde`, `#1a0a3e`).
+- Do not alter the mark's purple fill (`#814DDE`) or its embedded `#000000` backdrop — these are fixed, independent of `docs/visual-identity.md`'s theme tokens (which no longer use purple or this specific black at all; see §3 there).
 
 ## License & Ownership
 


### PR DESCRIPTION
## Summary
- Follow-up flagged in `docs/visual-identity.md` §8 (PR #236): `assets/brand/README.md`'s "Approved Backgrounds" section cited `--color-canvas: #000000` / `--color-surface: #1a0a3e`, values from before the Notion redesign that no longer correspond to any token.
- Reworded to describe reality: `mark.svg` has its own embedded `#000000` backdrop baked into the file, independent of the app's light/dark theme — not "designed for dark backgrounds" (a claim that no longer parses now that canvas/surface are light+dark pairs).
- Dropped `#1a0a3e` from the prohibited-treatments list (it was never the mark's own color — that's `#814DDE` — just a stale token reference).

No code, no asset changes — only doc text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
