### PR TITLE
feat: display app version, auto-bumped per release

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -65,10 +65,14 @@ final class AuthController extends Controller
             }
         }
 
+        $versionFile = base_path('VERSION');
+        $version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : null;
+
         return response()->json([
             'data' => [
                 'provider' => $provider,
                 'sso_login_url' => $ssoLoginUrl,
+                'version' => $version,
             ],
         ]);
     }

--- a/compose.yaml
+++ b/compose.yaml
@@ -75,6 +75,9 @@ services:
       context: .
       dockerfile: docker/release/Dockerfile
       target: release
+      args:
+        GIT_SHA: ${GIT_SHA:-dev}
+        BUILD_TIME: ${BUILD_TIME:-unknown}
     volumes:
       - ./dist:/dist
     command:

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -18,15 +18,22 @@ RUN composer dump-autoload --optimize --no-dev --no-scripts
 
 FROM node:22-bookworm-slim AS frontend
 
+ARG GIT_SHA=dev
+ARG BUILD_TIME=unknown
+
 WORKDIR /app/frontend
 
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
 COPY frontend/ ./
+ENV VITE_APP_VERSION="${GIT_SHA} · ${BUILD_TIME}"
 RUN npm run build
 
 FROM alpine:3.21 AS release
+
+ARG GIT_SHA=dev
+ARG BUILD_TIME=unknown
 
 RUN apk add --no-cache zip
 
@@ -34,6 +41,8 @@ WORKDIR /release
 
 COPY --from=vendor /app /release/app
 COPY --from=frontend /app/public/build /release/app/public/build
+
+RUN echo "${GIT_SHA} · ${BUILD_TIME}" > /release/app/VERSION
 
 RUN cd /release/app \
     && rm -rf \

