### PR TITLE
docs: add Obsidian UI-parity audit, file gap issues (#286-#290)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,20 @@ C1, C2, C3, C5, and C6 were resolved — see `docs/decisions.md`. This section p
 - **Roadmap baseline provenance.** `TODO(spec): confirm whether the roadmap's gap analysis was drawn from a different product of the same name. Until confirmed, spec §14.3 governs what counts as delivered.`
 - **Markdown textarea + Edit/Split/Preview toggle vs. real Notion-feel (#263, XL, P3).** `docs/20260803-jotter-editor-chrome-notion-parity-audit.md` §B.1, Part D.6, Open Question 1: `NoteEditor.vue`'s core editing surface is a single `<textarea>` in `--font-mono` paired with a rendered preview and an Edit/Split/Preview toggle — a control whose mere existence announces "this is a Markdown tool." No amount of chrome/spacing work (the rest of this audit's #250–#262) closes that gap while this textarea remains the primary editing surface. This collides directly with the Markdown-on-disk invariant (spec §1/`AGENTS.md`), so it's a product decision, not a UI task — do not drift into it via smaller PRs. Options, ascending cost: (a) keep the textarea, drop the toggle, default to a single rendered-ish view; (b) inline WYSIWYG over Markdown (TipTap/Milkdown/ProseMirror with a Markdown serializer, preserving the on-disk invariant) — the only option reaching real Notion parity while keeping the Markdown-on-disk rule intact, a multi-PR epic; (c) a real block model (furthest from current architecture, highest cost). The open question to resolve first: is Notion-*feel* the actual goal, or is Notion-*calm* enough via #250–#262 while keeping an honest Markdown editor? All other issues from the audit are independent of this answer and can proceed regardless.
 
+## Obsidian UI-parity gaps
+
+`docs/20260803-jotter-obsidian-ui-parity-audit.md` — findings from a UI
+comparison against Obsidian, verified against `frontend/src/` post-#285.
+Command palette, tag cloud/filter, collapsible sidebar, and the
+right-hand drawer were already shipped and dropped from this list during
+verification.
+
+- **No headings outline/TOC pane for the current note (#286, S, P2).**
+- **No hover preview for wikilinks (#287, M, P2).**
+- **No transclusion / `![[note]]` embeds (#288, M–L, P2).**
+- **No contextual/local graph per note (#289, M, P3).**
+- **No multi-pane / tabbed editing (#290, L, P3).**
+
 ## Not adopted
 
 - **Visual canvas / whiteboard** — spec §3 N3; the roadmap itself lists whiteboard parity as a non-goal for the next cycle.

--- a/docs/20260803-jotter-obsidian-ui-parity-audit.md
+++ b/docs/20260803-jotter-obsidian-ui-parity-audit.md
@@ -1,0 +1,82 @@
+# Obsidian UI-Parity Audit
+
+Date: 2026-08-03
+Status: **Diagnosis only.** Nothing here is approved, planned, or
+implemented.
+Trigger: product question — "what does Obsidian offer in UI that Jotter
+doesn't?" — answered against `frontend/src/` at the tip of `main`
+(post-#250–#285 Notion-parity fixes).
+
+Method: grep/read of `frontend/src/` cross-referenced against Obsidian's
+UI vocabulary (Live Preview, quick switcher/command palette, hover
+preview, outline pane, local graph, panes/tabs, transclusion, tag pane).
+Items already shipped were dropped from this list during verification:
+command palette (`CommandPalette.vue`, mounted in `App.vue:215`),
+tag cloud + filter pills (`Sidebar.vue:289-305`, `SearchResults.vue:37-47`),
+collapsible sidebar (#259), right-hand drawer (#262). Canvas/whiteboard
+is an explicit non-goal (`BACKLOG.md` "Not adopted", spec §3 N3).
+
+## Findings
+
+### G.1 No headings outline/TOC pane for the current note
+
+`NoteEditor.vue` and `MarkdownPreview.vue` have no heading-navigation
+surface. Obsidian's Outline pane lists the current note's heading
+hierarchy and jumps the cursor/scroll on click. Jotter has no equivalent
+— navigating a long note means scrolling.
+
+Effort: S. Priority: P2.
+
+### G.2 No hover preview for wikilinks
+
+`MarkdownPreview.vue:41-46` handles `wikilink` clicks (navigate) and
+`:89` only tints on hover (`:deep(.wikilink:hover)`). There is no popup
+showing the target note's content on hover, the single most-used
+Obsidian affordance for following a train of thought without leaving the
+page.
+
+Effort: M (popup component, position calc, fetch-on-hover, debounce).
+Priority: P2.
+
+### G.3 No contextual/local graph per note
+
+`GraphView.vue` is mounted once, globally, toggled via `App.vue:69-74`
+(`isGraphViewActive`) and shows the whole vault's graph. Obsidian also
+offers a *local graph* scoped to the current note's immediate neighbors,
+embeddable in the sidebar. Jotter has no per-note graph — only the
+all-or-nothing global view.
+
+Effort: M. Priority: P3.
+
+### G.4 No multi-pane / tabbed editing
+
+`App.vue:147` mounts exactly one `NoteEditor` instance; there is no tab
+bar and no split-pane layout. Obsidian lets a user open several notes
+side by side or in tabs and keeps that layout across sessions. Jotter
+can show exactly one note at a time.
+
+Effort: L (structural — multi-instance editor state, tab/pane layout,
+persistence). Priority: P3.
+
+### G.5 No transclusion (`![[note]]` embeds)
+
+No occurrence of embed/transclusion handling anywhere in
+`frontend/src/` (grep for "transclu"/"embed" is empty). Obsidian renders
+`![[Note Title]]` as the referenced note's content inline, and
+`![[Note#^block]]` as a single embedded block. Jotter's wikilinks
+(`[[...]]`) are link-only; there is no embed syntax or renderer.
+
+Effort: M–L (parser support in the wikilink pipeline, embed renderer,
+circular-embed guard). Does not collide with the Markdown-on-disk
+invariant — the source stays plain `![[...]]` text; only rendering
+pulls in the referenced content. Priority: P2.
+
+## Severity
+
+| # | Gap | Effort | Priority |
+|---|---|---|---|
+| G.1 | No outline/TOC pane | S | P2 |
+| G.2 | No hover preview for wikilinks | M | P2 |
+| G.5 | No transclusion (`![[note]]` embeds) | M–L | P2 |
+| G.3 | No contextual/local graph per note | M | P3 |
+| G.4 | No multi-pane / tabbed editing | L | P3 |


### PR DESCRIPTION
## Summary
- Compares Jotter's frontend against Obsidian's UI vocabulary, verified against `frontend/src/` post-Notion-parity work (#250-#285)
- Drops already-shipped items found during verification (command palette, tag cloud, collapsible sidebar, right drawer)
- Files remaining 5 gaps as issues #286-#290 and adds a BACKLOG.md section indexing them

## Test plan
- [ ] Docs-only change — no code touched