### PR TITLE
feat: page icon (emoji) for notes — sidebar tree + editor title

### DIFF
--- a/app/Domain/Vault/NotePropertyProjector.php
+++ b/app/Domain/Vault/NotePropertyProjector.php
@@ -13,7 +13,7 @@ final class NotePropertyProjector
         $currentKeys = [];
 
         foreach ($frontmatter as $key => $value) {
-            if ($key === 'tags' || $value === null) {
+            if ($key === 'tags' || $key === 'icon' || $value === null) {
                 continue;
             }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -410,6 +410,22 @@ async function loadActiveNote(noteId: number) {
     const detail = await getNote(activeWorkspaceId.value, noteId)
     activeNoteId.value = noteId
     activeNoteDetail.value = detail
+
+    // Keep the sidebar tree's copy of this note (frontmatter, title, path)
+    // in sync — loadActiveNote only refetches the single note detail, and
+    // the tree renders from the separate `notes` list, which would
+    // otherwise go stale after any frontmatter-driven change (e.g. the
+    // page icon) until the next full notes-list refetch.
+    const index = notes.value.findIndex(n => n.id === noteId)
+    if (index !== -1) {
+      notes.value[index] = {
+        id: detail.id,
+        path: detail.path,
+        title: detail.title,
+        frontmatter: detail.frontmatter,
+        updated_at: detail.updated_at,
+      }
+    }
   } catch (err) {
     console.error('Failed to load note detail:', err)
   }

--- a/frontend/src/NoteEditor.spec.ts
+++ b/frontend/src/NoteEditor.spec.ts
@@ -1,0 +1,108 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import NoteEditor from './components/NoteEditor.vue'
+import type { NoteDetail } from './services/types'
+
+vi.mock('./services/api', () => ({
+  getNoteComments: vi.fn().mockResolvedValue([]),
+  getUnlinkedMentions: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  setNoteProperty: vi.fn().mockResolvedValue({}),
+  deleteNoteProperty: vi.fn().mockResolvedValue({}),
+}))
+
+import { setNoteProperty, deleteNoteProperty } from './services/api'
+
+function makeNote(overrides: Partial<NoteDetail> = {}): NoteDetail {
+  return {
+    id: 1,
+    path: 'test-note.md',
+    title: 'Test Note',
+    frontmatter: null,
+    updated_at: '2026-07-31T00:00:00Z',
+    content: '# Test Note',
+    backlinks: [],
+    properties: [],
+    ...overrides,
+  }
+}
+
+describe('NoteEditor page icon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the fallback icon when no icon is set', () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote(), allNotes: [], workspaceId: 1 },
+    })
+    expect(wrapper.find('[data-testid="editor-icon-fallback"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="editor-icon-emoji"]').exists()).toBe(false)
+  })
+
+  it('renders the emoji when frontmatter.icon is set', () => {
+    const wrapper = mount(NoteEditor, {
+      props: {
+        note: makeNote({ frontmatter: { icon: '📄' } }),
+        allNotes: [],
+        workspaceId: 1,
+      },
+    })
+    expect(wrapper.find('[data-testid="editor-icon-emoji"]').text()).toBe('📄')
+    expect(wrapper.find('[data-testid="editor-icon-fallback"]').exists()).toBe(false)
+  })
+
+  it('clicking the icon opens the input, typing an emoji and pressing Enter calls setNoteProperty', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote(), allNotes: [], workspaceId: 1 },
+    })
+    await wrapper.find('[data-testid="editor-icon-btn"]').trigger('click')
+    const input = wrapper.find('[data-testid="editor-icon-input"]')
+    expect(input.exists()).toBe(true)
+    await input.setValue('🚀')
+    await input.trigger('keydown.enter')
+    expect(setNoteProperty).toHaveBeenCalledWith(1, 1, 'icon', '🚀')
+  })
+
+  it('pressing Enter with an empty draft calls deleteNoteProperty instead', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: {
+        note: makeNote({ frontmatter: { icon: '📄' } }),
+        allNotes: [],
+        workspaceId: 1,
+      },
+    })
+    await wrapper.find('[data-testid="editor-icon-btn"]').trigger('click')
+    const input = wrapper.find('[data-testid="editor-icon-input"]')
+    await input.setValue('')
+    await input.trigger('keydown.enter')
+    expect(deleteNoteProperty).toHaveBeenCalledWith(1, 1, 'icon')
+    expect(setNoteProperty).not.toHaveBeenCalled()
+  })
+
+  it('clicking the hover clear button calls deleteNoteProperty without opening the input', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: {
+        note: makeNote({ frontmatter: { icon: '📄' } }),
+        allNotes: [],
+        workspaceId: 1,
+      },
+    })
+    await wrapper.find('[data-testid="editor-icon-clear"]').trigger('click')
+    expect(deleteNoteProperty).toHaveBeenCalledWith(1, 1, 'icon')
+    expect(wrapper.find('[data-testid="editor-icon-input"]').exists()).toBe(false)
+  })
+
+  it('pressing Escape closes the input without calling either API function', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote(), allNotes: [], workspaceId: 1 },
+    })
+    await wrapper.find('[data-testid="editor-icon-btn"]').trigger('click')
+    const input = wrapper.find('[data-testid="editor-icon-input"]')
+    await input.setValue('🚀')
+    await input.trigger('keydown.escape')
+    expect(setNoteProperty).not.toHaveBeenCalled()
+    expect(deleteNoteProperty).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="editor-icon-input"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -3,7 +3,35 @@
     <!-- Top Action Bar -->
     <header class="editor-bar">
       <div class="note-meta-info">
