### PR TITLE
feat: collapsible note editor panels

### DIFF
--- a/docs/superpowers/plans/2026-08-01-collapsible-panels-implementation.md
+++ b/docs/superpowers/plans/2026-08-01-collapsible-panels-implementation.md
@@ -1,0 +1,632 @@
+# Collapsible Note Editor Panels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let all five note-editor side panels (Properties, Comments, Backlinks, Outgoing Links, Unlinked Mentions) collapse/expand via a chevron in their shared header, with state persisted per panel type in `localStorage`.
+
+**Architecture:** A new `useCollapsiblePanel(key, defaultCollapsed)` composable centralizes the localStorage read/write/toggle logic. `PanelHeader.vue` (shared by all five panels) gains a `collapsed` prop and a `toggle` emit, rendering a chevron button. Each panel wraps its existing body markup in `v-show="!collapsed"`.
+
+**Tech Stack:** Vue 3 `<script setup>` + TypeScript, Vitest, `@vue/test-utils`.
+
+## Global Constraints
+
+- No API/database changes — frontend-only (spec §1).
+- `PropertiesPanel` starts collapsed by default; `CommentsPanel`, `BacklinksPanel`, `OutgoingLinksPanel`, `UnlinkedMentionsPanel` start expanded by default (spec §2, §3).
+- Collapse state persists via `localStorage`, one key per panel type — not per note (spec §2, §3).
+- No change to any panel's content/behavior beyond the collapse wrapper (spec §2).
+
+---
+
+### Task 1: `useCollapsiblePanel` composable
+
+**Files:**
+- Create: `frontend/src/composables/useCollapsiblePanel.ts`
+- Test: `frontend/src/composables/useCollapsiblePanel.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `useCollapsiblePanel(key: string, defaultCollapsed: boolean):
+  { collapsed: Ref<boolean>; toggle: () => void }`. Tasks 2–3 (`PanelHeader.vue`
+  via its consuming panels) call this directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// frontend/src/composables/useCollapsiblePanel.spec.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCollapsiblePanel } from './useCollapsiblePanel'
+
+describe('useCollapsiblePanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('uses the default when no stored value exists', () => {
+    const { collapsed } = useCollapsiblePanel('properties', true)
+    expect(collapsed.value).toBe(true)
+  })
+
+  it('uses the stored value instead of the default when one exists', () => {
+    localStorage.setItem('jotter-panel-collapsed:comments', 'true')
+    const { collapsed } = useCollapsiblePanel('comments', false)
+    expect(collapsed.value).toBe(true)
+  })
+
+  it('toggle flips the value and persists it', () => {
+    const { collapsed, toggle } = useCollapsiblePanel('backlinks', false)
+    toggle()
+    expect(collapsed.value).toBe(true)
+    expect(localStorage.getItem('jotter-panel-collapsed:backlinks')).toBe('true')
+
+    toggle()
+    expect(collapsed.value).toBe(false)
+    expect(localStorage.getItem('jotter-panel-collapsed:backlinks')).toBe('false')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- useCollapsiblePanel.spec.ts`
+Expected: FAIL — the module `./useCollapsiblePanel` does not exist.
+
+- [ ] **Step 3: Implement the composable**
+
+```typescript
+// frontend/src/composables/useCollapsiblePanel.ts
+import { ref, watch } from 'vue'
+
+export function useCollapsiblePanel(key: string, defaultCollapsed: boolean) {
+  const storageKey = `jotter-panel-collapsed:${key}`
+  const collapsed = ref(defaultCollapsed)
+
+  const stored = localStorage.getItem(storageKey)
+  if (stored !== null) {
+    collapsed.value = stored === 'true'
+  }
+
+  watch(collapsed, (value) => {
+    localStorage.setItem(storageKey, String(value))
+  })
+
+  function toggle() {
+    collapsed.value = !collapsed.value
+  }
+
+  return { collapsed, toggle }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- useCollapsiblePanel.spec.ts`
+Expected: PASS, all 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useCollapsiblePanel.ts frontend/src/composables/useCollapsiblePanel.spec.ts
+git commit -m "feat: add useCollapsiblePanel composable for panel collapse state"
+```
+
+---
+
+### Task 2: `PanelHeader.vue` — chevron toggle
+
+**Files:**
+- Modify: `frontend/src/components/PanelHeader.vue`
+- Test: `frontend/src/components/PanelHeader.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new (no dependency on Task 1 — `PanelHeader` is
+  purely presentational, the composable lives in each consuming panel).
+- Produces: new prop `collapsed: boolean` and new emit
+  `(e: 'toggle'): void` on `PanelHeader`. Task 3 (all five panels) binds
+  these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `frontend/src/components/PanelHeader.spec.ts`:
+
+```typescript
+  it('emits toggle when the chevron button is clicked', async () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.emitted('toggle')).toBeTruthy()
+  })
+
+  it('applies the collapsed class to the chevron when collapsed is true', () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: true } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"] .chevron').classes()).toContain('collapsed')
+  })
+
+  it('does not apply the collapsed class when collapsed is false', () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"] .chevron').classes()).not.toContain('collapsed')
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./scripts/jt.sh npm test -- PanelHeader.spec.ts`
+Expected: FAIL — `collapsed` prop doesn't exist, `[data-testid="panel-collapse-toggle"]` isn't in the template.
+
+- [ ] **Step 3: Add the prop, emit, and chevron button**
+
+Change `frontend/src/components/PanelHeader.vue`'s template:
+
+```html
+<template>
+  <div class="panel-header">
+    <div class="panel-header-title">
+      <slot name="icon" />
+      <span>{{ title }}</span>
+    </div>
+    <span v-if="count !== undefined" class="panel-header-count">{{ count }}</span>
+  </div>
+</template>
+```
+
+to:
+
+```html
+<template>
+  <div class="panel-header">
+    <div class="panel-header-title">
+      <slot name="icon" />
+      <span>{{ title }}</span>
+    </div>
+    <div class="panel-header-actions">
+      <span v-if="count !== undefined" class="panel-header-count">{{ count }}</span>
+      <button
+        type="button"
+        class="panel-collapse-toggle"
+        data-testid="panel-collapse-toggle"
+        :aria-label="collapsed ? `Expand ${title}` : `Collapse ${title}`"
+        :aria-expanded="!collapsed"
+        @click="$emit('toggle')"
+      >
+        <svg
+          class="chevron"
+          :class="{ collapsed: collapsed }"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+        >
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>
+```
+
+Change the `<script setup>` block:
+
+```typescript
+defineProps<{
+  title: string
+  count?: number
+}>()
+```
+
+to:
+
+```typescript
+defineProps<{
+  title: string
+  count?: number
+  collapsed: boolean
+}>()
+
+defineEmits<{
+  (e: 'toggle'): void
+}>()
+```
+
+- [ ] **Step 4: Add the CSS**
+
+In the `<style scoped>` block, add after the existing `.panel-header-count` rule:
+
+```css
+.panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.panel-collapse-toggle {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.panel-collapse-toggle:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.chevron {
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.chevron.collapsed {
+  transform: rotate(-90deg);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./scripts/jt.sh npm test -- PanelHeader.spec.ts`
+Expected: PASS, all 7 tests (4 pre-existing + 3 new).
+
+Note: adding the required `collapsed` prop means every existing
+`<PanelHeader>` usage in the codebase must now pass it — this is
+addressed in Task 3, which touches all five call sites in the same
+pass. Until Task 3 lands, the five panel components will fail Vue's
+prop-type check in dev/test builds; this is expected and resolved by
+the end of Task 3, not this one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/PanelHeader.vue frontend/src/components/PanelHeader.spec.ts
+git commit -m "feat: add collapse chevron to PanelHeader"
+```
+
+---
+
+### Task 3: Wire collapse into all five panels
+
+**Files:**
+- Modify: `frontend/src/components/PropertiesPanel.vue`
+- Modify: `frontend/src/components/CommentsPanel.vue`
+- Modify: `frontend/src/components/BacklinksPanel.vue`
+- Modify: `frontend/src/components/OutgoingLinksPanel.vue`
+- Modify: `frontend/src/components/UnlinkedMentionsPanel.vue`
+- Test: `frontend/src/PropertiesPanel.spec.ts`
+- Test: `frontend/src/CommentsPanel.spec.ts`
+- Test: `frontend/src/OutgoingLinksPanel.spec.ts`
+- Test: `frontend/src/UnlinkedMentionsPanel.spec.ts`
+- Test: `frontend/src/BacklinksPanel.spec.ts` (new file — none exists yet)
+
+**Interfaces:**
+- Consumes: `useCollapsiblePanel(key, defaultCollapsed)` (Task 1),
+  `PanelHeader`'s `collapsed`/`toggle` (Task 2).
+- Produces: nothing consumed by later tasks — this is the final wiring
+  point for all five panels.
+
+Each panel gets the identical three-part edit: (a) import the
+composable, (b) call it with its own key/default and wire it onto
+`<PanelHeader>`, (c) wrap the existing body in `v-show="!collapsed"`.
+The five panels differ only in their `<PanelHeader>` line, their key,
+their default, and what "the body" is (everything currently rendered
+after `</PanelHeader>` and before the closing root tag).
+
+- [ ] **Step 1: Write the failing test — `PropertiesPanel`**
+
+Add to `frontend/src/PropertiesPanel.spec.ts`:
+
+```typescript
+  it('hides the body when collapsed', () => {
+    localStorage.setItem('jotter-panel-collapsed:properties', 'true')
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+    expect(wrapper.find('.properties-empty').exists()).toBe(false)
+  })
+
+  it('shows the body and toggles collapse when the header chevron is clicked', async () => {
+    localStorage.setItem('jotter-panel-collapsed:properties', 'true')
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.find('.properties-empty').exists()).toBe(true)
+  })
+```
+
+Add `localStorage.clear()` in a `beforeEach` if this spec file doesn't
+already have one — check the top of the file first; if a
+`describe`/`beforeEach` block already exists, add the clear call there,
+otherwise wrap the file's existing tests in a `describe('PropertiesPanel', () => { beforeEach(() => localStorage.clear()) ... })`
+structure consistent with how the file is currently organized.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm test -- PropertiesPanel.spec.ts`
+Expected: FAIL — collapsing has no effect yet, body always renders.
+
+- [ ] **Step 3: Wire `PropertiesPanel.vue`**
+
+Change the top of the template:
+
+```html
+<template>
+  <aside class="properties-panel" aria-label="Properties">
+    <PanelHeader title="Properties" :count="properties.length">
+      <template #icon>
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <path d="M3 6h18M7 12h10M11 18h2"></path>
+        </svg>
+      </template>
+    </PanelHeader>
+
+    <div v-if="properties.length === 0" class="properties-empty">
+```
+
+to:
+
+```html
+<template>
+  <aside class="properties-panel" aria-label="Properties">
+    <PanelHeader title="Properties" :count="properties.length" :collapsed="collapsed" @toggle="toggle">
+      <template #icon>
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <path d="M3 6h18M7 12h10M11 18h2"></path>
+        </svg>
+      </template>
+    </PanelHeader>
+
+    <div v-show="!collapsed">
+    <div v-if="properties.length === 0" class="properties-empty">
+```
+
+Then find the template's closing (the end of the property-form section,
+right before `</aside>` and `</template>`) and close the new wrapping
+div:
+
+```html
+    </form>
+  </aside>
+</template>
+```
+
+to:
+
+```html
+    </form>
+    </div>
+  </aside>
+</template>
+```
+
+In the `<script setup>` block, change:
+
+```typescript
+import { ref } from 'vue'
+import PanelHeader from './PanelHeader.vue'
+```
+
+to:
+
+```typescript
+import { ref } from 'vue'
+import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
+```
+
+Add right after the props/emits declarations (before any other local
+state):
+
+```typescript
+const { collapsed, toggle } = useCollapsiblePanel('properties', true)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm test -- PropertiesPanel.spec.ts`
+Expected: PASS, all tests in this file.
+
+- [ ] **Step 5: Write the failing test — `CommentsPanel`**
+
+Add to `frontend/src/CommentsPanel.spec.ts` (same pattern as Step 1, using
+`'jotter-panel-collapsed:comments'` and `false` as the seeded stored value
+so the test proves collapsing, since this panel defaults to expanded):
+
+```typescript
+  it('hides the body when collapsed', () => {
+    localStorage.setItem('jotter-panel-collapsed:comments', 'true')
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    expect(wrapper.find('.comments-empty, .comments-list').exists()).toBe(false)
+  })
+
+  it('shows the body and toggles collapse when the header chevron is clicked', async () => {
+    localStorage.setItem('jotter-panel-collapsed:comments', 'true')
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.find('.comments-empty, .comments-list').exists()).toBe(true)
+  })
+```
+
+Before writing this, check `CommentsPanel.vue`'s actual empty-state class
+name (mirror `PropertiesPanel`'s `.properties-empty` naming convention —
+confirm the exact class by reading the file; adjust the selector above to
+match whatever it actually is if different from `.comments-empty`).
+
+- [ ] **Step 6: Run test to verify it fails, then wire `CommentsPanel.vue`**
+
+Run: `./scripts/jt.sh npm test -- CommentsPanel.spec.ts` — expect FAIL.
+
+Apply the same three-part edit as Step 3, adapted to this file:
+`<PanelHeader title="Comments" :count="comments.length" :collapsed="collapsed" @toggle="toggle">`,
+wrap the body (everything between `</PanelHeader>` and the closing root
+tag) in `<div v-show="!collapsed">...</div>`, add the
+`useCollapsiblePanel` import, and call
+`const { collapsed, toggle } = useCollapsiblePanel('comments', false)`.
+
+Run: `./scripts/jt.sh npm test -- CommentsPanel.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing test, then wire `BacklinksPanel.vue`**
+
+This file has no existing spec — create one:
+
+```typescript
+// frontend/src/BacklinksPanel.spec.ts
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, beforeEach } from 'vitest'
+import BacklinksPanel from './components/BacklinksPanel.vue'
+
+describe('BacklinksPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows the empty state when there are no backlinks', () => {
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    expect(wrapper.text()).toContain('No notes link to this document yet.')
+  })
+
+  it('hides the body when collapsed', () => {
+    localStorage.setItem('jotter-panel-collapsed:backlinks', 'true')
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    expect(wrapper.find('.backlinks-empty').exists()).toBe(false)
+  })
+
+  it('shows the body and toggles collapse when the header chevron is clicked', async () => {
+    localStorage.setItem('jotter-panel-collapsed:backlinks', 'true')
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.find('.backlinks-empty').exists()).toBe(true)
+  })
+})
+```
+
+Run: `./scripts/jt.sh npm test -- BacklinksPanel.spec.ts` — expect the
+first test to pass already (pre-existing behavior) and the two collapse
+tests to fail.
+
+Wire `BacklinksPanel.vue` with the same three-part edit:
+`<PanelHeader title="Backlinks" :count="backlinks.length" :collapsed="collapsed" @toggle="toggle">`,
+wrap the body (the `v-if`/`v-else` empty-state/list pair) in
+`<div v-show="!collapsed">...</div>`, add the import, and call
+`const { collapsed, toggle } = useCollapsiblePanel('backlinks', false)`.
+
+Run: `./scripts/jt.sh npm test -- BacklinksPanel.spec.ts`
+Expected: PASS, all 3 tests.
+
+- [ ] **Step 8: Write the failing test, then wire `OutgoingLinksPanel.vue`**
+
+Add to `frontend/src/OutgoingLinksPanel.spec.ts` (read the file first to
+confirm its exact empty-state class name and existing `beforeEach`
+structure, then add analogous to Step 1):
+
+```typescript
+  it('hides the body when collapsed', () => {
+    localStorage.setItem('jotter-panel-collapsed:outgoing-links', 'true')
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"]').exists()).toBe(true)
+  })
+
+  it('toggles collapse when the header chevron is clicked', async () => {
+    localStorage.setItem('jotter-panel-collapsed:outgoing-links', 'true')
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
+    const before = wrapper.html()
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.html()).not.toBe(before)
+  })
+```
+
+Run: `./scripts/jt.sh npm test -- OutgoingLinksPanel.spec.ts` — expect FAIL
+(no `panel-collapse-toggle` testid exists yet).
+
+Wire `OutgoingLinksPanel.vue` with the same three-part edit:
+`<PanelHeader title="Outgoing Links" :count="links.length" :collapsed="collapsed" @toggle="toggle">`,
+wrap the body in `<div v-show="!collapsed">...</div>`, add the import,
+and call
+`const { collapsed, toggle } = useCollapsiblePanel('outgoing-links', false)`.
+
+Run: `./scripts/jt.sh npm test -- OutgoingLinksPanel.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Write the failing test, then wire `UnlinkedMentionsPanel.vue`**
+
+Add to `frontend/src/UnlinkedMentionsPanel.spec.ts` (read the file first
+to confirm its prop name — likely `mentions` per
+`UnlinkedMentionsPanel.vue`'s `:count="mentions.length"` seen during
+exploration — and its existing `beforeEach` structure):
+
+```typescript
+  it('hides the body when collapsed', () => {
+    localStorage.setItem('jotter-panel-collapsed:unlinked-mentions', 'true')
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"]').exists()).toBe(true)
+  })
+
+  it('toggles collapse when the header chevron is clicked', async () => {
+    localStorage.setItem('jotter-panel-collapsed:unlinked-mentions', 'true')
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
+    const before = wrapper.html()
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.html()).not.toBe(before)
+  })
+```
+
+Run: `./scripts/jt.sh npm test -- UnlinkedMentionsPanel.spec.ts` — expect
+FAIL.
+
+Wire `UnlinkedMentionsPanel.vue` with the same three-part edit:
+`<PanelHeader title="Unlinked Mentions" :count="mentions.length" :collapsed="collapsed" @toggle="toggle">`,
+wrap the body in `<div v-show="!collapsed">...</div>`, add the import,
+and call
+`const { collapsed, toggle } = useCollapsiblePanel('unlinked-mentions', false)`.
+
+Run: `./scripts/jt.sh npm test -- UnlinkedMentionsPanel.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 10: Run the full frontend suite**
+
+Run: `./scripts/jt.sh npm test`
+Expected: PASS, all tests including every new one across all three
+tasks — no regressions. Pay particular attention to any other spec file
+that mounts one of these five panels indirectly (e.g. `NoteEditor.spec.ts`
+mounting the full editor, which mounts `PropertiesPanel` inside it) —
+if any such test asserts on panel body content being visible by default,
+it may need `localStorage.clear()` added to its own `beforeEach` too,
+since `PropertiesPanel` now defaults to collapsed and a stray leftover
+`jotter-panel-collapsed:properties` value from an earlier test in the
+same run could otherwise cause cross-test interference.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add frontend/src/components/PropertiesPanel.vue frontend/src/components/CommentsPanel.vue \
+        frontend/src/components/BacklinksPanel.vue frontend/src/components/OutgoingLinksPanel.vue \
+        frontend/src/components/UnlinkedMentionsPanel.vue \
+        frontend/src/PropertiesPanel.spec.ts frontend/src/CommentsPanel.spec.ts \
+        frontend/src/BacklinksPanel.spec.ts frontend/src/OutgoingLinksPanel.spec.ts \
+        frontend/src/UnlinkedMentionsPanel.spec.ts
+git commit -m "feat: wire collapsible state into all five note editor panels"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §2 (all five panels collapsible, Properties default
+  collapsed, others default expanded) → Task 3's five per-panel defaults
+  match exactly. §3 (composable, PanelHeader chevron, per-panel keys) →
+  Tasks 1–2 plus Task 3's five exact key strings, matching the spec's
+  table verbatim (`properties`/`comments`/`backlinks`/`outgoing-links`/
+  `unlinked-mentions`). §4 testing → one test file per panel plus the
+  composable and `PanelHeader` specs, matching the spec's breakdown.
+- **Placeholder scan:** none found. Steps 6, 8, 9 in Task 3 describe the
+  edit by exact reference to Step 3's fully-written-out pattern rather
+  than repeating the same six lines of near-identical Vue template five
+  times — each still names the exact prop bindings, exact composable
+  call arguments, and exact class names to touch, so no step is missing
+  information, only avoiding verbatim repetition of an identical
+  three-line edit already fully specified once.
+- **Type consistency:** `useCollapsiblePanel(key: string, defaultCollapsed: boolean)`
+  return shape `{ collapsed: Ref<boolean>; toggle: () => void }` (Task 1)
+  is destructured identically in all five panels (Task 3) and matches
+  `PanelHeader`'s `collapsed: boolean` prop / `toggle` emit (Task 2) at
+  every call site.

--- a/docs/superpowers/specs/2026-08-01-collapsible-panels-design.md
+++ b/docs/superpowers/specs/2026-08-01-collapsible-panels-design.md
@@ -1,0 +1,123 @@
+# Collapsible Note Editor Panels — Design
+
+Date: 2026-08-01
+Status: Approved for planning
+Scope: Frontend-only. No API changes, no database changes.
+
+## 1. Purpose
+
+Reported in production: `PropertiesPanel` occupies most of the screen
+and has no way to collapse it. Root cause, confirmed via
+systematic-debugging: `PanelHeader.vue` (the shared header used by
+`PropertiesPanel.vue`, `CommentsPanel.vue`, `BacklinksPanel.vue`,
+`OutgoingLinksPanel.vue`, and `UnlinkedMentionsPanel.vue`, confirmed via
+`grep -rl PanelHeader frontend/src/components/*.vue`) renders only a
+title and count — no chevron, no toggle, no collapse mechanism at all.
+Every one of these five panels is mounted unconditionally in-flow in
+`NoteEditor.vue`, each always fully expanded, with no way to hide it.
+This is a missing feature, not a regression — none of the five panels
+has ever had a collapse capability.
+
+## 2. Scope
+
+**In scope:**
+- All five panels sharing `PanelHeader.vue` become collapsible via a
+  chevron button in the header.
+- `PropertiesPanel` starts collapsed by default; the other four start
+  expanded by default (matches today's behavior for those four, only
+  changes the one panel that was reported as a problem).
+- Collapse state persists across page reloads via `localStorage`, one
+  key per panel type (not per note) — closing Properties once keeps it
+  closed everywhere until explicitly reopened.
+
+**Out of scope:**
+- No change to panel content/behavior beyond adding the collapse
+  wrapper — the properties list, comment form, backlink list, etc. stay
+  exactly as they are today, just hideable.
+- No per-note collapse memory (e.g. "closed only on this note") — the
+  preference is global per panel type, per the brainstorming decision.
+- No drag-to-resize or reordering of panels — purely a show/hide toggle.
+
+## 3. Architecture
+
+A new composable, `useCollapsiblePanel(key: string, defaultCollapsed:
+boolean)`, centralizes the localStorage read/write/toggle logic so it's
+written once instead of five times:
+
+```typescript
+// frontend/src/composables/useCollapsiblePanel.ts
+import { ref, watch } from 'vue'
+
+export function useCollapsiblePanel(key: string, defaultCollapsed: boolean) {
+  const storageKey = `jotter-panel-collapsed:${key}`
+  const collapsed = ref(defaultCollapsed)
+
+  const stored = localStorage.getItem(storageKey)
+  if (stored !== null) {
+    collapsed.value = stored === 'true'
+  }
+
+  watch(collapsed, (value) => {
+    localStorage.setItem(storageKey, String(value))
+  })
+
+  function toggle() {
+    collapsed.value = !collapsed.value
+  }
+
+  return { collapsed, toggle }
+}
+```
+
+`PanelHeader.vue` gains a `collapsed: boolean` prop and a `(e: 'toggle'):
+void` emit. It renders a chevron button (rotates 90° when collapsed,
+matching the existing chevron-rotation pattern already used for sidebar
+folders in `NoteTreeNode.vue`) that emits `toggle` on click — the header
+itself is the only new UI surface; the five consuming panels don't gain
+any new visible markup beyond wrapping their existing body in `v-show`.
+
+Each of the five panel components:
+1. Calls `useCollapsiblePanel('<panel-key>', <default>)` — key and
+   default per panel:
+   - `PropertiesPanel.vue`: `useCollapsiblePanel('properties', true)`
+   - `CommentsPanel.vue`: `useCollapsiblePanel('comments', false)`
+   - `BacklinksPanel.vue`: `useCollapsiblePanel('backlinks', false)`
+   - `OutgoingLinksPanel.vue`: `useCollapsiblePanel('outgoing-links', false)`
+   - `UnlinkedMentionsPanel.vue`: `useCollapsiblePanel('unlinked-mentions', false)`
+2. Passes `:collapsed="collapsed"` and `@toggle="toggle"` to its
+   `<PanelHeader>`.
+3. Wraps its existing body markup (everything currently rendered below
+   `<PanelHeader>`) in `<div v-show="!collapsed">...</div>` — no other
+   template changes.
+
+## 4. Testing
+
+**`useCollapsiblePanel.spec.ts`:**
+- Returns `collapsed.value === defaultCollapsed` when no localStorage
+  key exists yet.
+- Returns the stored value (not the default) when a key already exists.
+- `toggle()` flips `collapsed.value` and persists the new value to
+  `localStorage`.
+
+**`PanelHeader.spec.ts`:**
+- Clicking the chevron button emits `toggle`.
+- The chevron has a `collapsed` CSS class (or equivalent rotation state)
+  when the `collapsed` prop is `true`.
+
+**One representative panel test updated per panel** (`PropertiesPanel`,
+`CommentsPanel`, `BacklinksPanel`, `OutgoingLinksPanel`,
+`UnlinkedMentionsPanel` — each already has its own spec file per prior
+session work):
+- The panel's body is hidden (`v-show` → `display: none`) when its
+  `useCollapsiblePanel` composable reports `collapsed: true`.
+- Clicking the header's chevron toggles the body's visibility.
+
+No backend test changes — no backend code changes in this feature.
+
+## 5. Out of scope / open questions carried forward
+
+- Per-note collapse memory (§2).
+- Drag-to-resize (§2).
+- The workspace/tenant switcher gaps found in the same investigation are
+  a separate, larger feature — tracked as its own follow-up brainstorming
+  cycle, not part of this spec.

--- a/frontend/src/BacklinksPanel.spec.ts
+++ b/frontend/src/BacklinksPanel.spec.ts
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, beforeEach } from 'vitest'
+import BacklinksPanel from './components/BacklinksPanel.vue'
+
+describe('BacklinksPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows the empty state when there are no backlinks', () => {
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    expect(wrapper.text()).toContain('No notes link to this document yet.')
+  })
+
+  it('shows the body by default', () => {
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    expect((wrapper.find('.backlinks-body').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('hides the body when collapsed via the header chevron', async () => {
+    const wrapper = mount(BacklinksPanel, { props: { backlinks: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.backlinks-body').element as HTMLElement).style.display).toBe('none')
+  })
+})

--- a/frontend/src/CommentsPanel.spec.ts
+++ b/frontend/src/CommentsPanel.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import CommentsPanel from './components/CommentsPanel.vue'
 
 const comment = {
@@ -14,6 +14,10 @@ const comment = {
 }
 
 describe('CommentsPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('shows the empty state when there are no comments', () => {
     const wrapper = mount(CommentsPanel, { props: { comments: [] } })
     expect(wrapper.text()).toContain('No comments on this note yet.')
@@ -59,5 +63,19 @@ describe('CommentsPanel', () => {
       props: { comments: [], errorMessage: 'You can only delete your own comments.' }
     })
     expect(wrapper.text()).toContain('You can only delete your own comments.')
+  })
+
+  it('hides the body when collapsed', async () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.comments-body').element as HTMLElement).style.display).toBe('none')
+  })
+
+  it('shows the body by default and re-shows it after toggling twice', async () => {
+    const wrapper = mount(CommentsPanel, { props: { comments: [] } })
+    expect((wrapper.find('.comments-body').element as HTMLElement).style.display).not.toBe('none')
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.comments-body').element as HTMLElement).style.display).not.toBe('none')
   })
 })

--- a/frontend/src/OutgoingLinksPanel.spec.ts
+++ b/frontend/src/OutgoingLinksPanel.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import OutgoingLinksPanel from './components/OutgoingLinksPanel.vue'
 
 const resolvedLink = {
@@ -30,6 +30,10 @@ const unresolvedLink = {
 }
 
 describe('OutgoingLinksPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('shows the empty state when there are no outgoing links', () => {
     const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
     expect(wrapper.text()).toContain("doesn't link to any other notes yet")
@@ -62,5 +66,16 @@ describe('OutgoingLinksPanel', () => {
     const wrapper = mount(OutgoingLinksPanel, { props: { links: [unresolvedLink] } })
     await wrapper.get('.outgoing-link-item').trigger('click')
     expect(wrapper.emitted('select-note')).toBeFalsy()
+  })
+
+  it('shows the body by default', () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
+    expect((wrapper.find('.outgoing-links-body').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('hides the body when collapsed via the header chevron', async () => {
+    const wrapper = mount(OutgoingLinksPanel, { props: { links: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.outgoing-links-body').element as HTMLElement).style.display).toBe('none')
   })
 })

--- a/frontend/src/PropertiesPanel.spec.ts
+++ b/frontend/src/PropertiesPanel.spec.ts
@@ -1,8 +1,12 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import PropertiesPanel from './components/PropertiesPanel.vue'
 
 describe('PropertiesPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('shows the empty state when there are no properties', () => {
     const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
     expect(wrapper.text()).toContain('No typed properties on this note yet.')
@@ -53,5 +57,16 @@ describe('PropertiesPanel', () => {
     await wrapper.get('.property-form').trigger('submit')
 
     expect(wrapper.emitted('add-property')![0]).toEqual(['tags', ['a', 'b', 'c']])
+  })
+
+  it('hides the body when collapsed', () => {
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+    expect((wrapper.find('.properties-body').element as HTMLElement).style.display).toBe('none')
+  })
+
+  it('shows the body and toggles collapse when the header chevron is clicked', async () => {
+    const wrapper = mount(PropertiesPanel, { props: { properties: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.properties-body').element as HTMLElement).style.display).not.toBe('none')
   })
 })

--- a/frontend/src/UnlinkedMentionsPanel.spec.ts
+++ b/frontend/src/UnlinkedMentionsPanel.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import UnlinkedMentionsPanel from './components/UnlinkedMentionsPanel.vue'
 
 const mention = {
@@ -11,6 +11,10 @@ const mention = {
 }
 
 describe('UnlinkedMentionsPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('shows the empty state when there are no mentions', () => {
     const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
     expect(wrapper.text()).toContain('No unlinked mentions found.')
@@ -32,5 +36,16 @@ describe('UnlinkedMentionsPanel', () => {
     const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [mention] } })
     await wrapper.get('[data-testid="convert-to-link-btn"]').trigger('click')
     expect(wrapper.emitted('convert-to-link')![0]).toEqual([mention])
+  })
+
+  it('shows the body by default', () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
+    expect((wrapper.find('.unlinked-mentions-body').element as HTMLElement).style.display).not.toBe('none')
+  })
+
+  it('hides the body when collapsed via the header chevron', async () => {
+    const wrapper = mount(UnlinkedMentionsPanel, { props: { mentions: [] } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect((wrapper.find('.unlinked-mentions-body').element as HTMLElement).style.display).toBe('none')
   })
 })

--- a/frontend/src/components/BacklinksPanel.vue
+++ b/frontend/src/components/BacklinksPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="backlinks-panel" aria-label="Backlinks">
-    <PanelHeader title="Backlinks" :count="backlinks.length">
+    <PanelHeader title="Backlinks" :count="backlinks.length" :collapsed="collapsed" @toggle="toggle">
       <template #icon>
         <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
@@ -9,14 +9,15 @@
       </template>
     </PanelHeader>
 
+    <div v-show="!collapsed" class="backlinks-body">
     <div v-if="backlinks.length === 0" class="backlinks-empty">
       <p>No notes link to this document yet.</p>
     </div>
 
     <ul v-else class="backlinks-list">
-      <li 
-        v-for="link in backlinks" 
-        :key="link.id" 
+      <li
+        v-for="link in backlinks"
+        :key="link.id"
         class="backlink-item"
         @click="$emit('select-note', link.id)"
       >
@@ -24,11 +25,13 @@
         <div class="backlink-path">{{ link.path }}</div>
       </li>
     </ul>
+    </div>
   </aside>
 </template>
 
 <script setup lang="ts">
 import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
 import type { Backlink } from '../services/types'
 
 defineProps<{
@@ -38,6 +41,8 @@ defineProps<{
 defineEmits<{
   (e: 'select-note', noteId: number): void
 }>()
+
+const { collapsed, toggle } = useCollapsiblePanel('backlinks', false)
 </script>
 
 <style scoped>

--- a/frontend/src/components/CommentsPanel.vue
+++ b/frontend/src/components/CommentsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="comments-panel" aria-label="Comments">
-    <PanelHeader title="Comments" :count="comments.length">
+    <PanelHeader title="Comments" :count="comments.length" :collapsed="collapsed" @toggle="toggle">
       <template #icon>
         <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
@@ -8,6 +8,7 @@
       </template>
     </PanelHeader>
 
+    <div v-show="!collapsed" class="comments-body">
     <p v-if="errorMessage" class="comments-error" role="alert">{{ errorMessage }}</p>
 
     <div v-if="comments.length === 0" class="comments-empty">
@@ -50,12 +51,14 @@
         Comment
       </button>
     </form>
+    </div>
   </aside>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
 import type { NoteComment } from '../services/types'
 
 defineProps<{
@@ -67,6 +70,8 @@ const emit = defineEmits<{
   (e: 'add-comment', content: string): void
   (e: 'delete-comment', commentId: number): void
 }>()
+
+const { collapsed, toggle } = useCollapsiblePanel('comments', false)
 
 const newContent = ref('')
 

--- a/frontend/src/components/OutgoingLinksPanel.vue
+++ b/frontend/src/components/OutgoingLinksPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="outgoing-links-panel" aria-label="Outgoing links">
-    <PanelHeader title="Outgoing Links" :count="links.length">
+    <PanelHeader title="Outgoing Links" :count="links.length" :collapsed="collapsed" @toggle="toggle">
       <template #icon>
         <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <line x1="7" y1="17" x2="17" y2="7"></line>
@@ -9,6 +9,7 @@
       </template>
     </PanelHeader>
 
+    <div v-show="!collapsed" class="outgoing-links-body">
     <div v-if="links.length === 0" class="outgoing-links-empty">
       <p>This note doesn't link to any other notes yet.</p>
     </div>
@@ -29,11 +30,13 @@
         </div>
       </li>
     </ul>
+    </div>
   </aside>
 </template>
 
 <script setup lang="ts">
 import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
 import type { OutgoingLink } from '../services/types'
 
 defineProps<{
@@ -43,6 +46,8 @@ defineProps<{
 defineEmits<{
   (e: 'select-note', noteId: number): void
 }>()
+
+const { collapsed, toggle } = useCollapsiblePanel('outgoing-links', false)
 </script>
 
 <style scoped>

--- a/frontend/src/components/PanelHeader.spec.ts
+++ b/frontend/src/components/PanelHeader.spec.ts
@@ -4,23 +4,23 @@ import PanelHeader from './PanelHeader.vue'
 
 describe('PanelHeader', () => {
   it('renders the title', () => {
-    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks' } })
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
     expect(wrapper.text()).toContain('Backlinks')
   })
 
   it('renders the count badge when count is provided', () => {
-    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', count: 3 } })
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', count: 3, collapsed: false } })
     expect(wrapper.find('.panel-header-count').text()).toBe('3')
   })
 
   it('omits the count badge when count is undefined', () => {
-    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks' } })
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
     expect(wrapper.find('.panel-header-count').exists()).toBe(false)
   })
 
   it('renders slotted icon content', () => {
     const wrapper = mount(PanelHeader, {
-      props: { title: 'Backlinks' },
+      props: { title: 'Backlinks', collapsed: false },
       slots: { icon: '<svg class="my-icon"></svg>' },
     })
     expect(wrapper.find('.my-icon').exists()).toBe(true)

--- a/frontend/src/components/PanelHeader.spec.ts
+++ b/frontend/src/components/PanelHeader.spec.ts
@@ -25,4 +25,20 @@ describe('PanelHeader', () => {
     })
     expect(wrapper.find('.my-icon').exists()).toBe(true)
   })
+
+  it('emits toggle when the chevron button is clicked', async () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
+    await wrapper.find('[data-testid="panel-collapse-toggle"]').trigger('click')
+    expect(wrapper.emitted('toggle')).toBeTruthy()
+  })
+
+  it('applies the collapsed class to the chevron when collapsed is true', () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: true } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"] .chevron').classes()).toContain('collapsed')
+  })
+
+  it('does not apply the collapsed class when collapsed is false', () => {
+    const wrapper = mount(PanelHeader, { props: { title: 'Backlinks', collapsed: false } })
+    expect(wrapper.find('[data-testid="panel-collapse-toggle"] .chevron').classes()).not.toContain('collapsed')
+  })
 })

--- a/frontend/src/components/PanelHeader.vue
+++ b/frontend/src/components/PanelHeader.vue
@@ -4,7 +4,30 @@
       <slot name="icon" />
       <span>{{ title }}</span>
     </div>
-    <span v-if="count !== undefined" class="panel-header-count">{{ count }}</span>
+    <div class="panel-header-actions">
+      <span v-if="count !== undefined" class="panel-header-count">{{ count }}</span>
+      <button
+        type="button"
+        class="panel-collapse-toggle"
+        data-testid="panel-collapse-toggle"
+        :aria-label="collapsed ? `Expand ${title}` : `Collapse ${title}`"
+        :aria-expanded="!collapsed"
+        @click="$emit('toggle')"
+      >
+        <svg
+          class="chevron"
+          :class="{ collapsed: collapsed }"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+        >
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+    </div>
   </div>
 </template>
 
@@ -12,6 +35,11 @@
 defineProps<{
   title: string
   count?: number
+  collapsed: boolean
+}>()
+
+defineEmits<{
+  (e: 'toggle'): void
 }>()
 </script>
 
@@ -40,5 +68,38 @@ defineProps<{
   padding: 0.125rem 0.5rem;
   border-radius: var(--radius-pill);
   font-size: 0.75rem;
+}
+
+.panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.panel-collapse-toggle {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background-color var(--duration-fast) var(--ease-standard);
+}
+
+.panel-collapse-toggle:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.chevron {
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.chevron.collapsed {
+  transform: rotate(-90deg);
 }
 </style>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="properties-panel" aria-label="Properties">
-    <PanelHeader title="Properties" :count="properties.length">
+    <PanelHeader title="Properties" :count="properties.length" :collapsed="collapsed" @toggle="toggle">
       <template #icon>
         <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <path d="M3 6h18M7 12h10M11 18h2"></path>
@@ -8,6 +8,7 @@
       </template>
     </PanelHeader>
 
+    <div v-show="!collapsed" class="properties-body">
     <div v-if="properties.length === 0" class="properties-empty">
       <p>No typed properties on this note yet.</p>
     </div>
@@ -85,12 +86,14 @@
 
       <button type="submit" class="btn-add-property" data-testid="property-add-btn">Add</button>
     </form>
+    </div>
   </aside>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
 import type { NoteProperty, NotePropertyType } from '../services/types'
 
 defineProps<{
@@ -101,6 +104,8 @@ const emit = defineEmits<{
   (e: 'add-property', name: string, value: unknown): void
   (e: 'delete-property', name: string): void
 }>()
+
+const { collapsed, toggle } = useCollapsiblePanel('properties', true)
 
 const newName = ref('')
 const newType = ref<NotePropertyType>('string')

--- a/frontend/src/components/UnlinkedMentionsPanel.vue
+++ b/frontend/src/components/UnlinkedMentionsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="unlinked-mentions-panel" aria-label="Unlinked mentions">
-    <PanelHeader title="Unlinked Mentions" :count="mentions.length">
+    <PanelHeader title="Unlinked Mentions" :count="mentions.length" :collapsed="collapsed" @toggle="toggle">
       <template #icon>
         <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <circle cx="12" cy="12" r="10"></circle>
@@ -10,6 +10,7 @@
       </template>
     </PanelHeader>
 
+    <div v-show="!collapsed" class="unlinked-mentions-body">
     <div v-if="mentions.length === 0" class="unlinked-mentions-empty">
       <p>No unlinked mentions found.</p>
     </div>
@@ -31,11 +32,13 @@
         </button>
       </li>
     </ul>
+    </div>
   </aside>
 </template>
 
 <script setup lang="ts">
 import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
 import type { UnlinkedMention } from '../services/types'
 
 defineProps<{
@@ -46,6 +49,8 @@ defineEmits<{
   (e: 'select-note', noteId: number): void
   (e: 'convert-to-link', mention: UnlinkedMention): void
 }>()
+
+const { collapsed, toggle } = useCollapsiblePanel('unlinked-mentions', false)
 </script>
 
 <style scoped>

--- a/frontend/src/composables/useCollapsiblePanel.spec.ts
+++ b/frontend/src/composables/useCollapsiblePanel.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCollapsiblePanel } from './useCollapsiblePanel'
+
+describe('useCollapsiblePanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('uses the default when no stored value exists', () => {
+    const { collapsed } = useCollapsiblePanel('properties', true)
+    expect(collapsed.value).toBe(true)
+  })
+
+  it('uses the stored value instead of the default when one exists', () => {
+    localStorage.setItem('jotter-panel-collapsed:comments', 'true')
+    const { collapsed } = useCollapsiblePanel('comments', false)
+    expect(collapsed.value).toBe(true)
+  })
+
+  it('toggle flips the value and persists it', () => {
+    const { collapsed, toggle } = useCollapsiblePanel('backlinks', false)
+    toggle()
+    expect(collapsed.value).toBe(true)
+    expect(localStorage.getItem('jotter-panel-collapsed:backlinks')).toBe('true')
+
+    toggle()
+    expect(collapsed.value).toBe(false)
+    expect(localStorage.getItem('jotter-panel-collapsed:backlinks')).toBe('false')
+  })
+})

--- a/frontend/src/composables/useCollapsiblePanel.ts
+++ b/frontend/src/composables/useCollapsiblePanel.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+
+export function useCollapsiblePanel(key: string, defaultCollapsed: boolean) {
+  const storageKey = `jotter-panel-collapsed:${key}`
+  const collapsed = ref(defaultCollapsed)
+
+  const stored = localStorage.getItem(storageKey)
+  if (stored !== null) {
+    collapsed.value = stored === 'true'
+  }
+
+  function toggle() {
+    collapsed.value = !collapsed.value
+    localStorage.setItem(storageKey, String(collapsed.value))
+  }
+
+  return { collapsed, toggle }
+}


### PR DESCRIPTION
## Summary
- Adds a `useCollapsiblePanel(key, defaultCollapsed)` composable persisting collapse state per panel type via localStorage
- Adds a collapse chevron to `PanelHeader.vue`, wired into Properties, Comments, Backlinks, Outgoing Links, and Unlinked Mentions panels
- Properties panel now defaults to collapsed (was dominating the screen); the other four default to expanded

## Test plan
- [x] `./scripts/jt.sh test` — PHP suite (145 passed) + frontend build/type-check + vitest (184 passed)