### PR TITLE
Inline per-folder quick-create (Feature 3)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-inline-folder-create-implementation.md
+++ b/docs/superpowers/plans/2026-07-31-inline-folder-create-implementation.md
@@ -1,0 +1,573 @@
+# Inline Per-Folder Quick Create Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a hover-reveal "+" button on each sidebar folder row that creates a new note directly inside that folder, auto-expanding the folder and selecting the new note.
+
+**Architecture:** `NoteTreeNode.vue` emits a new `create-note-in-folder` event bubbled up through `Sidebar.vue` to `App.vue`, which prefixes an auto-generated filename with the folder path and delegates to the existing `handleCreateNote` (unchanged, already does create → refresh → select).
+
+**Tech Stack:** Vue 3 `<script setup>` + TypeScript, Vitest, `@vue/test-utils`.
+
+## Global Constraints
+
+- No new API endpoint or backend change — reuses the existing note-create endpoint via `handleCreateNote` (spec §1).
+- "+" appears only on folder rows, never on note rows and never on the root "All Notes" header (spec §2).
+- No inline rename prompt after creation — filename follows the existing `untitled-<base36 timestamp>.md` pattern used by `CommandPalette`'s quick-create (spec §2, §3).
+- Clicking "+" must not toggle the folder's own expand/collapse state via the parent row's click handler — it has its own `@click.stop` (spec §3).
+- Clicking "+" on a collapsed folder must expand it (spec §3).
+
+---
+
+### Task 1: `NoteTreeNode.vue` — hover "+" button, new emit, auto-expand
+
+**Files:**
+- Modify: `frontend/src/components/NoteTreeNode.vue`
+- Test: `frontend/src/NoteTreeNode.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new — pure template/script addition to the existing component.
+- Produces: new emit `(e: 'create-note-in-folder', folderPath: string): void`, which `Sidebar.vue` (Task 2) listens for on both the recursive `<NoteTreeNode>` (nested folders) and the root-level `<NoteTreeNode>` in its own template.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `frontend/src/NoteTreeNode.spec.ts` (existing file — these are new `it()` blocks inside the existing `describe('NoteTreeNode drag attributes', ...)` block is the wrong place; add a new sibling `describe`):
+
+```typescript
+describe('NoteTreeNode folder quick-create', () => {
+  function makeFolderNode(overrides: Partial<TreeNode> = {}): TreeNode {
+    return {
+      type: 'folder',
+      name: 'docs',
+      fullPath: 'docs',
+      children: [],
+      ...overrides,
+    } as TreeNode
+  }
+
+  it('emits create-note-in-folder with the folder\'s fullPath when + is clicked', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode(), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+
+  it('does not toggle collapse when + is clicked on an expanded folder', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: {
+        node: makeFolderNode({
+          children: [
+            { type: 'file', note: { id: 1, path: 'docs/a.md', title: 'A', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' } },
+          ],
+        }),
+        selectedNoteId: null,
+        depth: 0,
+      },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    const children = wrapper.find('.folder-children')
+    expect((children.element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('expands a collapsed folder when + is clicked', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: {
+        node: makeFolderNode({
+          children: [
+            { type: 'file', note: { id: 1, path: 'docs/a.md', title: 'A', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' } },
+          ],
+        }),
+        selectedNoteId: null,
+        depth: 0,
+      },
+    })
+    // Collapse it first (starts expanded by default)
+    await wrapper.find('.folder-row').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+
+  it('bubbles a nested folder\'s + click up through the parent NoteTreeNode unchanged', async () => {
+    const nested: TreeNode = makeFolderNode({
+      name: 'archived',
+      fullPath: 'docs/archived',
+      children: [],
+    })
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ children: [nested] }), selectedNoteId: null, depth: 0 },
+    })
+    const nestedBtn = wrapper.findAll('[data-testid="folder-create-note-btn"]')[1]
+    await nestedBtn.trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs/archived']])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- NoteTreeNode.spec.ts`
+Expected: FAIL — `[data-testid="folder-create-note-btn"]` does not exist yet.
+
+- [ ] **Step 3: Restructure the folder row and add the button**
+
+`.folder-row` is currently a `<button>` (toggles expand/collapse on click).
+A `<button>` cannot contain another `<button>` per HTML semantics, so the
+new "+" button must be a **sibling** of `.folder-row`, not nested inside
+it. Wrap both in a new flex container.
+
+In `frontend/src/components/NoteTreeNode.vue`, change:
+
+```html
+  <div
+    v-if="node.type === 'folder'"
+    class="tree-folder"
+    data-item-type="folder"
+    :data-item-path="node.fullPath"
+  >
+    <button
+      type="button"
+      class="folder-row"
+      :style="{ paddingLeft: `${depth * 14 + 8}px` }"
+      :aria-expanded="expanded"
+      @click="expanded = !expanded"
+    >
+      <svg
+        class="chevron"
+        :class="{ collapsed: !expanded }"
+        viewBox="0 0 24 24"
+        width="12"
+        height="12"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+      >
+        <polyline points="9 6 15 12 9 18"></polyline>
+      </svg>
+      <svg class="folder-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"></path>
+      </svg>
+      <span class="folder-name">{{ node.name }}</span>
+      <span class="folder-count">{{ noteCount }}</span>
+    </button>
+    <div v-show="expanded" class="folder-children" ref="childrenListRef" :data-folder-path="node.fullPath">
+```
+
+to:
+
+```html
+  <div
+    v-if="node.type === 'folder'"
+    class="tree-folder"
+    data-item-type="folder"
+    :data-item-path="node.fullPath"
+  >
+    <div class="folder-row-wrapper">
+      <button
+        type="button"
+        class="folder-row"
+        :style="{ paddingLeft: `${depth * 14 + 8}px` }"
+        :aria-expanded="expanded"
+        @click="expanded = !expanded"
+      >
+        <svg
+          class="chevron"
+          :class="{ collapsed: !expanded }"
+          viewBox="0 0 24 24"
+          width="12"
+          height="12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+        >
+          <polyline points="9 6 15 12 9 18"></polyline>
+        </svg>
+        <svg class="folder-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"></path>
+        </svg>
+        <span class="folder-name">{{ node.name }}</span>
+        <span class="folder-count">{{ noteCount }}</span>
+      </button>
+      <button
+        type="button"
+        class="btn-create-in-folder"
+        data-testid="folder-create-note-btn"
+        title="Create note in this folder"
+        aria-label="Create note in this folder"
+        @click.stop="createNoteInFolder"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="12" y1="5" x2="12" y2="19"></line>
+          <line x1="5" y1="12" x2="19" y2="12"></line>
+        </svg>
+      </button>
+    </div>
+    <div v-show="expanded" class="folder-children" ref="childrenListRef" :data-folder-path="node.fullPath">
+```
+
+(The `.folder-children` div and everything inside it — the recursive
+`<NoteTreeNode>` list — is unchanged in this step; Task 1 Step 4 adds the
+bubble-up wiring to it.)
+
+- [ ] **Step 4: Add the emit, handler, and bubble-up wiring**
+
+Change the `defineEmits` call:
+
+```typescript
+defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'delete-note', noteId: number): void
+}>()
+```
+
+to:
+
+```typescript
+const emit = defineEmits<{
+  (e: 'select-note', noteId: number): void
+  (e: 'delete-note', noteId: number): void
+  (e: 'create-note-in-folder', folderPath: string): void
+}>()
+```
+
+Add this function next to `noteIcon` (or any other computed/function in
+the `<script setup>` block):
+
+```typescript
+function createNoteInFolder() {
+  expanded.value = true
+  if (props.node.type === 'folder') {
+    emit('create-note-in-folder', props.node.fullPath)
+  }
+}
+```
+
+Update the recursive `<NoteTreeNode>` invocation inside `.folder-children`
+to bubble the new event up:
+
+```html
+      <NoteTreeNode
+        v-for="child in node.children"
+        :key="child.type === 'folder' ? `f:${child.fullPath}` : `n:${child.note.id}`"
+        :node="child"
+        :selected-note-id="selectedNoteId"
+        :depth="depth + 1"
+        @select-note="$emit('select-note', $event)"
+        @delete-note="$emit('delete-note', $event)"
+        @create-note-in-folder="$emit('create-note-in-folder', $event)"
+      />
+```
+
+- [ ] **Step 5: Add the hover-reveal CSS**
+
+In the `<style scoped>` block, change `.folder-row`'s `width: 100%` to
+`flex: 1; min-width: 0;` (it now sits inside a flex wrapper instead of
+being the full-width element itself):
+
+```css
+.folder-row {
+  width: 100%;
+  display: flex;
+```
+
+to:
+
+```css
+.folder-row {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+```
+
+Add a new `.folder-row-wrapper` rule right before `.folder-row` and a
+`.btn-create-in-folder` rule right after `.folder-count`'s rule:
+
+```css
+.folder-row-wrapper {
+  display: flex;
+  align-items: center;
+}
+```
+
+```css
+.btn-create-in-folder {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  flex-shrink: 0;
+  margin-right: var(--space-1);
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard),
+              opacity var(--duration-fast) var(--ease-standard);
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.folder-row-wrapper:hover .btn-create-in-folder {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .btn-create-in-folder {
+    opacity: 1;
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+.btn-create-in-folder:hover {
+  color: var(--color-action);
+  background: var(--color-hover);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- NoteTreeNode.spec.ts`
+Expected: PASS — the 4 new tests plus the pre-existing tests in this file
+all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/NoteTreeNode.vue frontend/src/NoteTreeNode.spec.ts
+git commit -m "feat: add hover + button to create a note inside a sidebar folder"
+```
+
+---
+
+### Task 2: `Sidebar.vue` — bubble the event to the root
+
+**Files:**
+- Modify: `frontend/src/components/Sidebar.vue`
+- Test: `frontend/src/Sidebar.spec.ts`
+
+**Interfaces:**
+- Consumes: `create-note-in-folder` emit from `NoteTreeNode` (Task 1).
+- Produces: `Sidebar` re-emits the same `create-note-in-folder` event one
+  level up, for `App.vue` (Task 3) to listen to.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/Sidebar.spec.ts` (existing file, add as a new `it()`
+inside the existing `describe('Sidebar manual sort mode', ...)` block, or
+as its own sibling `describe` — use a sibling block since this isn't
+about sort mode):
+
+```typescript
+describe('Sidebar folder quick-create', () => {
+  it('bubbles create-note-in-folder from a root-level folder up to its own emit', async () => {
+    const notes: NoteMeta[] = [
+      makeNote({ id: 1, path: 'docs/a.md', title: 'A' }),
+    ]
+    const wrapper = mount(Sidebar, {
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [] },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm test -- Sidebar.spec.ts`
+Expected: FAIL — `Sidebar` doesn't declare or wire the `create-note-in-folder` emit yet.
+
+- [ ] **Step 3: Add the emit and wire the root `<NoteTreeNode>`**
+
+Change the `defineEmits` call (find the line ending `(e: 'notes-reordered'): void` and add one more entry):
+
+```typescript
+  (e: 'notes-reordered'): void
+}>()
+```
+
+to:
+
+```typescript
+  (e: 'notes-reordered'): void
+  (e: 'create-note-in-folder', folderPath: string): void
+}>()
+```
+
+Update the root-level `<NoteTreeNode>` in the template:
+
+```html
+        <NoteTreeNode
+          v-for="node in noteTree"
+          :key="node.type === 'folder' ? `f:${node.fullPath}` : `n:${node.note.id}`"
+          :node="node"
+          :selected-note-id="selectedNoteId"
+          :depth="0"
+          @select-note="$emit('select-note', $event)"
+          @delete-note="$emit('delete-note', $event)"
+        />
+```
+
+to:
+
+```html
+        <NoteTreeNode
+          v-for="node in noteTree"
+          :key="node.type === 'folder' ? `f:${node.fullPath}` : `n:${node.note.id}`"
+          :node="node"
+          :selected-note-id="selectedNoteId"
+          :depth="0"
+          @select-note="$emit('select-note', $event)"
+          @delete-note="$emit('delete-note', $event)"
+          @create-note-in-folder="$emit('create-note-in-folder', $event)"
+        />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm test -- Sidebar.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Sidebar.vue frontend/src/Sidebar.spec.ts
+git commit -m "feat: bubble create-note-in-folder up through Sidebar"
+```
+
+---
+
+### Task 3: `App.vue` — handler that prefixes the path and reuses `handleCreateNote`
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+- Test: `frontend/src/App.spec.ts`
+
+**Interfaces:**
+- Consumes: `create-note-in-folder` emit from `Sidebar` (Task 2);
+  `handleCreateNote(path: string): Promise<void>` (existing, unchanged).
+- Produces: nothing consumed by later tasks — this is the final wiring
+  point.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `frontend/src/App.spec.ts` (existing file). This file's `vi.mock('./services/api', ...)` block already mocks `createNote` as `vi.fn()` (no resolved value) — check it before adding, and give it a resolved value so `await handleSelectNote(created.id)` inside `handleCreateNote` doesn't throw on `created.id`:
+
+```typescript
+  createNote: vi.fn().mockResolvedValue({ id: 99, path: 'docs/untitled-x.md', title: '', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' }),
+```
+
+(replace the existing bare `createNote: vi.fn(),` line with this one).
+
+Then add the test, importing `createNote` from the mocked module at the
+top of the file alongside any other imported mocks:
+
+```typescript
+import { createNote } from './services/api'
+
+describe('App folder quick-create', () => {
+  it('prefixes the auto-generated filename with the folder path', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    await vm.handleCreateNoteInFolder('docs')
+    expect(createNote).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^docs\/untitled-[a-z0-9]+\.md$/),
+      expect.any(String),
+    )
+  })
+
+  it('creates at the vault root when folderPath is empty', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    await vm.handleCreateNoteInFolder('')
+    expect(createNote).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^untitled-[a-z0-9]+\.md$/),
+      expect.any(String),
+    )
+  })
+})
+```
+
+`handleCreateNoteInFolder` is reachable via `(wrapper.vm as any).handleCreateNoteInFolder(...)`
+with no `defineExpose` needed — confirmed working precedent already in
+this codebase: `frontend/src/CommandPalette.spec.ts:15-16` does
+`const vm = wrapper.vm as any; vm.open()` against a plain `<script setup>`
+component, calling a top-level function the same way.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- App.spec.ts`
+Expected: FAIL — `handleCreateNoteInFolder` is not defined, and `Sidebar` isn't wired to it yet.
+
+- [ ] **Step 3: Add the handler and wire it on `<Sidebar>`**
+
+Add this function in `frontend/src/App.vue`'s `<script setup>` block,
+directly above `async function handleCreateNote(path: string) {`:
+
+```typescript
+function handleCreateNoteInFolder(folderPath: string) {
+  const fileName = `untitled-${Date.now().toString(36)}.md`
+  const path = folderPath === '' ? fileName : `${folderPath}/${fileName}`
+  return handleCreateNote(path)
+}
+```
+
+Wire it on the `<Sidebar>` element in the template:
+
+```html
+      @notes-reordered="refreshNotesList"
+      @select-note="handleSelectNote"
+```
+
+to:
+
+```html
+      @notes-reordered="refreshNotesList"
+      @create-note-in-folder="handleCreateNoteInFolder"
+      @select-note="handleSelectNote"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- App.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full frontend suite**
+
+Run: `./scripts/jt.sh npm test`
+Expected: PASS, all tests including the new ones — no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/App.vue frontend/src/App.spec.ts
+git commit -m "feat: wire per-folder quick-create through App.vue"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §2 in-scope bullets (hover "+" on folder rows only,
+  create + auto-select + auto-expand) → Task 1 Steps 3–5. §2 out-of-scope
+  bullets (no note-row "+", no root-header "+", no rename prompt, no new
+  collision handling) → simply not built; nothing in any task adds them.
+  §3's exact handler code for all three files → Tasks 1–3. §4 testing →
+  one test file touched per task, matching the spec's per-file breakdown
+  exactly.
+- **Placeholder scan:** none found.
+- **Type consistency:** `create-note-in-folder` emitted with a `string`
+  payload (`folderPath`) consistently across `NoteTreeNode.vue` (Task 1),
+  `Sidebar.vue` (Task 2, pure passthrough), and `App.vue`'s
+  `handleCreateNoteInFolder(folderPath: string)` (Task 3) — same name,
+  same type, at every hop.

--- a/docs/superpowers/specs/2026-07-31-inline-folder-create-design.md
+++ b/docs/superpowers/specs/2026-07-31-inline-folder-create-design.md
@@ -1,0 +1,142 @@
+# Inline "+" Per-Folder Quick Create — Design
+
+Date: 2026-07-31
+Status: Approved for planning
+Scope: Presentation-only. No new API endpoints, no database change, no
+change to the Markdown-on-disk invariant — reuses the existing note-create
+endpoint and `App.vue`'s existing `handleCreateNote` handler verbatim.
+
+## 1. Purpose
+
+Feature 3 of 5 Notion-parity UX features proposed for Jotter (features 1,
+page icon, and 2, sidebar drag-and-drop, are already implemented and
+merged). Notion shows a "+" on hover over a page-tree folder to instantly
+create a new page inside it. Jotter today only offers note creation via
+the header "New Note" modal (typed full path) or the Command Palette's
+quick-create (always at the vault root) — there is no way to create a
+note directly inside a specific folder without typing that folder's path
+by hand into the modal.
+
+## 2. Scope
+
+**In scope:**
+- A hover-reveal "+" button on each **folder** row in `NoteTreeNode.vue`,
+  same visual/interaction pattern as the existing hover-reveal
+  `.btn-delete` on note rows.
+- Clicking it creates a new note directly inside that folder, auto-selects
+  it in the editor, and auto-expands the folder if it was collapsed.
+
+**Out of scope (confirmed during brainstorming):**
+- No "+" on note rows — creating a sibling note is already covered by the
+  parent folder's own "+", so a second affordance per note row would be
+  redundant.
+- No "+" on the root-level "All Notes" section header — the vault root
+  already has two quick-create paths (header "New Note" modal, Command
+  Palette), a third would be redundant.
+- No inline rename prompt after creation. Jotter has no separate editable
+  "title" field — `NoteEditor.vue`'s title (`.editor-title`, confirmed
+  read-only `<h2>`) is derived from the note's first `# heading` or its
+  path. Renaming already happens by editing that heading in the body, same
+  as every other note creation path in the app.
+- No filename collision handling beyond what already exists: the
+  auto-generated name uses the same `untitled-<base36 timestamp>.md`
+  pattern as `CommandPalette`'s quick-create (`App.vue`'s
+  `@create-note="() => handleCreateNote(...)"` handler), which is already
+  accepted as sufficiently collision-free for this app's usage pattern.
+
+## 3. Component changes
+
+### `NoteTreeNode.vue`
+
+In the folder branch's `.folder-row` button, next to the existing
+`.folder-count` badge, add a "+" button:
+- Hover-reveal opacity (same pattern as `.btn-delete`), full 44×44px hit
+  target under the existing `@media (max-width: 768px)` touch rule so it's
+  always visible (not hover-dependent) on touch devices.
+- `@click.stop` — critical: `.folder-row`'s own click handler toggles
+  `expanded`, and the "+" sits inside that same button-like row, so its
+  click must not also trigger the parent's toggle in a way that conflicts
+  with the auto-expand behavior below (only this button's own logic
+  should decide expansion state on this interaction).
+- `title="Create note in this folder"` / `aria-label` for accessibility.
+- Handler:
+  ```typescript
+  function createNoteInFolder() {
+    expanded.value = true
+    emit('create-note-in-folder', (props.node as TreeFolder).fullPath)
+  }
+  ```
+- New emit added to the existing `defineEmits`:
+  `(e: 'create-note-in-folder', folderPath: string): void`
+- The recursive `<NoteTreeNode>` invocation (folder's own children list)
+  gets `@create-note-in-folder="$emit('create-note-in-folder', $event)"`
+  added alongside the existing `@select-note`/`@delete-note` bubble-up,
+  so the event propagates from any depth up to `Sidebar.vue`.
+
+### `Sidebar.vue`
+
+- New emit: `(e: 'create-note-in-folder', folderPath: string): void`.
+- The root-level `<NoteTreeNode>` invocation (the `v-for="node in
+  noteTree"` one, depth 0) gets
+  `@create-note-in-folder="$emit('create-note-in-folder', $event)"`.
+
+### `App.vue`
+
+New handler, placed next to the existing `handleCreateNote`:
+```typescript
+function handleCreateNoteInFolder(folderPath: string) {
+  const fileName = `untitled-${Date.now().toString(36)}.md`
+  const path = folderPath === '' ? fileName : `${folderPath}/${fileName}`
+  handleCreateNote(path)
+}
+```
+Wired on `<Sidebar>` as `@create-note-in-folder="handleCreateNoteInFolder"`.
+Reuses `handleCreateNote` unchanged — it already does the create-API-call
+→ `refreshNotesList()` → `handleSelectNote(created.id)` sequence, so no
+new API-calling code is written; this handler is purely a path-prefixing
+adapter in front of it. `folderPath === ''` case exists for defensive
+completeness (matches the fallback root-folder path used throughout
+`buildTree()`) even though the root header has no "+" per §2 — the root
+folder node itself is never rendered as a `.folder-row` today, so this
+branch is not reachable through the UI, only through direct calls to
+`handleCreateNoteInFolder('')`.
+
+## 4. Testing
+
+**Frontend (Vitest), `NoteTreeNode.spec.ts`:**
+- Clicking the "+" on a folder row emits `create-note-in-folder` with that
+  folder's exact `fullPath`.
+- Clicking the "+" on a folder row does **not** toggle `expanded` away
+  from its already-expanded state (i.e., it doesn't collapse an open
+  folder) — asserts `.folder-children`'s `display` stays visible
+  afterward.
+- Clicking the "+" on a **collapsed** folder row both expands it
+  (`.folder-children` becomes visible) and emits the event.
+- A nested folder's "+" click bubbles the event up through an intermediate
+  parent `NoteTreeNode` unchanged (asserts the emitted `folderPath` is the
+  nested folder's path, not the parent's).
+
+**`Sidebar.spec.ts`:**
+- Clicking a folder's "+" in a mounted `Sidebar` emits
+  `create-note-in-folder` from the `Sidebar` component itself with the
+  correct path (confirms the root-level wiring, not just `NoteTreeNode`'s
+  own emit).
+
+**`App.spec.ts`:**
+- `handleCreateNoteInFolder('docs')` calls the (mocked) `createNote` API
+  function with path `docs/untitled-<something>.md` (asserted via a
+  regex/prefix match, since the timestamp portion is non-deterministic).
+- `handleCreateNoteInFolder('')` calls `createNote` with a bare
+  `untitled-<something>.md` path (no leading slash or empty segment).
+
+No backend test changes — no backend code changes in this feature.
+
+## 5. Out of scope / open questions carried forward
+
+- No "+" on note rows or the root header (§2).
+- No inline rename UX (§2) — would require Jotter to grow an editable
+  title field, a larger, separate feature if ever requested.
+- Filename collision at sub-millisecond double-click speed is
+  theoretically possible (same as the pre-existing Command Palette
+  quick-create) but not handled — consistent with existing accepted risk,
+  not a new gap introduced by this feature.

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import App from './App.vue'
+import { createNote } from './services/api'
 
 vi.mock('./services/api', () => ({
   getWorkspaces: vi.fn().mockResolvedValue([
@@ -20,7 +21,7 @@ vi.mock('./services/api', () => ({
     content: '# Welcome to Jotter\n\n[[Other Note]]',
     backlinks: []
   }),
-  createNote: vi.fn(),
+  createNote: vi.fn().mockResolvedValue({ id: 99, path: 'docs/untitled-x.md', title: '', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' }),
   updateNote: vi.fn(),
   deleteNote: vi.fn(),
   searchNotes: vi.fn().mockResolvedValue([]),
@@ -40,5 +41,31 @@ describe('App Component', () => {
   it('renders the Jotter sidebar brand title', () => {
     const wrapper = mount(App)
     expect(wrapper.find('.brand-title').text()).toBe('Jotter')
+  })
+})
+
+describe('App folder quick-create', () => {
+  it('prefixes the auto-generated filename with the folder path', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    await vm.handleCreateNoteInFolder('docs')
+    expect(createNote).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^docs\/untitled-[a-z0-9]+\.md$/),
+      expect.any(String),
+    )
+  })
+
+  it('creates at the vault root when folderPath is empty', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    await vm.handleCreateNoteInFolder('')
+    expect(createNote).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^untitled-[a-z0-9]+\.md$/),
+      expect.any(String),
+    )
   })
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,6 +27,7 @@
       :workspace-id="activeWorkspaceId"
       :folder-positions="folderPositions"
       @notes-reordered="refreshNotesList"
+      @create-note-in-folder="handleCreateNoteInFolder"
       @select-note="handleSelectNote"
       @create-note="handleCreateNote"
       @create-note-from-template="handleCreateNoteFromTemplate"
@@ -654,6 +655,12 @@ async function handleDeleteAttachment(attachment: AttachmentItem) {
     console.error('Failed to delete attachment:', err)
     errorMessage.value = 'Failed to delete attachment.'
   }
+}
+
+function handleCreateNoteInFolder(folderPath: string) {
+  const fileName = `untitled-${Date.now().toString(36)}.md`
+  const path = folderPath === '' ? fileName : `${folderPath}/${fileName}`
+  return handleCreateNote(path)
 }
 
 async function handleCreateNote(path: string) {

--- a/frontend/src/NoteTreeNode.spec.ts
+++ b/frontend/src/NoteTreeNode.spec.ts
@@ -36,3 +36,75 @@ describe('NoteTreeNode drag attributes', () => {
     expect((children.element as HTMLElement).style.display).toBe('none')
   })
 })
+
+describe('NoteTreeNode folder quick-create', () => {
+  function makeFolderNode(overrides: Partial<TreeNode> = {}): TreeNode {
+    return {
+      type: 'folder',
+      name: 'docs',
+      fullPath: 'docs',
+      children: [],
+      ...overrides,
+    } as TreeNode
+  }
+
+  it('emits create-note-in-folder with the folder\'s fullPath when + is clicked', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode(), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+
+  it('does not toggle collapse when + is clicked on an expanded folder', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: {
+        node: makeFolderNode({
+          children: [
+            { type: 'file', note: { id: 1, path: 'docs/a.md', title: 'A', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' } },
+          ],
+        }),
+        selectedNoteId: null,
+        depth: 0,
+      },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    const children = wrapper.find('.folder-children')
+    expect((children.element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('expands a collapsed folder when + is clicked', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: {
+        node: makeFolderNode({
+          children: [
+            { type: 'file', note: { id: 1, path: 'docs/a.md', title: 'A', frontmatter: null, sort_position: null, updated_at: '2026-07-31T00:00:00Z' } },
+          ],
+        }),
+        selectedNoteId: null,
+        depth: 0,
+      },
+    })
+    // Collapse it first (starts expanded by default)
+    await wrapper.find('.folder-row').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+
+  it('bubbles a nested folder\'s + click up through the parent NoteTreeNode unchanged', async () => {
+    const nested: TreeNode = makeFolderNode({
+      name: 'archived',
+      fullPath: 'docs/archived',
+      children: [],
+    })
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ children: [nested] }), selectedNoteId: null, depth: 0 },
+    })
+    const nestedBtn = wrapper.findAll('[data-testid="folder-create-note-btn"]')[1]
+    await nestedBtn.trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs/archived']])
+  })
+})

--- a/frontend/src/Sidebar.spec.ts
+++ b/frontend/src/Sidebar.spec.ts
@@ -44,3 +44,16 @@ describe('Sidebar manual sort mode', () => {
     expect(titles).toEqual(['docs', 'A', 'archived', 'Inner', 'Z'])
   })
 })
+
+describe('Sidebar folder quick-create', () => {
+  it('bubbles create-note-in-folder from a root-level folder up to its own emit', async () => {
+    const notes: NoteMeta[] = [
+      makeNote({ id: 1, path: 'docs/a.md', title: 'A' }),
+    ]
+    const wrapper = mount(Sidebar, {
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [] },
+    })
+    await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
+    expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
+  })
+})

--- a/frontend/src/components/NoteTreeNode.vue
+++ b/frontend/src/components/NoteTreeNode.vue
@@ -5,31 +5,46 @@
     data-item-type="folder"
     :data-item-path="node.fullPath"
   >
-    <button
-      type="button"
-      class="folder-row"
-      :style="{ paddingLeft: `${depth * 14 + 8}px` }"
-      :aria-expanded="expanded"
-      @click="expanded = !expanded"
-    >
-      <svg
-        class="chevron"
-        :class="{ collapsed: !expanded }"
-        viewBox="0 0 24 24"
-        width="12"
-        height="12"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2.5"
+    <div class="folder-row-wrapper">
+      <button
+        type="button"
+        class="folder-row"
+        :style="{ paddingLeft: `${depth * 14 + 8}px` }"
+        :aria-expanded="expanded"
+        @click="expanded = !expanded"
       >
-        <polyline points="9 6 15 12 9 18"></polyline>
-      </svg>
-      <svg class="folder-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-        <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"></path>
-      </svg>
-      <span class="folder-name">{{ node.name }}</span>
-      <span class="folder-count">{{ noteCount }}</span>
-    </button>
+        <svg
+          class="chevron"
+          :class="{ collapsed: !expanded }"
+          viewBox="0 0 24 24"
+          width="12"
+          height="12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+        >
+          <polyline points="9 6 15 12 9 18"></polyline>
+        </svg>
+        <svg class="folder-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"></path>
+        </svg>
+        <span class="folder-name">{{ node.name }}</span>
+        <span class="folder-count">{{ noteCount }}</span>
+      </button>
+      <button
+        type="button"
+        class="btn-create-in-folder"
+        data-testid="folder-create-note-btn"
+        title="Create note in this folder"
+        aria-label="Create note in this folder"
+        @click.stop="createNoteInFolder"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="12" y1="5" x2="12" y2="19"></line>
+          <line x1="5" y1="12" x2="19" y2="12"></line>
+        </svg>
+      </button>
+    </div>
     <div v-show="expanded" class="folder-children" ref="childrenListRef" :data-folder-path="node.fullPath">
       <NoteTreeNode
         v-for="child in node.children"
@@ -39,6 +54,7 @@
         :depth="depth + 1"
         @select-note="$emit('select-note', $event)"
         @delete-note="$emit('delete-note', $event)"
+        @create-note-in-folder="$emit('create-note-in-folder', $event)"
       />
     </div>
   </div>
@@ -104,9 +120,10 @@ const props = defineProps<{
   depth: number
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'select-note', noteId: number): void
   (e: 'delete-note', noteId: number): void
+  (e: 'create-note-in-folder', folderPath: string): void
 }>()
 
 const expanded = ref(true)
@@ -123,6 +140,13 @@ const noteIcon = computed(() => {
   const icon = props.node.note.frontmatter?.icon
   return typeof icon === 'string' && icon.trim() !== '' ? icon : null
 })
+
+function createNoteInFolder() {
+  expanded.value = true
+  if (props.node.type === 'folder') {
+    emit('create-note-in-folder', props.node.fullPath)
+  }
+}
 
 const dragCallbacks = inject<NoteTreeSortableCallbacks>('noteTreeDragCallbacks')
 const isManualMode = inject<Ref<boolean>>('noteTreeManualMode')
@@ -145,8 +169,14 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+.folder-row-wrapper {
+  display: flex;
+  align-items: center;
+}
+
 .folder-row {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--space-1);
@@ -197,6 +227,43 @@ onBeforeUnmount(() => {
   border-radius: var(--radius-sm);
   font-size: 0.6875rem;
   font-weight: 500;
+}
+
+.btn-create-in-folder {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  flex-shrink: 0;
+  margin-right: var(--space-1);
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard),
+              opacity var(--duration-fast) var(--ease-standard);
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.folder-row-wrapper:hover .btn-create-in-folder {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .btn-create-in-folder {
+    opacity: 1;
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+.btn-create-in-folder:hover {
+  color: var(--color-action);
+  background: var(--color-hover);
 }
 
 .note-item {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -287,6 +287,7 @@
           :depth="0"
           @select-note="$emit('select-note', $event)"
           @delete-note="$emit('delete-note', $event)"
+          @create-note-in-folder="$emit('create-note-in-folder', $event)"
         />
       </div>
     </div>
@@ -409,6 +410,7 @@ const emit = defineEmits<{
   (e: 'toggle-board-view'): void
   (e: 'toggle-calendar-view'): void
   (e: 'notes-reordered'): void
+  (e: 'create-note-in-folder', folderPath: string): void
 }>()
 
 const searchQuery = ref('')


### PR DESCRIPTION
## Summary
- Adds a hover-reveal "+" on each sidebar folder row (`NoteTreeNode.vue`) that creates a new note directly inside that folder, auto-expanding it and selecting the note — matching Notion's per-folder quick-add.
- No new API endpoint or backend change: reuses the existing note-create flow via `App.vue`'s existing `handleCreateNote`, with a thin `handleCreateNoteInFolder` adapter that prefixes the auto-generated `untitled-<timestamp>.md` filename with the folder path (same naming convention already used by the Command Palette's root-level quick-create).
- Out of scope (per design): no "+" on note rows or the root header (redundant with existing create paths), no inline rename UI (Jotter has no separate editable title field).

Spec: `docs/superpowers/specs/2026-07-31-inline-folder-create-design.md`
Plan: `docs/superpowers/plans/2026-07-31-inline-folder-create-implementation.md`

## Test plan
- [x] `NoteTreeNode.spec.ts`: "+" emits `create-note-in-folder` with the folder's path, doesn't collapse an expanded folder, expands a collapsed one, and bubbles correctly from a nested folder.
- [x] `Sidebar.spec.ts`: event bubbles from the root-level tree up through `Sidebar`'s own emit.
- [x] `App.spec.ts`: `handleCreateNoteInFolder` prefixes the path correctly for both a named folder and the vault root.
- [x] Full suite: 144 PHP tests (1 pre-existing skip) + 147 Vitest tests passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)