-        <h2 class="editor-title" data-testid="editor-title">{{ note.title || note.path }}</h2>
+        <div class="editor-title-row">
+          <button
+            v-if="!isEditingIcon"
+            type="button"
+            class="editor-icon-btn"
+            :aria-label="noteIcon ? 'Change page icon' : 'Set page icon'"
+            data-testid="editor-icon-btn"
+            @click="startEditingIcon"
+          >
+            <span v-if="noteIcon" data-testid="editor-icon-emoji">{{ noteIcon }}</span>
+            <svg v-else data-testid="editor-icon-fallback" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+            </svg>
+            <span v-if="noteIcon" class="editor-icon-clear" data-testid="editor-icon-clear" @click.stop="clearIcon">&times;</span>
+          </button>
+          <input
+            v-else
+            v-model="iconDraft"
+            type="text"
+            class="editor-icon-input"
+            data-testid="editor-icon-input"
+            autofocus
+            @keydown.enter="confirmEditingIcon"
+            @keydown.escape="cancelEditingIcon"
+            @blur="confirmEditingIcon"
+          />
+          <h2 class="editor-title" data-testid="editor-title">{{ note.title || note.path }}</h2>
+        </div>
         <span class="editor-path" data-testid="editor-path">{{ note.path }}</span>
       </div>
 
@@ -237,6 +265,54 @@ const emit = defineEmits<{
   (e: 'select-note', noteId: number): void
   (e: 'navigate-wikilink', target: string): void
 }>()
+
+const isEditingIcon = ref(false)
+const iconDraft = ref('')
+
+const noteIcon = computed(() => {
+  const icon = props.note.frontmatter?.icon
+  return typeof icon === 'string' && icon.trim() !== '' ? icon : null
+})
+
+function startEditingIcon() {
+  iconDraft.value = noteIcon.value ?? ''
+  isEditingIcon.value = true
+}
+
+function cancelEditingIcon() {
+  isEditingIcon.value = false
+  iconDraft.value = ''
+}
+
+async function confirmEditingIcon() {
+  const trimmed = iconDraft.value.trim()
+  if (!props.workspaceId) {
+    cancelEditingIcon()
+    return
+  }
+  try {
+    if (trimmed === '') {
+      await deleteNoteProperty(props.workspaceId, props.note.id, 'icon')
+    } else {
+      await setNoteProperty(props.workspaceId, props.note.id, 'icon', trimmed)
+    }
+    emit('select-note', props.note.id)
+  } catch (err) {
+    console.error('Failed to update page icon:', err)
+  }
+  isEditingIcon.value = false
+  iconDraft.value = ''
+}
+
+async function clearIcon() {
+  if (!props.workspaceId) return
+  try {
+    await deleteNoteProperty(props.workspaceId, props.note.id, 'icon')
+    emit('select-note', props.note.id)
+  } catch (err) {
+    console.error('Failed to clear page icon:', err)
+  }
+}
 
 const viewMode = ref<'edit' | 'split' | 'preview'>('split')
 const editableContent = ref(props.note.content)
