### PR TITLE
Editor breadcrumb trail (Feature 4)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-editor-breadcrumb-implementation.md
+++ b/docs/superpowers/plans/2026-07-31-editor-breadcrumb-implementation.md
@@ -1,0 +1,641 @@
+# Editor Breadcrumb Trail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `NoteEditor.vue`'s plain-text `.editor-path` into clickable folder segments that reveal (expand + scroll to + highlight) that folder in the sidebar tree.
+
+**Architecture:** `NoteEditor.vue` emits `reveal-folder` with the cumulative folder path of the clicked segment. `App.vue` stores it as a `{path, nonce}` request object and passes it down to `Sidebar.vue`, which forwards the path to every root `NoteTreeNode` (which expands itself if it's the target or an ancestor of it) and, after the DOM updates, scrolls the target folder row into view with a brief highlight.
+
+**Tech Stack:** Vue 3 `<script setup>` + TypeScript, Vitest, `@vue/test-utils`.
+
+## Global Constraints
+
+- No new API endpoint or backend change (spec §1).
+- Only folder segments are clickable; the file name segment stays plain text (spec §2, §3).
+- No new sidebar "filter by folder" mode — reveal reuses each folder's existing `expanded` ref (spec §2).
+- Revealing a folder must also open the mobile sidebar if it's closed (spec §3, `App.vue`).
+- The `nonce` on the reveal request must change on every click, including repeated clicks on the same segment, so `Sidebar` re-triggers even when `path` is unchanged (spec §3).
+
+---
+
+### Task 1: `NoteTreeNode.vue` — `revealPath` prop expands ancestor/target folders
+
+**Files:**
+- Modify: `frontend/src/components/NoteTreeNode.vue`
+- Test: `frontend/src/NoteTreeNode.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: new prop `revealPath?: string | null` on `NoteTreeNode`, threaded through its own recursive `<NoteTreeNode>` invocation. Task 3 (`Sidebar.vue`) passes this prop to the root-level `<NoteTreeNode>` instances.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `frontend/src/NoteTreeNode.spec.ts`, as a new sibling `describe` block:
+
+```typescript
+describe('NoteTreeNode revealPath', () => {
+  function makeFolderNode(overrides: Partial<TreeNode> = {}): TreeNode {
+    return {
+      type: 'folder',
+      name: 'docs',
+      fullPath: 'docs',
+      children: [],
+      ...overrides,
+    } as TreeNode
+  }
+
+  it('expands when revealPath equals its own fullPath', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode(), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('expands when revealPath is a nested descendant of its fullPath', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'docs' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs/archived' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('does not expand for an unrelated folder path', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'other' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+  })
+
+  it('does not falsely match a folder whose name is a string-prefix of another (docs vs docsx)', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'docsx' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- NoteTreeNode.spec.ts`
+Expected: FAIL — Vue Test Utils' `setProps({ revealPath: ... })` throws or is a no-op since the prop doesn't exist yet, so `.folder-children` never becomes visible in any of the 4 new tests.
+
+- [ ] **Step 3: Add the prop and watcher**
+
+In `frontend/src/components/NoteTreeNode.vue`, change:
+
+```typescript
+const props = defineProps<{
+  node: TreeNode
+  selectedNoteId: number | null
+  depth: number
+}>()
+```
+
+to:
+
+```typescript
+const props = defineProps<{
+  node: TreeNode
+  selectedNoteId: number | null
+  depth: number
+  revealPath?: string | null
+}>()
+```
+
+Add this function and `watch` call right after the `expanded` ref
+declaration (`const expanded = ref(true)`):
+
+```typescript
+function isRevealTarget(revealPath: string, fullPath: string): boolean {
+  return revealPath === fullPath || revealPath.startsWith(`${fullPath}/`)
+}
+
+watch(
+  () => props.revealPath,
+  (revealPath) => {
+    if (props.node.type === 'folder' && revealPath && isRevealTarget(revealPath, props.node.fullPath)) {
+      expanded.value = true
+    }
+  },
+)
+```
+
+(`isRevealTarget` is exported implicitly through the module scope only for
+this file's own use — no separate export needed, it's not consumed
+outside this component.)
+
+- [ ] **Step 4: Thread the prop through the recursive invocation**
+
+Change the recursive `<NoteTreeNode>` block inside `.folder-children`:
+
+```html
+      <NoteTreeNode
+        v-for="child in node.children"
+        :key="child.type === 'folder' ? `f:${child.fullPath}` : `n:${child.note.id}`"
+        :node="child"
+        :selected-note-id="selectedNoteId"
+        :depth="depth + 1"
+        @select-note="$emit('select-note', $event)"
+        @delete-note="$emit('delete-note', $event)"
+        @create-note-in-folder="$emit('create-note-in-folder', $event)"
+      />
+```
+
+to:
+
+```html
+      <NoteTreeNode
+        v-for="child in node.children"
+        :key="child.type === 'folder' ? `f:${child.fullPath}` : `n:${child.note.id}`"
+        :node="child"
+        :selected-note-id="selectedNoteId"
+        :depth="depth + 1"
+        :reveal-path="revealPath"
+        @select-note="$emit('select-note', $event)"
+        @delete-note="$emit('delete-note', $event)"
+        @create-note-in-folder="$emit('create-note-in-folder', $event)"
+      />
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- NoteTreeNode.spec.ts`
+Expected: PASS — the 4 new tests plus all pre-existing tests in this file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/NoteTreeNode.vue frontend/src/NoteTreeNode.spec.ts
+git commit -m "feat: expand folder in tree when it matches a revealPath"
+```
+
+---
+
+### Task 2: `NoteEditor.vue` — clickable breadcrumb segments
+
+**Files:**
+- Modify: `frontend/src/components/NoteEditor.vue`
+- Test: `frontend/src/NoteEditor.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: new emit `(e: 'reveal-folder', folderPath: string): void`. Task 4 (`App.vue`) listens for it on `<NoteEditor>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `frontend/src/NoteEditor.spec.ts`, as a new sibling `describe`:
+
+```typescript
+describe('NoteEditor breadcrumb', () => {
+  it('renders a clickable segment per folder and a plain-text file name', () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'docs/archived/note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    const segments = wrapper.findAll('[data-testid="editor-path-segment"]')
+    expect(segments).toHaveLength(2)
+    expect(segments[0].text()).toBe('docs')
+    expect(segments[1].text()).toBe('archived')
+    expect(wrapper.find('[data-testid="editor-path-filename"]').text()).toBe('note.md')
+  })
+
+  it('renders no folder segments for a root-level note', () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    expect(wrapper.findAll('[data-testid="editor-path-segment"]')).toHaveLength(0)
+    expect(wrapper.find('[data-testid="editor-path-filename"]').text()).toBe('note.md')
+  })
+
+  it('emits reveal-folder with the cumulative path when a segment is clicked', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'docs/archived/note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    const segments = wrapper.findAll('[data-testid="editor-path-segment"]')
+    await segments[1].trigger('click')
+    expect(wrapper.emitted('reveal-folder')).toEqual([['docs/archived']])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- NoteEditor.spec.ts`
+Expected: FAIL — `[data-testid="editor-path-segment"]` and
+`[data-testid="editor-path-filename"]` don't exist yet (`.editor-path`
+currently renders `note.path` as one plain string).
+
+- [ ] **Step 3: Add the computed and emit**
+
+In `frontend/src/components/NoteEditor.vue`, change the `defineEmits` call:
+
+```typescript
+const emit = defineEmits<{
+  (e: 'update-note', noteId: number, content: string): void
+  (e: 'select-note', noteId: number): void
+  (e: 'navigate-wikilink', target: string): void
+}>()
+```
+
+to:
+
+```typescript
+const emit = defineEmits<{
+  (e: 'update-note', noteId: number, content: string): void
+  (e: 'select-note', noteId: number): void
+  (e: 'navigate-wikilink', target: string): void
+  (e: 'reveal-folder', folderPath: string): void
+}>()
+```
+
+Add this computed right after `const noteIcon = computed(...)`:
+
+```typescript
+const breadcrumbSegments = computed(() => {
+  const parts = props.note.path.split('/')
+  const fileName = parts[parts.length - 1]
+  const folders = parts.slice(0, -1)
+  return {
+    folders: folders.map((name, index) => ({
+      name,
+      path: folders.slice(0, index + 1).join('/'),
+    })),
+    fileName,
+  }
+})
+```
+
+- [ ] **Step 4: Replace the template**
+
+Change:
+
+```html
+        <span class="editor-path" data-testid="editor-path">{{ note.path }}</span>
+```
+
+to:
+
+```html
+        <span class="editor-path" data-testid="editor-path">
+          <template v-for="folder in breadcrumbSegments.folders" :key="folder.path">
+            <button
+              type="button"
+              class="editor-path-segment"
+              data-testid="editor-path-segment"
+              @click="emit('reveal-folder', folder.path)"
+            >{{ folder.name }}</button>
+            <span class="editor-path-separator">/</span>
+          </template>
+          <span data-testid="editor-path-filename">{{ breadcrumbSegments.fileName }}</span>
+        </span>
+```
+
+- [ ] **Step 5: Add the CSS**
+
+In the `<style scoped>` block, find the existing `.editor-path` rule and
+add these rules right after it:
+
+```css
+.editor-path-segment {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: color var(--duration-fast) var(--ease-standard),
+              text-decoration-color var(--duration-fast) var(--ease-standard);
+}
+
+.editor-path-segment:hover {
+  color: var(--color-action);
+  text-decoration-color: var(--color-action);
+}
+
+.editor-path-separator {
+  margin: 0 0.2em;
+  color: var(--color-text-muted);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- NoteEditor.spec.ts`
+Expected: PASS — the 3 new tests plus all pre-existing tests in this file.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/NoteEditor.vue frontend/src/NoteEditor.spec.ts
+git commit -m "feat: make editor breadcrumb folder segments clickable"
+```
+
+---
+
+### Task 3: `Sidebar.vue` — reveal, scroll, and highlight
+
+**Files:**
+- Modify: `frontend/src/components/Sidebar.vue`
+- Test: `frontend/src/Sidebar.spec.ts`
+
+**Interfaces:**
+- Consumes: `revealPath` prop on `NoteTreeNode` (Task 1).
+- Produces: new prop `revealFolderRequest?: { path: string; nonce: number } | null` on `Sidebar`. Task 4 (`App.vue`) sets this prop.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/Sidebar.spec.ts`, as a new sibling `describe`:
+
+```typescript
+describe('Sidebar reveal folder', () => {
+  it('expands a nested folder and its ancestor when revealFolderRequest is set', async () => {
+    const notes: NoteMeta[] = [
+      makeNote({ id: 1, path: 'docs/archived/inner.md' }),
+    ]
+    const wrapper = mount(Sidebar, {
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [] },
+    })
+
+    // Both start expanded by default (NoteTreeNode's `expanded` ref defaults
+    // to true) — collapse them first so the test proves reveal re-expands.
+    const folderRows = wrapper.findAll('.folder-row')
+    await folderRows[0].trigger('click')
+    await folderRows[1].trigger('click')
+
+    await wrapper.setProps({ revealFolderRequest: { path: 'docs/archived', nonce: 1 } })
+    await wrapper.vm.$nextTick()
+
+    const children = wrapper.findAll('.folder-children')
+    for (const child of children) {
+      expect((child.element as HTMLElement).style.display).not.toBe('none')
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm test -- Sidebar.spec.ts`
+Expected: FAIL — `Sidebar` doesn't declare `revealFolderRequest` or pass
+anything down to `NoteTreeNode` yet, so both folders stay collapsed.
+
+- [ ] **Step 3: Add the prop, pass-through, and scroll/highlight logic**
+
+Change the `defineProps` call:
+
+```typescript
+const props = defineProps<{
+  notes: NoteMeta[]
+  selectedNoteId: number | null
+  currentUser?: AuthUser | null
+  notifications?: NotificationItem[]
+  isMobileSidebarOpen?: boolean
+  workspaceId?: number | null
+  folderPositions?: FolderPosition[]
+}>()
+```
+
+to:
+
+```typescript
+const props = defineProps<{
+  notes: NoteMeta[]
+  selectedNoteId: number | null
+  currentUser?: AuthUser | null
+  notifications?: NotificationItem[]
+  isMobileSidebarOpen?: boolean
+  workspaceId?: number | null
+  folderPositions?: FolderPosition[]
+  revealFolderRequest?: { path: string; nonce: number } | null
+}>()
+```
+
+Update the root-level `<NoteTreeNode>`:
+
+```html
+        <NoteTreeNode
+          v-for="node in noteTree"
+          :key="node.type === 'folder' ? `f:${node.fullPath}` : `n:${node.note.id}`"
+          :node="node"
+          :selected-note-id="selectedNoteId"
+          :depth="0"
+          @select-note="$emit('select-note', $event)"
+          @delete-note="$emit('delete-note', $event)"
+          @create-note-in-folder="$emit('create-note-in-folder', $event)"
+        />
+```
+
+to:
+
+```html
+        <NoteTreeNode
+          v-for="node in noteTree"
+          :key="node.type === 'folder' ? `f:${node.fullPath}` : `n:${node.note.id}`"
+          :node="node"
+          :selected-note-id="selectedNoteId"
+          :depth="0"
+          :reveal-path="props.revealFolderRequest?.path ?? null"
+          @select-note="$emit('select-note', $event)"
+          @delete-note="$emit('delete-note', $event)"
+          @create-note-in-folder="$emit('create-note-in-folder', $event)"
+        />
+```
+
+Add the scroll/highlight watcher next to the existing `watch(isManualMode, ...)`
+call — add this `import { nextTick }` to the existing Vue import line
+(find `import { ref, computed, provide, onMounted, onBeforeUnmount, watch, useTemplateRef } from 'vue'`
+and add `nextTick` to it), then add:
+
+```typescript
+watch(
+  () => props.revealFolderRequest,
+  async (request) => {
+    if (!request) return
+    await nextTick()
+    const el = rootListRef.value?.querySelector<HTMLElement>(
+      `[data-item-type="folder"][data-item-path="${request.path}"]`,
+    )
+    if (!el) return
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    el.classList.add('folder-row-highlight')
+    setTimeout(() => el.classList.remove('folder-row-highlight'), 1500)
+  },
+)
+```
+
+- [ ] **Step 4: Add the highlight CSS**
+
+In the `<style scoped>` block, add (anywhere among the other rules):
+
+```css
+.folder-row-highlight {
+  background: var(--color-hover);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm test -- Sidebar.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Sidebar.vue frontend/src/Sidebar.spec.ts
+git commit -m "feat: reveal, scroll to, and highlight a folder from a breadcrumb click"
+```
+
+---
+
+### Task 4: `App.vue` — wire `NoteEditor` to `Sidebar`
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+- Test: `frontend/src/App.spec.ts`
+
+**Interfaces:**
+- Consumes: `reveal-folder` emit from `NoteEditor` (Task 2);
+  `revealFolderRequest` prop on `Sidebar` (Task 3).
+- Produces: nothing consumed by later tasks — final wiring point.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/App.spec.ts`, as a new sibling `describe` (this file
+already has a precedent for calling script-setup functions directly via
+`(wrapper.vm as any).someFunction(...)`, established in this codebase at
+`frontend/src/CommandPalette.spec.ts:15-16` and reused for
+`handleCreateNoteInFolder` in this same file):
+
+```typescript
+describe('App reveal folder', () => {
+  it('opens the mobile sidebar when a folder is revealed', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    vm.handleRevealFolder('docs')
+    await wrapper.vm.$nextTick()
+    expect(vm.isMobileSidebarOpen).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm test -- App.spec.ts`
+Expected: FAIL — `handleRevealFolder` is not defined.
+
+- [ ] **Step 3: Add the state, handler, and wiring**
+
+Add this ref next to `const isMobileSidebarOpen = ref(false)`:
+
+```typescript
+const revealFolderRequest = ref<{ path: string; nonce: number } | null>(null)
+```
+
+Add this handler next to `handleCreateNoteInFolder`:
+
+```typescript
+function handleRevealFolder(folderPath: string) {
+  revealFolderRequest.value = { path: folderPath, nonce: Date.now() }
+  isMobileSidebarOpen.value = true
+}
+```
+
+Wire it on `<Sidebar>` (add the prop and the listener):
+
+```html
+      :workspace-id="activeWorkspaceId"
+      :folder-positions="folderPositions"
+      @notes-reordered="refreshNotesList"
+```
+
+to:
+
+```html
+      :workspace-id="activeWorkspaceId"
+      :folder-positions="folderPositions"
+      :reveal-folder-request="revealFolderRequest"
+      @notes-reordered="refreshNotesList"
+```
+
+Wire it on `<NoteEditor>`:
+
+```html
+      <NoteEditor
+        v-else-if="activeNoteDetail"
+        :note="activeNoteDetail"
+        :all-notes="notes"
+        :workspace-id="activeWorkspaceId || undefined"
+        @update-note="handleUpdateNote"
+        @select-note="handleSelectNote"
+        @navigate-wikilink="handleWikilinkNavigation"
+      />
+```
+
+to:
+
+```html
+      <NoteEditor
+        v-else-if="activeNoteDetail"
+        :note="activeNoteDetail"
+        :all-notes="notes"
+        :workspace-id="activeWorkspaceId || undefined"
+        @update-note="handleUpdateNote"
+        @select-note="handleSelectNote"
+        @navigate-wikilink="handleWikilinkNavigation"
+        @reveal-folder="handleRevealFolder"
+      />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm test -- App.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full frontend suite**
+
+Run: `./scripts/jt.sh npm test`
+Expected: PASS, all tests including the new ones — no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/App.vue frontend/src/App.spec.ts
+git commit -m "feat: wire editor breadcrumb reveal-folder through App.vue"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §2 in-scope bullets (clickable folder segments,
+  reveal-in-tree, mobile sidebar auto-open) → Tasks 1–4. §2 out-of-scope
+  (no folder-filter mode, no title/icon change, no path truncation) →
+  simply not built. §3's exact code for all four files → Tasks 1–4 in the
+  same order. §4 testing → one test file per task, matching the spec's
+  breakdown exactly, including the string-prefix edge case
+  (`docsx` vs `docs`) called out explicitly in the spec's `NoteTreeNode`
+  test bullet.
+- **Placeholder scan:** none found.
+- **Type consistency:** `revealPath?: string | null` on `NoteTreeNode`
+  (Task 1) is fed by `Sidebar`'s `props.revealFolderRequest?.path ?? null`
+  (Task 3), which itself is set from `App.vue`'s
+  `revealFolderRequest = ref<{ path: string; nonce: number } | null>`
+  (Task 4) — same shape at every hop. `reveal-folder` emitted with a
+  `string` from `NoteEditor` (Task 2) and consumed by
+  `handleRevealFolder(folderPath: string)` (Task 4) — matching name and
+  type.

--- a/docs/superpowers/specs/2026-07-31-editor-breadcrumb-design.md
+++ b/docs/superpowers/specs/2026-07-31-editor-breadcrumb-design.md
@@ -1,0 +1,158 @@
+# Editor Breadcrumb Trail — Design
+
+Date: 2026-07-31
+Status: Approved for planning
+Scope: Presentation-only. No new API endpoints, no database change, no
+change to the Markdown-on-disk invariant.
+
+## 1. Purpose
+
+Feature 4 of 5 Notion-parity UX features proposed for Jotter (features 1,
+page icon; 2, sidebar drag-and-drop; and 3, inline per-folder quick-create
+are already implemented and merged). Notion shows a clickable breadcrumb
+trail above the page title, letting the user navigate to any ancestor.
+Jotter's `NoteEditor.vue` already renders the active note's full path as
+plain text (`.editor-path`, confirmed at `NoteEditor.vue:35`) — this
+feature turns that into clickable folder segments.
+
+## 2. Scope
+
+**In scope:**
+- `.editor-path` renders each folder segment of `note.path` as a
+  clickable element; the final segment (the file name) stays plain text.
+- Clicking a folder segment reveals that folder in the sidebar tree:
+  expands it (and every ancestor folder up to the root), scrolls it into
+  view, and briefly highlights it.
+- Opens the mobile sidebar (`isMobileSidebarOpen`) if it was closed, so
+  the revealed folder is actually visible.
+
+**Out of scope (confirmed during brainstorming):**
+- No new "filter notes by folder" mode in the sidebar. The sidebar
+  already has two filter mechanisms (`activeTag`, `searchQuery`); adding
+  a third, folder-scoped one is unnecessary for what this feature needs
+  and was explicitly rejected in favor of the simpler "reveal in tree"
+  behavior, which reuses each folder's existing `expanded` state instead
+  of introducing new filter state.
+- No change to the note title (`.editor-title`) or its surrounding
+  page-icon UI (feature 1) — only `.editor-path` changes.
+- No breadcrumb truncation/collapsing for very deep paths (e.g. Notion's
+  "..." middle-collapse for long trails) — out of scope; Jotter's vault
+  paths are not expected to run deep enough in practice to need it, and
+  it can be added later without touching this design's data flow.
+
+## 3. Component changes
+
+### `NoteEditor.vue`
+
+Replace the plain-text `.editor-path` span:
+```html
+<span class="editor-path" data-testid="editor-path">{{ note.path }}</span>
+```
+with a computed breadcrumb list. `pathSegments` splits `note.path` on
+`/`; every segment except the last is a clickable button whose own
+cumulative path (folder path up to and including that segment) is what
+gets emitted:
+```typescript
+const breadcrumbSegments = computed(() => {
+  const parts = props.note.path.split('/')
+  const fileName = parts[parts.length - 1]
+  const folders = parts.slice(0, -1)
+  return {
+    folders: folders.map((name, index) => ({
+      name,
+      path: folders.slice(0, index + 1).join('/'),
+    })),
+    fileName,
+  }
+})
+```
+Each folder segment emits `(e: 'reveal-folder', folderPath: string): void`
+on click. The file name renders as plain text (matches the existing
+`data-testid="editor-path"` container for backward test compatibility —
+the testid stays on the outer wrapper, individual segments get their own
+`data-testid="editor-path-segment"` for targeted testing).
+
+### `App.vue`
+
+New state:
+```typescript
+const revealFolderRequest = ref<{ path: string; nonce: number } | null>(null)
+```
+New handler, wired to `NoteEditor`'s `@reveal-folder`:
+```typescript
+function handleRevealFolder(folderPath: string) {
+  revealFolderRequest.value = { path: folderPath, nonce: Date.now() }
+  isMobileSidebarOpen.value = true
+}
+```
+The `nonce` (not otherwise read) exists so clicking the *same* segment
+twice in a row still produces a new object reference, since `Sidebar`'s
+watcher (below) needs to re-fire even when `path` is unchanged — clicking
+"docs" again after having since collapsed it manually should still
+re-expand and re-scroll to it.
+`revealFolderRequest` is passed to `<Sidebar>` as a new prop.
+
+### `Sidebar.vue`
+
+New prop: `revealFolderRequest?: { path: string; nonce: number } | null`.
+A `watch` on this prop:
+1. Passes `props.revealFolderRequest?.path ?? null` down to every
+   root-level `<NoteTreeNode>` as a new `revealPath` prop.
+2. After `nextTick()`, queries
+   `this.$el.querySelector('[data-item-type="folder"][data-item-path="<path>"]')`
+   (the `data-item-path` attribute already exists on every folder row,
+   added in feature 2) and calls `scrollIntoView({ block: 'center',
+   behavior: 'smooth' })` on it, then toggles a `.folder-row-highlight`
+   class for ~1.5s (a plain `setTimeout`, matching the existing
+   short-lived UI feedback pattern already used elsewhere in the app —
+   no new animation library).
+
+### `NoteTreeNode.vue`
+
+New prop: `revealPath?: string | null`. A `watch` on it: if
+`revealPath` equals `node.fullPath`, or `node.fullPath` is a proper
+prefix of `revealPath` (i.e. this folder is an ancestor of the revealed
+one), set `expanded.value = true`. The prop is threaded through the
+existing recursive `<NoteTreeNode>` invocation inside `.folder-children`
+exactly like `selectedNoteId`/`depth` already are, so it reaches every
+depth automatically.
+
+## 4. Testing
+
+**`NoteEditor.spec.ts`:**
+- A note at `docs/archived/note.md` renders 2 clickable folder segments
+  (`docs`, `archived`) and 1 plain-text file-name segment (`note.md`).
+- A note at the vault root (`note.md`, no `/`) renders 0 folder segments,
+  just the plain file name — no empty/broken breadcrumb for root notes.
+- Clicking the "archived" segment emits `reveal-folder` with
+  `docs/archived` (the cumulative path up to and including that segment,
+  not just its own name).
+
+**`Sidebar.spec.ts`:**
+- Setting `revealFolderRequest` to `{ path: 'docs/archived', nonce: 1 }`
+  results in both `docs` and `docs/archived` folder rows being expanded
+  (`.folder-children` visible) after the next tick.
+
+**`NoteTreeNode.spec.ts`:**
+- A folder node with `fullPath: 'docs'` and `revealPath: 'docs/archived'`
+  expands (ancestor case).
+- A folder node with `fullPath: 'docs/archived'` and
+  `revealPath: 'docs/archived'` expands (exact-match case).
+- A folder node with `fullPath: 'other'` and `revealPath: 'docs/archived'`
+  does **not** expand (unrelated folder, proves the prefix check is
+  exact-segment, not a naive string-prefix that would wrongly match
+  `docsx` against `revealPath: 'docs'`).
+
+**`App.spec.ts`:**
+- `handleRevealFolder('docs')` sets `isMobileSidebarOpen` to `true`.
+
+No backend test changes — no backend code changes in this feature.
+
+## 5. Out of scope / open questions carried forward
+
+- No folder-filtering mode in the sidebar (§2).
+- No breadcrumb path truncation for deep trees (§2).
+- The highlight duration/easing is a fixed constant, not themed through
+  a design token — acceptable for a one-off transient effect, revisit
+  only if a similar "flash to draw attention" pattern gets reused
+  elsewhere in the app.

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -69,3 +69,14 @@ describe('App folder quick-create', () => {
     )
   })
 })
+
+describe('App reveal folder', () => {
+  it('opens the mobile sidebar when a folder is revealed', async () => {
+    const wrapper = mount(App)
+    await wrapper.vm.$nextTick()
+    const vm = wrapper.vm as any
+    vm.handleRevealFolder('docs')
+    await wrapper.vm.$nextTick()
+    expect(vm.isMobileSidebarOpen).toBe(true)
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -26,6 +26,7 @@
       :is-mobile-sidebar-open="isMobileSidebarOpen"
       :workspace-id="activeWorkspaceId"
       :folder-positions="folderPositions"
+      :reveal-folder-request="revealFolderRequest"
       @notes-reordered="refreshNotesList"
       @create-note-in-folder="handleCreateNoteInFolder"
       @select-note="handleSelectNote"
@@ -137,6 +138,7 @@
         @update-note="handleUpdateNote"
         @select-note="handleSelectNote"
         @navigate-wikilink="handleWikilinkNavigation"
+        @reveal-folder="handleRevealFolder"
       />
 
       <!-- Empty State -->
@@ -254,6 +256,7 @@ const currentUser = ref<AuthUser | null>(null)
 const showLoginModal = ref(false)
 const isMobileSidebarOpen = ref(false)
 const isGraphViewActive = ref(false)
+const revealFolderRequest = ref<{ path: string; nonce: number } | null>(null)
 
 const isSearchActive = ref(false)
 const searchQuery = ref('')
@@ -661,6 +664,11 @@ function handleCreateNoteInFolder(folderPath: string) {
   const fileName = `untitled-${Date.now().toString(36)}.md`
   const path = folderPath === '' ? fileName : `${folderPath}/${fileName}`
   return handleCreateNote(path)
+}
+
+function handleRevealFolder(folderPath: string) {
+  revealFolderRequest.value = { path: folderPath, nonce: Date.now() }
+  isMobileSidebarOpen.value = true
 }
 
 async function handleCreateNote(path: string) {

--- a/frontend/src/NoteEditor.spec.ts
+++ b/frontend/src/NoteEditor.spec.ts
@@ -107,3 +107,33 @@ describe('NoteEditor page icon', () => {
     expect(wrapper.find('[data-testid="editor-icon-input"]').exists()).toBe(false)
   })
 })
+
+describe('NoteEditor breadcrumb', () => {
+  it('renders a clickable segment per folder and a plain-text file name', () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'docs/archived/note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    const segments = wrapper.findAll('[data-testid="editor-path-segment"]')
+    expect(segments).toHaveLength(2)
+    expect(segments[0].text()).toBe('docs')
+    expect(segments[1].text()).toBe('archived')
+    expect(wrapper.find('[data-testid="editor-path-filename"]').text()).toBe('note.md')
+  })
+
+  it('renders no folder segments for a root-level note', () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    expect(wrapper.findAll('[data-testid="editor-path-segment"]')).toHaveLength(0)
+    expect(wrapper.find('[data-testid="editor-path-filename"]').text()).toBe('note.md')
+  })
+
+  it('emits reveal-folder with the cumulative path when a segment is clicked', async () => {
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote({ path: 'docs/archived/note.md' }), allNotes: [], workspaceId: 1 },
+    })
+    const segments = wrapper.findAll('[data-testid="editor-path-segment"]')
+    await segments[1].trigger('click')
+    expect(wrapper.emitted('reveal-folder')).toEqual([['docs/archived']])
+  })
+})

--- a/frontend/src/NoteTreeNode.spec.ts
+++ b/frontend/src/NoteTreeNode.spec.ts
@@ -108,3 +108,56 @@ describe('NoteTreeNode folder quick-create', () => {
     expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs/archived']])
   })
 })
+
+describe('NoteTreeNode revealPath', () => {
+  function makeFolderNode(overrides: Partial<TreeNode> = {}): TreeNode {
+    return {
+      type: 'folder',
+      name: 'docs',
+      fullPath: 'docs',
+      children: [],
+      ...overrides,
+    } as TreeNode
+  }
+
+  it('expands when revealPath equals its own fullPath', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode(), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('expands when revealPath is a nested descendant of its fullPath', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'docs' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs/archived' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('does not expand for an unrelated folder path', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'other' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+  })
+
+  it('does not falsely match a folder whose name is a string-prefix of another (docs vs docsx)', async () => {
+    const wrapper = mount(NoteTreeNode, {
+      props: { node: makeFolderNode({ fullPath: 'docsx' }), selectedNoteId: null, depth: 0 },
+    })
+    await wrapper.find('.folder-row').trigger('click')
+
+    await wrapper.setProps({ revealPath: 'docs' })
+    expect((wrapper.find('.folder-children').element as HTMLElement).style.display).toBe('none')
+  })
+})

--- a/frontend/src/Sidebar.spec.ts
+++ b/frontend/src/Sidebar.spec.ts
@@ -57,3 +57,28 @@ describe('Sidebar folder quick-create', () => {
     expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
   })
 })
+
+describe('Sidebar reveal folder', () => {
+  it('expands a nested folder and its ancestor when revealFolderRequest is set', async () => {
+    const notes: NoteMeta[] = [
+      makeNote({ id: 1, path: 'docs/archived/inner.md' }),
+    ]
+    const wrapper = mount(Sidebar, {
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [] },
+    })
+
+    // Both start expanded by default (NoteTreeNode's `expanded` ref defaults
+    // to true) — collapse them first so the test proves reveal re-expands.
+    const folderRows = wrapper.findAll('.folder-row')
+    await folderRows[0].trigger('click')
+    await folderRows[1].trigger('click')
+
+    await wrapper.setProps({ revealFolderRequest: { path: 'docs/archived', nonce: 1 } })
+    await wrapper.vm.$nextTick()
+
+    const children = wrapper.findAll('.folder-children')
+    for (const child of children) {
+      expect((child.element as HTMLElement).style.display).not.toBe('none')
+    }
+  })
+})

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -32,7 +32,18 @@
           />
           <h2 class="editor-title" data-testid="editor-title">{{ note.title || note.path }}</h2>
         </div>
