### PR TITLE
Fix: enable SortableJS forceFallback for touch support

### DIFF
--- a/frontend/src/composables/useNoteTreeSortable.ts
+++ b/frontend/src/composables/useNoteTreeSortable.ts
@@ -48,6 +48,11 @@ export function createNoteTreeSortable(
     disabled: initiallyDisabled,
     animation: 150,
     ghostClass: 'note-tree-ghost',
+    // Native HTML5 drag-and-drop never fires from touch input, so the
+    // fallback (mouse/touch-event-based) simulation is required for the
+    // touch support this feature is spec'd to have — not just a testing
+    // convenience.
+    forceFallback: true,
     onMove(evt) {
       const draggedType = (evt.dragged as HTMLElement).dataset.itemType
       return !shouldRejectMove(draggedType, evt.from === evt.to)


### PR DESCRIPTION
## Summary
- PR #240 (sidebar drag-and-drop) shipped without `forceFallback: true` on the SortableJS instance — this option was decided during design/planning (spec §5, plan Task 5) but the local change was accidentally left uncommitted.
- Without it, SortableJS uses native HTML5 drag-and-drop, which never fires from touch input — the "desktop + touch" requirement chosen during brainstorming silently didn't work on touch devices.
- Discovered while investigating why the e2e drag simulation wasn't registering; confirmed the fix is required by re-reading the composable against the merged spec.

## Test plan
- [x] `useNoteTreeSortable.spec.ts` — 10 unit tests pass unchanged (this option doesn't affect the pure helper functions under test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)