@@ -607,6 +683,66 @@ async function handleSave() {
 .note-meta-info {
   display: flex;
   flex-direction: column;
+}
+
+.editor-title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.editor-icon-btn {
+  position: relative;
+  flex-shrink: 0;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+.editor-icon-btn:hover {
+  background: var(--color-hover);
+}
+
+.editor-icon-clear {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-standard);
+}
+
+.editor-icon-btn:hover .editor-icon-clear {
+  opacity: 1;
+}
+
+.editor-icon-input {
+  width: 44px;
+  min-height: 44px;
+  text-align: center;
+  font-size: 1.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
 }
 
 .editor-title {

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -285,6 +285,14 @@ function cancelEditingIcon() {
 }
 
 async function confirmEditingIcon() {
+  // Unmounting the icon input (which happens at the end of this very
+  // function, via isEditingIcon.value = false) fires a native blur event
+  // in a real browser, re-invoking this handler through @blur. Guard
+  // against that re-entrant call — jsdom-based unit tests never trigger
+  // it, so this only surfaces in a real browser (found via manual/e2e
+  // verification, not the component test suite).
+  if (!isEditingIcon.value) return
+
   const trimmed = iconDraft.value.trim()
   if (!props.workspaceId) {
     cancelEditingIcon()

--- a/frontend/src/components/NoteTreeNode.vue
+++ b/frontend/src/components/NoteTreeNode.vue
@@ -45,6 +45,11 @@
     :style="{ paddingLeft: `${depth * 14 + 8}px` }"
     @click="$emit('select-note', node.note.id)"
   >
+    <span v-if="noteIcon" class="note-icon" data-testid="note-icon-emoji">{{ noteIcon }}</span>
+    <svg v-else class="note-icon note-icon-fallback" data-testid="note-icon-fallback" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+      <polyline points="14 2 14 8 20 8"></polyline>
+    </svg>
     <div class="note-info">
       <span class="note-title">{{ node.note.title || node.note.path }}</span>
       <span class="note-path">{{ node.note.path }}</span>
@@ -99,6 +104,12 @@ function countNotes(node: TreeNode): number {
 }
 
 const noteCount = computed(() => (props.node.type === 'folder' ? countNotes(props.node) : 0))
+
+const noteIcon = computed(() => {
+  if (props.node.type !== 'file') return null
+  const icon = props.node.note.frontmatter?.icon
+  return typeof icon === 'string' && icon.trim() !== '' ? icon : null
+})
 </script>
 
 <style scoped>
@@ -179,6 +190,21 @@ const noteCount = computed(() => (props.node.type === 'folder' ? countNotes(prop
   background: color-mix(in srgb, var(--color-action) 20%, transparent);
   color: var(--color-action);
   font-weight: 600;
+}
+
+.note-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.note-icon-fallback {
+  color: var(--color-text-muted);
 }
 
 .note-info {

--- a/tests/Feature/NotePropertyProjectionTest.php
+++ b/tests/Feature/NotePropertyProjectionTest.php
@@ -128,4 +128,48 @@ MARKDOWN);
             'value_datetime' => '2026-12-31 00:00:00',
         ]);
     }
+
+    public function test_icon_frontmatter_key_is_excluded_from_property_projection(): void
+    {
+        $tenant = Tenant::create(['slug' => 'icon-test', 'name' => 'Icon Test']);
+        $vaultPath = storage_path('app/vaults/prop_icon_'.uniqid());
+        @mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'icon-test',
+            'name' => 'Icon Test Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        $storage = new VaultStorage();
+        $note = $storage->write($workspace, 'iconed.md', <<<'MARKDOWN'
+---
+title: Iconed Note
+icon: "📄"
+status: "active"
+---
+# Iconed Note Body
+MARKDOWN);
+
+        // icon must not be projected as a queryable NoteProperty row...
+        $this->assertDatabaseMissing('note_properties', [
+            'note_id' => $note->id,
+            'name' => 'icon',
+        ]);
+
+        // ...but a sibling ordinary key on the same note still is, proving
+        // the exclusion is scoped to `icon` specifically, not a projection
+        // regression.
+        $this->assertDatabaseHas('note_properties', [
+            'note_id' => $note->id,
+            'name' => 'status',
+            'type' => 'string',
+            'value_string' => 'active',
+        ]);
+
+        // ...and the frontmatter column itself still carries the raw value,
+        // since that's what the frontend reads to render the icon.
+        $this->assertSame('📄', $note->fresh()->frontmatter['icon']);
+    }
 }


### PR DESCRIPTION
## Summary
Feature 1 of 5 proposed Notion-parity UX improvements: a per-note emoji icon, shown read-only in the sidebar tree and editable in the editor title bar.

- `icon` is stored as a plain front-matter key, written/read through the existing generic `setNoteProperty`/`deleteNoteProperty` path — zero new API endpoints, zero migration.
- Excluded from `NotePropertyProjector` (mirroring the existing `tags` exclusion) so it never becomes a queryable `NoteProperty` row / never shows in `PropertiesPanel`.
- Native OS emoji picker (no in-app grid), fallback document-glyph icon reserving fixed space so the title never shifts, editor-only edit affordance (tree stays read-only).
- Click icon → inline input → `Enter` confirms, `Escape` cancels, empty `Enter` or hover-`×` clears.

Two real bugs found and fixed during manual/real-browser verification (invisible to jsdom-based unit tests):
1. `App.vue`'s note-selection reload only refreshed the active note detail, not the separate list the sidebar tree renders from — icon changes went stale in the tree until an unrelated reload. Fixed by patching the tree's copy in place.
2. The icon input's `@blur` handler re-fired after the input unmounted (real browsers fire a native blur on removal; jsdom doesn't), sending a spurious delete right after every set. Fixed with an idempotency guard.

Spec: `docs/superpowers/specs/2026-07-31-page-icon-design.md` (PR #238)
Plan: `docs/superpowers/plans/2026-07-31-page-icon-implementation.md`

## Test plan
- [x] `./scripts/jt.sh test` — 139 PHP tests passed (1 skipped), 123 frontend tests passed
- [x] `./scripts/check-design-tokens.sh` — all 5 guards pass
- [x] Real-browser Playwright verification: set/clear icon, sidebar sync, Properties panel excludes `icon`, Escape/blur behavior
- [x] Existing `e2e/notes.spec.ts` re-confirmed passing (one flaky retry due to environment contention, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