-        <span class="editor-path" data-testid="editor-path">{{ note.path }}</span>
+        <span class="editor-path" data-testid="editor-path">
+          <template v-for="folder in breadcrumbSegments.folders" :key="folder.path">
+            <button
+              type="button"
+              class="editor-path-segment"
+              data-testid="editor-path-segment"
+              @click="emit('reveal-folder', folder.path)"
+            >{{ folder.name }}</button>
+            <span class="editor-path-separator">/</span>
+          </template>
+          <span data-testid="editor-path-filename">{{ breadcrumbSegments.fileName }}</span>
+        </span>
       </div>
 
       <div class="editor-controls">
@@ -264,6 +275,7 @@ const emit = defineEmits<{
   (e: 'update-note', noteId: number, content: string): void
   (e: 'select-note', noteId: number): void
   (e: 'navigate-wikilink', target: string): void
+  (e: 'reveal-folder', folderPath: string): void
 }>()
 
 const isEditingIcon = ref(false)
@@ -272,6 +284,19 @@ const iconDraft = ref('')
 const noteIcon = computed(() => {
   const icon = props.note.frontmatter?.icon
   return typeof icon === 'string' && icon.trim() !== '' ? icon : null
+})
+
+const breadcrumbSegments = computed(() => {
+  const parts = props.note.path.split('/')
+  const fileName = parts[parts.length - 1]
+  const folders = parts.slice(0, -1)
+  return {
+    folders: folders.map((name, index) => ({
+      name,
+      path: folders.slice(0, index + 1).join('/'),
+    })),
+    fileName,
+  }
 })
 
 function startEditingIcon() {
@@ -763,6 +788,29 @@ async function handleSave() {
 
 .editor-path {
   font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.editor-path-segment {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: color var(--duration-fast) var(--ease-standard),
+              text-decoration-color var(--duration-fast) var(--ease-standard);
+}
+
+.editor-path-segment:hover {
+  color: var(--color-action);
+  text-decoration-color: var(--color-action);
+}
+
+.editor-path-separator {
+  margin: 0 0.2em;
   color: var(--color-text-muted);
 }
 

--- a/frontend/src/components/NoteTreeNode.vue
+++ b/frontend/src/components/NoteTreeNode.vue
@@ -385,4 +385,8 @@ onBeforeUnmount(() => {
   background: var(--color-hover);
   opacity: 0.6;
 }
+
+.folder-row-highlight .folder-row {
+  background: var(--color-hover);
+}
 </style>

--- a/frontend/src/components/NoteTreeNode.vue
+++ b/frontend/src/components/NoteTreeNode.vue
@@ -52,6 +52,7 @@
         :node="child"
         :selected-note-id="selectedNoteId"
         :depth="depth + 1"
+        :reveal-path="revealPath"
         @select-note="$emit('select-note', $event)"
         @delete-note="$emit('delete-note', $event)"
         @create-note-in-folder="$emit('create-note-in-folder', $event)"
@@ -118,6 +119,7 @@ const props = defineProps<{
   node: TreeNode
   selectedNoteId: number | null
   depth: number
+  revealPath?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -127,6 +129,19 @@ const emit = defineEmits<{
 }>()
 
 const expanded = ref(true)
+
+function isRevealTarget(revealPath: string, fullPath: string): boolean {
+  return revealPath === fullPath || revealPath.startsWith(`${fullPath}/`)
+}
+
+watch(
+  () => props.revealPath,
+  (revealPath) => {
+    if (props.node.type === 'folder' && revealPath && isRevealTarget(revealPath, props.node.fullPath)) {
+      expanded.value = true
+    }
+  },
+)
 
 function countNotes(node: TreeNode): number {
   if (node.type === 'file') return 1

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -285,6 +285,7 @@
           :node="node"
           :selected-note-id="selectedNoteId"
           :depth="0"
+          :reveal-path="props.revealFolderRequest?.path ?? null"
           @select-note="$emit('select-note', $event)"
           @delete-note="$emit('delete-note', $event)"
           @create-note-in-folder="$emit('create-note-in-folder', $event)"
@@ -372,7 +373,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, provide, onMounted, onBeforeUnmount, watch, useTemplateRef } from 'vue'
+import { ref, computed, provide, onMounted, onBeforeUnmount, watch, useTemplateRef, nextTick } from 'vue'
 import type { NoteMeta, AuthUser, NotificationItem, FolderPosition, SortItem } from '../services/types'
 import NoteTreeNode from './NoteTreeNode.vue'
 import type { TreeFolder, TreeNode } from './NoteTreeNode.vue'
@@ -388,6 +389,7 @@ const props = defineProps<{
   isMobileSidebarOpen?: boolean
   workspaceId?: number | null
   folderPositions?: FolderPosition[]
+  revealFolderRequest?: { path: string; nonce: number } | null
 }>()
 
 const emit = defineEmits<{
@@ -606,6 +608,21 @@ watch(isManualMode, (manual) => {
 onBeforeUnmount(() => {
   rootSortable?.destroy()
 })
+
+watch(
+  () => props.revealFolderRequest,
+  async (request) => {
+    if (!request) return
+    await nextTick()
+    const el = rootListRef.value?.querySelector<HTMLElement>(
+      `[data-item-type="folder"][data-item-path="${request.path}"]`,
+    )
+    if (!el) return
+    el.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+    el.classList.add('folder-row-highlight')
+    setTimeout(() => el.classList.remove('folder-row-highlight'), 1500)
+  },
+)
 
 function onSearchInput() {
   emit('search', searchQuery.value)


### PR DESCRIPTION
## Summary
- Turns `NoteEditor.vue`'s plain-text `.editor-path` into clickable folder segments (`docs / archived / note.md`), matching Notion's breadcrumb navigation.
- Clicking a folder segment reveals that folder in the sidebar tree: expands it and every ancestor folder (`NoteTreeNode.vue`'s new `revealPath` prop), scrolls it into view, and briefly highlights it (`Sidebar.vue`). Opens the mobile sidebar if it was closed.
- No new API endpoint or backend change — reuses each folder's existing `expanded` state instead of introducing a new sidebar filter mode.

Spec: `docs/superpowers/specs/2026-07-31-editor-breadcrumb-design.md`
Plan: `docs/superpowers/plans/2026-07-31-editor-breadcrumb-implementation.md`

## Test plan
- [x] `NoteTreeNode.spec.ts`: expands on exact/descendant `revealPath` match, doesn't expand for unrelated folders, and doesn't false-match on a folder-name string prefix (`docs` vs `docsx`).
- [x] `NoteEditor.spec.ts`: renders one clickable segment per folder + plain-text file name, no segments for a root-level note, emits `reveal-folder` with the cumulative path.
- [x] `Sidebar.spec.ts`: `revealFolderRequest` expands a nested folder and its ancestor.
- [x] `App.spec.ts`: revealing a folder opens the mobile sidebar.
- [x] Full suite: 144 PHP tests (1 pre-existing skip) + 156 Vitest tests passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)