--- a/docs/superpowers/plans/2026-08-01-app-version-display-implementation.md
+++ b/docs/superpowers/plans/2026-08-01-app-version-display-implementation.md
@@ -1,0 +1,611 @@
+# App Version Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a build-identifying version string (`<short-git-sha> · <UTC build timestamp>`) automatically on every `./scripts/jt.sh release`, bake it into both the frontend bundle and the backend release directory, and show it in the Sidebar footer — with a visible warning if frontend and backend versions ever diverge.
+
+**Architecture:** `jt.sh release` computes `GIT_SHA`/`BUILD_TIME` and passes them as Docker build-args into `docker/release/Dockerfile`. The frontend stage sets them as a `VITE_APP_VERSION` env var before `npm run build` (Vite auto-exposes any `VITE_`-prefixed env var as `import.meta.env.VITE_APP_VERSION`, no vite.config.ts change needed). The release stage writes a plain `VERSION` file into the release directory. `AuthController@config` reads that file and returns it as `version` in its existing JSON response. `App.vue` calls `getAuthConfig()` once on mount (a new call there — today only `LoginModal.vue` calls it, which doesn't fire for an already-authenticated user, so version needs its own always-fires call) and passes both versions down to `Sidebar.vue`.
+
+**Tech Stack:** Bash (`jt.sh`), Docker multi-stage build, Laravel 11 (PHP 8.2+/8.3), PHPUnit, Vue 3 `<script setup>` + TypeScript, Vite, Vitest.
+
+## Global Constraints
+
+- Use only `./scripts/jt.sh` wrappers for all dependency/build/test/db commands — never call `docker`/`php`/`npm` directly.
+- No manual semver bumping anywhere — the version must be fully automatic from `jt.sh release`, with zero manual steps.
+- The version format is exactly `<short-git-sha> · <UTC build timestamp formatted as 'YYYY-MM-DD HH:MM'>` on both frontend and backend — same format, same source values, so they match under normal deploys.
+- Local dev (`jt.sh up`, `npm run dev`) is not a release build: frontend must fall back to `'dev'`, backend's `version` must be `null` when no `VERSION` file exists. Do not treat this as an error.
+
+---
+
+### Task 1: Generate and thread the version through the release Docker build
+
+**Files:**
+- Modify: `scripts/jt.sh` (`cmd_release()`)
+- Modify: `compose.yaml` (the `release` service)
+- Modify: `docker/release/Dockerfile` (`frontend` and `release` stages)
+
+**Interfaces:**
+- Produces: inside the built release image, `frontend/public/build`'s JS bundle has `import.meta.env.VITE_APP_VERSION` baked in as `"<sha> · <timestamp>"`, and `/release/app/VERSION` is a one-line text file with the same string. Task 2 (frontend `version.ts` module) and Task 3 (backend `AuthController@config`) consume these directly — no other interface changes.
+
+- [ ] **Step 1: Update `cmd_release()` in `scripts/jt.sh`**
+
+Replace:
+
+```bash
+cmd_release() {
+  ensure_env
+  mkdir -p dist
+  compose --profile tools run --rm --build release
+  test -s dist/jotter-release.zip
+  test -s dist/jotter-release.zip.sha256
+  (cd dist && sha256sum -c jotter-release.zip.sha256)
+  echo "Release written to dist/jotter-release.zip"
+}
+```
+
+With:
+
+```bash
+cmd_release() {
+  ensure_env
+  mkdir -p dist
+  export GIT_SHA="$(git rev-parse --short HEAD)"
+  export BUILD_TIME="$(date -u +'%Y-%m-%d %H:%M')"
+  compose --profile tools run --rm --build release
+  test -s dist/jotter-release.zip
+  test -s dist/jotter-release.zip.sha256
+  (cd dist && sha256sum -c jotter-release.zip.sha256)
+  echo "Release written to dist/jotter-release.zip (version: ${GIT_SHA} · ${BUILD_TIME})"
+}
+```
+
+`export` makes `GIT_SHA`/`BUILD_TIME` visible to the `docker compose` subprocess so `compose.yaml`'s `${GIT_SHA}`/`${BUILD_TIME}` interpolation (next step) can pick them up.
+
+- [ ] **Step 2: Pass them as build-args in `compose.yaml`**
+
+Find the `release` service (currently):
+
+```yaml
+  release:
+    profiles:
+      - tools
+    build:
+      context: .
+      dockerfile: docker/release/Dockerfile
+      target: release
+    volumes:
+      - ./dist:/dist
+    command:
+      - sh
+      - -c
+      - cp /jotter-release.zip /jotter-release.zip.sha256 /dist/
+```
+
+Add a `build.args` block:
+
+```yaml
+  release:
+    profiles:
+      - tools
+    build:
+      context: .
+      dockerfile: docker/release/Dockerfile
+      target: release
+      args:
+        GIT_SHA: ${GIT_SHA:-dev}
+        BUILD_TIME: ${BUILD_TIME:-unknown}
+    volumes:
+      - ./dist:/dist
+    command:
+      - sh
+      - -c
+      - cp /jotter-release.zip /jotter-release.zip.sha256 /dist/
+```
+
+The `:-dev`/`:-unknown` defaults mean `docker compose build release` (or any invocation outside `jt.sh release`, e.g. manual testing) still produces a valid, if generic, version rather than an empty string.
+
+- [ ] **Step 3: Declare and use the ARGs in `docker/release/Dockerfile`**
+
+In the `frontend` stage, currently:
+
+```dockerfile
+FROM node:22-bookworm-slim AS frontend
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+```
+
+Change to:
+
+```dockerfile
+FROM node:22-bookworm-slim AS frontend
+
+ARG GIT_SHA=dev
+ARG BUILD_TIME=unknown
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+ENV VITE_APP_VERSION="${GIT_SHA} · ${BUILD_TIME}"
+RUN npm run build
+```
+
+In the `release` stage, currently starts with:
+
+```dockerfile
+FROM alpine:3.21 AS release
+
+RUN apk add --no-cache zip
+
+WORKDIR /release
+
+COPY --from=vendor /app /release/app
+COPY --from=frontend /app/public/build /release/app/public/build
+
+RUN cd /release/app \
+    && rm -rf \
+```
+
+Change to:
+
+```dockerfile
+FROM alpine:3.21 AS release
+
+ARG GIT_SHA=dev
+ARG BUILD_TIME=unknown
+
+RUN apk add --no-cache zip
+
+WORKDIR /release
+
+COPY --from=vendor /app /release/app
+COPY --from=frontend /app/public/build /release/app/public/build
+
+RUN echo "${GIT_SHA} · ${BUILD_TIME}" > /release/app/VERSION
+
+RUN cd /release/app \
+    && rm -rf \
+```
+
+(The `RUN echo ... > VERSION` line is inserted as its own step, right after both `COPY --from=` lines and before the existing `rm -rf` cleanup step — the cleanup step doesn't touch `VERSION` so ordering relative to it doesn't matter, but placing it before keeps all "what's in the final app dir" steps grouped together.)
+
+- [ ] **Step 4: Verify the build produces a real version**
+
+Run: `./scripts/jt.sh release`
+Expected: succeeds as before, and the final echoed line shows a real short SHA and a real timestamp, e.g. `Release written to dist/jotter-release.zip (version: 9420233 · 2026-08-01 16:30)` — not `dev`/`unknown`.
+
+Then verify the artifacts directly:
+
+```bash
+mkdir -p /tmp/release-check && cd /tmp/release-check
+unzip -o -q /home/ubuntu/projects/web/iroh/jotter/.claude/worktrees/app-version/dist/jotter-release.zip
+cat app/VERSION
+grep -o 'VITE_APP_VERSION[^"]*' app/public/build/assets/index-*.js || true
+```
+
+Expected: `app/VERSION` contains the real sha+timestamp string. (The grep for `VITE_APP_VERSION` inside the built JS may not match literally since Vite substitutes the value at build time and doesn't keep the variable name in the output — Task 2's own test is the real verification for the frontend side. This check is just a sanity confirmation that the release zip was rebuilt.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/jt.sh compose.yaml docker/release/Dockerfile
+git commit -m "feat: bake git sha + build timestamp into release builds"
+```
+
+---
+
+### Task 2: Frontend version module and Sidebar footer display
+
+**Files:**
+- Create: `frontend/src/version.ts`
+- Modify: `frontend/src/components/Sidebar.vue`
+- Modify: `frontend/src/Sidebar.spec.ts`
+
+**Interfaces:**
+- Consumes: `import.meta.env.VITE_APP_VERSION` (set by Task 1's Docker build; unset in local dev).
+- Produces: `export const APP_VERSION: string` from `version.ts`. New `Sidebar.vue` props `frontendVersion: string` (required) and `backendVersion?: string | null` (optional). Task 3/4 (App.vue wiring) consumes these prop names directly.
+
+- [ ] **Step 1: Write the failing test for `version.ts`'s consumption in Sidebar**
+
+Add to `frontend/src/Sidebar.spec.ts` (a new `describe` block; this file has no shared base-props object — every test inlines its own `props`, so follow that same pattern):
+
+```typescript
+describe('Sidebar version footer', () => {
+  it('renders the frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'abc1234 · 2026-08-01 16:30' },
+    })
+    expect(wrapper.find('[data-testid="app-version"]').text()).toContain('abc1234 · 2026-08-01 16:30')
+  })
+
+  it('shows the backend version alongside when it differs from the frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: {
+        notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [],
+        frontendVersion: 'abc1234 · 2026-08-01 16:30',
+        backendVersion: 'def5678 · 2026-08-01 16:31',
+      },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').text()).toContain('def5678 · 2026-08-01 16:31')
+  })
+
+  it('does not show a mismatch segment when backend version matches frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: {
+        notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [],
+        frontendVersion: 'abc1234 · 2026-08-01 16:30',
+        backendVersion: 'abc1234 · 2026-08-01 16:30',
+      },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').exists()).toBe(false)
+  })
+
+  it('does not show a mismatch segment when backend version is absent', () => {
+    const wrapper = mount(Sidebar, {
+      props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'abc1234 · 2026-08-01 16:30' },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').exists()).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm -- run test -- Sidebar.spec.ts`
+Expected: FAIL — `frontendVersion` is not a known prop (TS error) and `[data-testid="app-version"]` doesn't exist yet.
+
+- [ ] **Step 3: Create `frontend/src/version.ts`**
+
+```typescript
+export const APP_VERSION: string = import.meta.env.VITE_APP_VERSION || 'dev'
+```
+
+- [ ] **Step 4: Add the props and template to `Sidebar.vue`**
+
+Add to the `defineProps` block (the same one Task 4/5 of the previous workspace-switcher plan already extended with `workspaces`):
+
+```typescript
+  frontendVersion: string
+  backendVersion?: string | null
+```
+
+In the template, right after the closing `</div>` of the existing `<!-- User Profile Footer -->` block (after line 376, before the closing `</aside>`):
+
+```vue
+    <div class="sidebar-version" data-testid="app-version">
+      v {{ props.frontendVersion }}
+      <span
+        v-if="props.backendVersion && props.backendVersion !== props.frontendVersion"
+        class="sidebar-version-mismatch"
+        data-testid="app-version-mismatch"
+      >
+        (backend: {{ props.backendVersion }})
+      </span>
+    </div>
+```
+
+Add matching CSS near the existing `.sidebar-footer` rules (around line 1250):
+
+```css
+.sidebar-version {
+  padding: var(--space-1) var(--space-4) var(--space-2);
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.sidebar-version-mismatch {
+  color: var(--color-status-warning);
+}
+```
+
+(`--color-status-warning` is already used elsewhere in this codebase, e.g. `OutgoingLinksPanel.vue`'s `.unresolved-badge` — reuse it rather than inventing a new token.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm -- run test -- Sidebar.spec.ts`
+Expected: PASS, including the four new tests and all pre-existing ones (existing `mount(Sidebar, ...)` calls in this file that don't pass `frontendVersion` will now fail TypeScript compilation once it's required — fix every pre-existing test in this file the same way Task 4 of the workspace-switcher plan fixed the `workspaces` prop: add `frontendVersion: 'dev'` to each one's `props` object).
+
+- [ ] **Step 6: Fix the other two files that mount `Sidebar` directly**
+
+This repeats the exact class of gap the workspace-switcher feature hit twice (`PanelHeader`'s `collapsed` prop, then `Sidebar`'s `workspaces` prop): making `frontendVersion` required breaks `vue-tsc -b` in any other file mounting `Sidebar` without it. There are two: `frontend/src/SidebarNotifications.spec.ts` (its `baseProps` object) and `frontend/src/a11y.spec.ts` (its two inline `mount(Sidebar, ...)` calls). Add `frontendVersion: 'dev'` to all of them.
+
+- [ ] **Step 7: Run the full frontend suite to confirm no regressions**
+
+Run: `./scripts/jt.sh npm -- run test`
+Expected: all tests pass, including `SidebarNotifications.spec.ts` and `a11y.spec.ts`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/version.ts frontend/src/components/Sidebar.vue frontend/src/Sidebar.spec.ts frontend/src/SidebarNotifications.spec.ts frontend/src/a11y.spec.ts
+git commit -m "feat: add version.ts and Sidebar version footer"
+```
+
+---
+
+### Task 3: Backend `version` field on `/api/auth/config`
+
+**Files:**
+- Modify: `app/Http/Controllers/AuthController.php`
+- Modify: `tests/Feature/AuthTest.php`
+
+**Interfaces:**
+- Produces: `GET /api/auth/config` response gains a `version` key: `{"data": {"provider": ..., "sso_login_url": ..., "version": "<sha> · <timestamp>" | null}}`. Task 4 (frontend `getAuthConfig()` type + App.vue) consumes this key directly.
+
+- [ ] **Step 1: Write the failing feature tests**
+
+Add to `tests/Feature/AuthTest.php`, near the existing `test_auth_config_endpoint_*` tests:
+
+```php
+public function test_auth_config_endpoint_reports_version_from_version_file(): void
+{
+    $versionFile = base_path('VERSION');
+    file_put_contents($versionFile, "abc1234 · 2026-08-01 16:30\n");
+
+    try {
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJsonPath('data.version', 'abc1234 · 2026-08-01 16:30');
+    } finally {
+        unlink($versionFile);
+    }
+}
+
+public function test_auth_config_endpoint_reports_null_version_when_version_file_absent(): void
+{
+    $versionFile = base_path('VERSION');
+    if (file_exists($versionFile)) {
+        unlink($versionFile);
+    }
+
+    $this->getJson('/api/auth/config')
+        ->assertOk()
+        ->assertJsonPath('data.version', null);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh test -- --filter=test_auth_config_endpoint_reports`
+Expected: FAIL — `data.version` key doesn't exist in the response yet.
+
+- [ ] **Step 3: Update `AuthController@config`**
+
+Current:
+
+```php
+    public function config(): JsonResponse
+    {
+        $provider = (string) config('jotter.auth_provider', 'local');
+
+        $ssoLoginUrl = null;
+        if ($provider === 'grandpasson') {
+            $brokerBaseUrl = config('jotter.sso.broker_base_url');
+            $clientId = config('jotter.sso.client_id');
+
+            if ($brokerBaseUrl && $clientId) {
+                $ssoLoginUrl = rtrim((string) $brokerBaseUrl, '/').'/login/email?'.http_build_query([
+                    'client_id' => $clientId,
+                    'redirect_uri' => config('app.url'),
+                    'state' => bin2hex(random_bytes(16)),
+                ]);
+            }
+        }
+
+        return response()->json([
+            'data' => [
+                'provider' => $provider,
+                'sso_login_url' => $ssoLoginUrl,
+            ],
+        ]);
+    }
+```
+
+Change to:
+
+```php
+    public function config(): JsonResponse
+    {
+        $provider = (string) config('jotter.auth_provider', 'local');
+
+        $ssoLoginUrl = null;
+        if ($provider === 'grandpasson') {
+            $brokerBaseUrl = config('jotter.sso.broker_base_url');
+            $clientId = config('jotter.sso.client_id');
+
+            if ($brokerBaseUrl && $clientId) {
+                $ssoLoginUrl = rtrim((string) $brokerBaseUrl, '/').'/login/email?'.http_build_query([
+                    'client_id' => $clientId,
+                    'redirect_uri' => config('app.url'),
+                    'state' => bin2hex(random_bytes(16)),
+                ]);
+            }
+        }
+
+        $versionFile = base_path('VERSION');
+        $version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : null;
+
+        return response()->json([
+            'data' => [
+                'provider' => $provider,
+                'sso_login_url' => $ssoLoginUrl,
+                'version' => $version,
+            ],
+        ]);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh test -- --filter=test_auth_config_endpoint`
+Expected: PASS (all 5 `test_auth_config_endpoint_*` tests — the 3 pre-existing plus the 2 new ones).
+
+- [ ] **Step 5: Run the full PHP suite to check for regressions**
+
+Run: `./scripts/jt.sh test`
+Expected: all PHP tests pass (there is no `VERSION` file in the test/dev environment by default, so every other test hitting `/api/auth/config` — e.g. the 3 pre-existing ones — must still pass with `version: null` implicitly satisfied by `assertJson` only checking the keys it names, not asserting the full response shape... verify this holds; if any pre-existing test uses `assertExactJson` or similar strict-shape assertion instead of `assertJson`/`assertJsonPath`, it will need `'version' => null` added to its expected array).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Http/Controllers/AuthController.php tests/Feature/AuthTest.php
+git commit -m "feat: expose release version on /api/auth/config"
+```
+
+---
+
+### Task 4: Wire both versions into `App.vue`
+
+**Files:**
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/App.vue`
+- Modify: `frontend/src/App.spec.ts`
+
+**Interfaces:**
+- Consumes: `version.ts`'s `APP_VERSION` (Task 2), `AuthController@config`'s new `version` field (Task 3), `Sidebar.vue`'s new `frontendVersion`/`backendVersion` props (Task 2).
+- Produces: nothing new consumed elsewhere — this is the final integration point.
+
+- [ ] **Step 1: Add `version` to the `AuthConfig` type**
+
+In `frontend/src/services/api.ts`, current:
+
+```typescript
+export interface AuthConfig {
+  provider: 'local' | 'grandpasson'
+  sso_login_url: string | null
+}
+```
+
+Change to:
+
+```typescript
+export interface AuthConfig {
+  provider: 'local' | 'grandpasson'
+  sso_login_url: string | null
+  version: string | null
+}
+```
+
+- [ ] **Step 2: Write the failing test in `App.spec.ts`**
+
+Check the top of `frontend/src/App.spec.ts` for its existing `vi.mock('./services/api', ...)` block and add a `getAuthConfig` mock alongside the others already there if one isn't present yet (the file may already import/mock it for other reasons — check first, don't assume). Add:
+
+```typescript
+it('passes the frontend version and fetched backend version down to Sidebar', async () => {
+  vi.mocked(getAuthConfig).mockResolvedValueOnce({
+    provider: 'local',
+    sso_login_url: null,
+    version: 'abc1234 · 2026-08-01 16:30',
+  })
+
+  const wrapper = mount(App)
+  await flushPromises()
+
+  expect(wrapper.findComponent({ name: 'Sidebar' }).props('backendVersion')).toBe('abc1234 · 2026-08-01 16:30')
+  expect(wrapper.findComponent({ name: 'Sidebar' }).props('frontendVersion')).toBe('dev')
+})
+```
+
+(`frontendVersion` is expected to be `'dev'` here because `import.meta.env.VITE_APP_VERSION` is unset in the Vitest environment, exactly like local dev — this is the correct, expected fallback per the Global Constraints, not a test artifact to work around.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm -- run test -- App.spec.ts`
+Expected: FAIL — `Sidebar` isn't receiving `frontendVersion`/`backendVersion` props yet.
+
+- [ ] **Step 4: Wire it into `App.vue`**
+
+Add to the import list from `./services/api` (the existing multi-line `import { ... } from './services/api'` block):
+
+```typescript
+  getAuthConfig,
+```
+
+Add a new ref near the other top-level refs (e.g. near `currentUser`):
+
+```typescript
+import { APP_VERSION } from './version'
+
+const backendVersion = ref<string | null>(null)
+```
+
+In `onMounted`, add a call to fetch it (it's fine for this to run independently of the `getMe()`/`initWorkspace()` flow — it's a background enrichment, not blocking):
+
+```typescript
+onMounted(async () => {
+  setUnauthenticatedHandler(() => {
+    showLoginModal.value = true
+  })
+
+  try {
+    const user = await getMe()
+    currentUser.value = user
+  } catch {
+    showLoginModal.value = true
+  }
+
+  getAuthConfig()
+    .then((config) => { backendVersion.value = config.version })
+    .catch(() => {})
+
+  await initWorkspace()
+})
+```
+
+Add the two new props to the `<Sidebar>` invocation:
+
+```vue
+      :frontend-version="APP_VERSION"
+      :backend-version="backendVersion"
+```
+
+(placed alongside the existing `:workspaces="workspaces"` prop, anywhere in the existing prop list — order doesn't matter for Vue template props.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm -- run test -- App.spec.ts`
+Expected: PASS, including the new test and all pre-existing ones.
+
+- [ ] **Step 6: Run the full frontend suite, then the full `jt.sh test` (PHP + build + frontend)**
+
+Run: `./scripts/jt.sh npm -- run test`
+Expected: all pass.
+
+Run: `./scripts/jt.sh test`
+Expected: PHP suite passes, `vue-tsc -b && vite build` succeeds (confirms `frontendVersion`/`backendVersion` prop types line up across every file that mounts `Sidebar`), vitest suite passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/App.vue frontend/src/App.spec.ts
+git commit -m "feat: fetch and display backend version in App.vue"
+```
+
+---
+
+### Task 5: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the complete test suite (PHP + frontend build + vitest)**
+
+Run: `./scripts/jt.sh test`
+Expected: exit 0, all PHP tests pass, `vue-tsc -b && vite build` succeeds with no type errors, all vitest tests pass.
+
+- [ ] **Step 2: Run a real release build and manually confirm the version end-to-end**
+
+Run: `./scripts/jt.sh release`
+Expected: succeeds, echoes a real (non-`dev`/`unknown`) version string. Optionally spin up `./scripts/jt.sh up` and check the Sidebar footer in a browser shows the same version, with no mismatch warning (frontend and backend built together, so they should match).
+
+- [ ] **Step 3: If green, proceed to `superpowers:finishing-a-development-branch`**
+
+Push the branch, open a PR, and follow the established auto-merge-on-green-CI pattern from prior features in this project.

--- a/docs/superpowers/specs/2026-08-01-app-version-display-design.md
+++ b/docs/superpowers/specs/2026-08-01-app-version-display-design.md
@@ -1,0 +1,42 @@
+# App Version Display Design
+
+## Problem
+
+There is no way to tell, from the running app itself, which build is currently live. After a deploy, verifying it landed requires SSHing into the host and diffing files or asset hashes by hand (as happened this session, investigating a "I don't see my changes" report — the deploy had in fact landed correctly, but there was no quick way to confirm that from the UI). A visible version indicator, refreshed automatically on every release build, removes that friction.
+
+## Goals
+
+- The frontend and backend each expose a build-identifying version string.
+- The version is generated automatically as part of `./scripts/jt.sh release` — no manual number to remember to bump.
+- The version is visible in the UI (Sidebar footer) without navigating anywhere.
+- If frontend and backend versions ever diverge (a partial or out-of-sync deploy), that's visible, not silently hidden.
+
+## Out of Scope
+
+- Manual semantic versioning (`1.4.2`-style numbers). The user explicitly chose the auto-generated git-sha + timestamp approach over manual bumping.
+- A dedicated "About" page or admin-only visibility — the version shows in the Sidebar footer for every user.
+- Versioning of anything other than "the currently deployed release build" (no per-feature flags, no changelog).
+
+## Architecture
+
+**Version format:** `<short-git-sha> · <UTC build timestamp>`, e.g. `a073e7d · 2026-08-01 16:05`. Generated once, at release-build time, and baked identically into both the frontend bundle and the backend release directory — they come from the same build, so under normal deploys they match exactly.
+
+**Generation (`scripts/jt.sh`):** `cmd_release()` computes `GIT_SHA=$(git rev-parse --short HEAD)` and `BUILD_TIME=$(date -u +'%Y-%m-%d %H:%M')` before invoking `docker compose --profile tools run --rm --build release`, and exports them so `compose.yaml`'s `release` service can pass them through as Docker build-args (compose supports `${VAR}` interpolation in `build.args`).
+
+**Frontend (`docker/release/Dockerfile`, `frontend` stage):** the Dockerfile declares `ARG GIT_SHA` and `ARG BUILD_TIME` in the `frontend` stage, and sets `ENV VITE_APP_VERSION="${GIT_SHA} · ${BUILD_TIME}"` before `RUN npm run build`. Vite automatically exposes any `VITE_`-prefixed environment variable present at build time as `import.meta.env.VITE_APP_VERSION` — no `vite.config.ts` changes needed. A small `frontend/src/version.ts` module exports `export const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'dev'` as the one place the rest of the frontend imports from (avoids `import.meta.env` string-literal accesses scattered around, and gives local `npm run dev` a sane `'dev'` fallback since that env var is never set outside the release build).
+
+**Backend (`docker/release/Dockerfile`, `release` stage):** the same `ARG GIT_SHA`/`ARG BUILD_TIME` are declared in the `release` stage, and a plain `VERSION` file is written into the release directory: `RUN echo "${GIT_SHA} · ${BUILD_TIME}" > /release/app/VERSION`. `AuthController@config` (already the one endpoint the frontend calls once on boot) reads this file at request time — `File::exists(base_path('VERSION')) ? trim(File::get(base_path('VERSION'))) : null` — and adds it to its existing JSON response as a `version` key. No new endpoint, since `config()` already fires on every app boot and its response already carries app-wide settings the frontend needs before rendering.
+
+**Frontend consumption:** `App.vue`'s existing boot-time fetch of `/api/auth/config` (used today for the SSO login URL / auth provider) also captures `data.version` into a `backendVersion` ref, and passes both `frontendVersion` (from `version.ts`, always available immediately, no fetch needed) and `backendVersion` (arrives async) down to `Sidebar.vue` as props.
+
+**Display logic:** Sidebar footer shows just the frontend version (`v a073e7d · 2026-08-01 16:05`) in the common case. If `backendVersion` is present AND differs from `frontendVersion`, the footer additionally shows `(backend: <backendVersion>)` right after — surfacing a mismatch as a visible warning-style diagnostic rather than silently picking one. If `backendVersion` hasn't arrived yet (still loading) or is `null` (non-release environment), nothing extra is shown.
+
+## Error Handling
+
+- Local dev (`npm run dev`, `jt.sh up`, not a release build): `VITE_APP_VERSION` is unset → frontend shows `dev`. The `VERSION` file doesn't exist in a non-release container → backend's `version` is `null` → footer shows only `v dev`, no backend comparison.
+- `/api/auth/config` request fails entirely (network error): `backendVersion` stays `null` (existing catch-based error handling in `App.vue` already covers this call) — footer just shows the frontend version, same as the "not yet arrived" case. No new error state needed.
+
+## Testing
+
+- Backend: a feature test on `GET /api/auth/config` asserting `version` is present and matches the `VERSION` file's contents when the file exists, and is `null` when it doesn't (using a temp file / `Storage::fake`-style setup, or simply asserting against `base_path('VERSION')`'s real absence in the test environment, whichever is simpler to write against the actual controller code once it exists).
+- Frontend: a `version.ts` module is trivial (a one-line constant), no dedicated unit test needed beyond what `Sidebar.spec.ts` covers. `Sidebar.spec.ts` gets new cases: renders the frontend version in the footer; shows the backend version alongside when it differs from the frontend version; does not show a backend version segment when they match or when backend version is absent.

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -1,7 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App.vue'
-import { createNote, getWorkspaces } from './services/api'
+import { createNote, getWorkspaces, getAuthConfig } from './services/api'
 
 vi.mock('./services/api', () => ({
   getWorkspaces: vi.fn().mockResolvedValue([
@@ -34,7 +34,8 @@ vi.mock('./services/api', () => ({
   login: vi.fn(),
   logout: vi.fn(),
   getCsrfCookie: vi.fn().mockResolvedValue(undefined),
-  setUnauthenticatedHandler: vi.fn()
+  setUnauthenticatedHandler: vi.fn(),
+  getAuthConfig: vi.fn().mockResolvedValue({ provider: 'local', sso_login_url: null, version: null })
 }))
 
 beforeEach(() => {
@@ -125,5 +126,19 @@ describe('App workspace switching and persistence', () => {
 
     expect(localStorage.getItem('jotter-active-workspace-id')).toBe('2')
     expect(wrapper.findComponent({ name: 'Sidebar' }).props('workspaceId')).toBe(2)
+  })
+
+  it('passes the frontend version and fetched backend version down to Sidebar', async () => {
+    vi.mocked(getAuthConfig).mockResolvedValueOnce({
+      provider: 'local',
+      sso_login_url: null,
+      version: 'abc1234 · 2026-08-01 16:30',
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'Sidebar' }).props('backendVersion')).toBe('abc1234 · 2026-08-01 16:30')
+    expect(wrapper.findComponent({ name: 'Sidebar' }).props('frontendVersion')).toBe('dev')
   })
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -26,6 +26,8 @@
       :is-mobile-sidebar-open="isMobileSidebarOpen"
       :workspace-id="activeWorkspaceId"
       :workspaces="workspaces"
+      :frontend-version="APP_VERSION"
+      :backend-version="backendVersion"
       :folder-positions="folderPositions"
       :reveal-folder-request="revealFolderRequest"
       @notes-reordered="refreshNotesList"
@@ -243,9 +245,11 @@ import {
   getCollection,
   getNotifications,
   markNotificationRead,
-  deleteNotification
+  deleteNotification,
+  getAuthConfig
 } from './services/api'
 import type { Workspace, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition } from './services/types'
+import { APP_VERSION } from './version'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -255,6 +259,7 @@ const activeNoteId = ref<number | null>(null)
 const activeNoteDetail = ref<NoteDetail | null>(null)
 
 const currentUser = ref<AuthUser | null>(null)
+const backendVersion = ref<string | null>(null)
 const showLoginModal = ref(false)
 const isMobileSidebarOpen = ref(false)
 const isGraphViewActive = ref(false)
@@ -323,6 +328,10 @@ onMounted(async () => {
   } catch {
     showLoginModal.value = true
   }
+
+  getAuthConfig()
+    .then((config) => { backendVersion.value = config.version })
+    .catch(() => {})
 
   await initWorkspace()
 })

--- a/frontend/src/LoginModal.spec.ts
+++ b/frontend/src/LoginModal.spec.ts
@@ -14,7 +14,7 @@ describe('LoginModal', () => {
   })
 
   it('does not show the SSO link when the provider is local', async () => {
-    vi.mocked(getAuthConfig).mockResolvedValue({ provider: 'local', sso_login_url: null })
+    vi.mocked(getAuthConfig).mockResolvedValue({ provider: 'local', sso_login_url: null, version: null })
 
     const wrapper = mount(LoginModal, { props: { show: true } })
     await flushPromises()
@@ -27,6 +27,7 @@ describe('LoginModal', () => {
     vi.mocked(getAuthConfig).mockResolvedValue({
       provider: 'grandpasson',
       sso_login_url: 'https://hub.taskconnect.com.br/sso/login/email?client_id=jotter&redirect_uri=x&state=y',
+      version: null,
     })
 
     const wrapper = mount(LoginModal, { props: { show: true } })

--- a/frontend/src/Sidebar.spec.ts
+++ b/frontend/src/Sidebar.spec.ts
@@ -22,7 +22,7 @@ function makeNote(overrides: Partial<NoteMeta>): NoteMeta {
 
 describe('Sidebar manual sort mode', () => {
   it('offers a Manual option in the sort dropdown', () => {
-    const wrapper = mount(Sidebar, { props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [] } })
+    const wrapper = mount(Sidebar, { props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'dev' } })
     const options = wrapper.findAll('#sidebar-sort-select option').map(o => o.attributes('value'))
     expect(options).toContain('manual')
   })
@@ -36,7 +36,7 @@ describe('Sidebar manual sort mode', () => {
     const folderPositions: FolderPosition[] = [{ folder_path: 'docs/archived', sort_position: 10 }]
 
     const wrapper = mount(Sidebar, {
-      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions, workspaces: [] },
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions, workspaces: [], frontendVersion: 'dev' },
     })
     await wrapper.find('#sidebar-sort-select').setValue('manual')
 
@@ -51,7 +51,7 @@ describe('Sidebar folder quick-create', () => {
       makeNote({ id: 1, path: 'docs/a.md', title: 'A' }),
     ]
     const wrapper = mount(Sidebar, {
-      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [] },
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'dev' },
     })
     await wrapper.find('[data-testid="folder-create-note-btn"]').trigger('click')
     expect(wrapper.emitted('create-note-in-folder')).toEqual([['docs']])
@@ -64,7 +64,7 @@ describe('Sidebar reveal folder', () => {
       makeNote({ id: 1, path: 'docs/archived/inner.md' }),
     ]
     const wrapper = mount(Sidebar, {
-      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [] },
+      props: { notes, selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'dev' },
     })
 
     // Both start expanded by default (NoteTreeNode's `expanded` ref defaults
@@ -96,6 +96,7 @@ describe('Sidebar workspace switcher', () => {
         workspaceId: 1,
         folderPositions: [],
         workspaces,
+        frontendVersion: 'dev',
       },
     })
     expect(wrapper.findAll('[data-testid="workspace-switcher-select"] option')).toHaveLength(2)
@@ -113,9 +114,48 @@ describe('Sidebar workspace switcher', () => {
         workspaceId: 1,
         folderPositions: [],
         workspaces,
+        frontendVersion: 'dev',
       },
     })
     await wrapper.find('[data-testid="workspace-switcher-select"]').setValue('2')
     expect(wrapper.emitted('switch-workspace')![0]).toEqual([2])
+  })
+})
+
+describe('Sidebar version footer', () => {
+  it('renders the frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'abc1234 · 2026-08-01 16:30' },
+    })
+    expect(wrapper.find('[data-testid="app-version"]').text()).toContain('abc1234 · 2026-08-01 16:30')
+  })
+
+  it('shows the backend version alongside when it differs from the frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: {
+        notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [],
+        frontendVersion: 'abc1234 · 2026-08-01 16:30',
+        backendVersion: 'def5678 · 2026-08-01 16:31',
+      },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').text()).toContain('def5678 · 2026-08-01 16:31')
+  })
+
+  it('does not show a mismatch segment when backend version matches frontend version', () => {
+    const wrapper = mount(Sidebar, {
+      props: {
+        notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [],
+        frontendVersion: 'abc1234 · 2026-08-01 16:30',
+        backendVersion: 'abc1234 · 2026-08-01 16:30',
+      },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').exists()).toBe(false)
+  })
+
+  it('does not show a mismatch segment when backend version is absent', () => {
+    const wrapper = mount(Sidebar, {
+      props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'abc1234 · 2026-08-01 16:30' },
+    })
+    expect(wrapper.find('[data-testid="app-version-mismatch"]').exists()).toBe(false)
   })
 })

--- a/frontend/src/SidebarNotifications.spec.ts
+++ b/frontend/src/SidebarNotifications.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import Sidebar from './components/Sidebar.vue'
 
-const baseProps = { notes: [], selectedNoteId: null, currentUser: null, workspaces: [] }
+const baseProps = { notes: [], selectedNoteId: null, currentUser: null, workspaces: [], frontendVersion: 'dev' }
 
 const notifications = [
   { id: 1, workspace_id: 1, user_id: 1, type: 'mention', title: 'You were mentioned', data: { comment_snippet: 'hey check this' }, read_at: null, created_at: '2026-07-01T00:00:00Z' },

--- a/frontend/src/a11y.spec.ts
+++ b/frontend/src/a11y.spec.ts
@@ -37,6 +37,7 @@ describe('Accessibility Audit (axe-core)', () => {
         selectedNoteId: null,
         currentUser: null,
         workspaces: [],
+        frontendVersion: 'dev',
       },
     })
     const results = await axe.run(wrapper.element, {
@@ -57,6 +58,7 @@ describe('Accessibility Audit (axe-core)', () => {
         selectedNoteId: null,
         currentUser: null,
         workspaces: [],
+        frontendVersion: 'dev',
         notifications: [
           { id: 1, workspace_id: 1, user_id: 1, type: 'mention', title: 'You were mentioned', data: { comment_snippet: 'hey @you check this' }, read_at: null, created_at: '2026-07-01T00:00:00Z' },
         ],

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -374,6 +374,17 @@
         </button>
       </div>
     </div>
+
+    <div class="sidebar-version" data-testid="app-version">
+      v {{ props.frontendVersion }}
+      <span
+        v-if="props.backendVersion && props.backendVersion !== props.frontendVersion"
+        class="sidebar-version-mismatch"
+        data-testid="app-version-mismatch"
+      >
+        (backend: {{ props.backendVersion }})
+      </span>
+    </div>
   </aside>
 </template>
 
@@ -397,6 +408,8 @@ const props = defineProps<{
   workspaces: Workspace[]
   folderPositions?: FolderPosition[]
   revealFolderRequest?: { path: string; nonce: number } | null
+  frontendVersion: string
+  backendVersion?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -1260,6 +1273,17 @@ function handleImportSubmit() {
   display: flex;
   align-items: center;
   gap: var(--space-1);
+}
+
+.sidebar-version {
+  padding: var(--space-1) var(--space-4) var(--space-2);
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.sidebar-version-mismatch {
+  color: var(--color-status-warning);
 }
 
 .user-badge {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -56,6 +56,7 @@ export async function getMe(): Promise<AuthUser | null> {
 export interface AuthConfig {
   provider: 'local' | 'grandpasson'
   sso_login_url: string | null
+  version: string | null
 }
 
 export async function getAuthConfig(): Promise<AuthConfig> {

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION: string = import.meta.env.VITE_APP_VERSION || 'dev'

--- a/scripts/jt.sh
+++ b/scripts/jt.sh
@@ -101,11 +101,13 @@ cmd_e2e() {
 cmd_release() {
   ensure_env
   mkdir -p dist
+  export GIT_SHA="$(git rev-parse --short HEAD)"
+  export BUILD_TIME="$(date -u +'%Y-%m-%d %H:%M')"
   compose --profile tools run --rm --build release
   test -s dist/jotter-release.zip
   test -s dist/jotter-release.zip.sha256
   (cd dist && sha256sum -c jotter-release.zip.sha256)
-  echo "Release written to dist/jotter-release.zip"
+  echo "Release written to dist/jotter-release.zip (version: ${GIT_SHA} · ${BUILD_TIME})"
 }
 
 main() {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -289,6 +289,32 @@ class AuthTest extends TestCase
             ->assertJson(['data' => ['provider' => 'grandpasson', 'sso_login_url' => null]]);
     }
 
+    public function test_auth_config_endpoint_reports_version_from_version_file(): void
+    {
+        $versionFile = base_path('VERSION');
+        file_put_contents($versionFile, "abc1234 · 2026-08-01 16:30\n");
+
+        try {
+            $this->getJson('/api/auth/config')
+                ->assertOk()
+                ->assertJsonPath('data.version', 'abc1234 · 2026-08-01 16:30');
+        } finally {
+            unlink($versionFile);
+        }
+    }
+
+    public function test_auth_config_endpoint_reports_null_version_when_version_file_absent(): void
+    {
+        $versionFile = base_path('VERSION');
+        if (file_exists($versionFile)) {
+            unlink($versionFile);
+        }
+
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJsonPath('data.version', null);
+    }
+
     public function test_logout_endpoint_invalidates_session_and_writes_audit_log(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- `./scripts/jt.sh release` now computes `<short-git-sha> · <UTC build timestamp>` and bakes it into both the frontend bundle (`VITE_APP_VERSION`) and the backend release dir (`VERSION` file) via Docker build-args — no manual bump step
- `GET /api/auth/config` exposes the backend version; `App.vue` fetches it on boot (a new always-fires call, since only `LoginModal.vue` called this endpoint before)
- Sidebar footer shows the version; if frontend/backend versions ever diverge, the mismatch is shown as a visible warning instead of silently picked
- Local dev (`jt.sh up`, `npm run dev`) falls back to `dev` / `null` — not an error state

## Test plan
- [x] `./scripts/jt.sh test` — PHP suite (155 passed) + frontend build/type-check + vitest (198 passed)
- [x] Real `./scripts/jt.sh release` run — confirmed the built `VERSION` file and the built JS bundle both contain the exact same version string end-to-end