### PR TITLE
feat: add tab strip (G.4 scope A, closes #290)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-tab-strip.md
+++ b/docs/superpowers/plans/2026-08-04-tab-strip.md
@@ -1,0 +1,704 @@
+# Tab Strip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Multiple notes stay open as tabs (browser-tab semantics — one `NoteEditor` mounted at a time, switching tabs swaps it), persisted per workspace, closing gap G.4 scope A ("tab strip, one note visible at a time") of the Obsidian UI-parity audit (issue #290).
+
+**Architecture:** A new `useOpenTabs` composable owns the ordered list of open note ids and pure open/close logic; `App.vue`'s existing `activeNoteId` ref stays the single source of truth for which tab is active. `handleSelectNote` gains one line (`openTab(noteId)`) so every existing note-selection call site across the app opens/activates a tab for free. A new pure `TabStrip.vue` renders the strip above `<main>`, visible only in note-viewing mode.
+
+**Tech Stack:** Vue 3 `<script setup lang="ts">` composables + components, `localStorage` persistence (same pattern as `composables/useCollapsiblePanel.ts`), Vitest + `@vue/test-utils`.
+
+## Global Constraints
+
+- Working directory: `/home/ubuntu/projects/web/iroh/jotter`, branch `feature/multi-pane-editing` (spec commit `b0dddba` already on this branch).
+- Frontend root: `frontend/`; source: `frontend/src/`; component/composable tests are flat files at `frontend/src/<Name>.spec.ts` and `frontend/src/composables/<name>.spec.ts` respectively (matches `useCollapsiblePanel.spec.ts`'s location).
+- Test runner: `./scripts/jt.sh npm run test -- <file>.spec.ts` for one frontend file, `./scripts/jt.sh test` for the full combined suite.
+- Commit style: lowercase `type: summary` (`feat:`), one commit per task, test + implementation together.
+- **Scope A only** (this plan) — every `NoteEditor` mount is single-instance, browser-tab semantics. True simultaneously-mounted split-screen (scope B) is explicitly out of scope, tracked as separate future work.
+- **Tab-close-next-active behavior, precisely** (a clarification made while gathering context for this plan — the spec's prose said "left neighbor, else right"; the actual algorithm below, matching standard browser-tab convention, is the reverse): closing a tab activates the tab that slides into its position — normally its **right** neighbor — except when closing the tab that was **last** in the list, which activates its **left** neighbor (the new last tab). Closing a non-active tab leaves the active tab unchanged. Closing the last remaining tab returns `null`.
+- `notes.value` (`NoteMeta[]`, id-keyed) is already kept in sync on every note load (`App.vue:536-545`) — tab labels are derived from it directly, no separate title cache needed.
+
+---
+
+### Task 1: `useOpenTabs` composable
+
+**Files:**
+- Create: `frontend/src/composables/useOpenTabs.ts`
+- Test: `frontend/src/composables/useOpenTabs.spec.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  function useOpenTabs(): {
+    openNoteIds: Ref<number[]>
+    loadTabs(workspaceId: number): number | null
+    saveTabs(workspaceId: number, activeNoteId: number | null): void
+    openTab(noteId: number): void
+    closeTab(noteId: number, activeNoteId: number | null): number | null
+  }
+  ```
+  Consumed by Task 3 (`App.vue`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/composables/useOpenTabs.spec.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useOpenTabs } from './useOpenTabs'
+
+describe('useOpenTabs', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('openTab appends a new note id', () => {
+    const { openNoteIds, openTab } = useOpenTabs()
+    openTab(1)
+    openTab(2)
+    expect(openNoteIds.value).toEqual([1, 2])
+  })
+
+  it('openTab does not duplicate an already-open note id', () => {
+    const { openNoteIds, openTab } = useOpenTabs()
+    openTab(1)
+    openTab(2)
+    openTab(1)
+    expect(openNoteIds.value).toEqual([1, 2])
+  })
+
+  it('closeTab on a non-active tab leaves the active id unchanged', () => {
+    const { openNoteIds, openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    const next = closeTab(2, 1)
+    expect(next).toBe(1)
+    expect(openNoteIds.value).toEqual([1, 3])
+  })
+
+  it('closeTab on the active middle tab activates its right neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(2, 2)).toBe(3)
+  })
+
+  it('closeTab on the active first tab activates its right neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(1, 1)).toBe(2)
+  })
+
+  it('closeTab on the active last tab activates its left neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(3, 3)).toBe(2)
+  })
+
+  it('closeTab on the last remaining tab returns null', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    openTab(1)
+    expect(closeTab(1, 1)).toBeNull()
+  })
+
+  it('saveTabs then loadTabs round-trips through localStorage', () => {
+    const writer = useOpenTabs()
+    ;[1, 2].forEach(writer.openTab)
+    writer.saveTabs(5, 2)
+
+    const reader = useOpenTabs()
+    const restoredActiveId = reader.loadTabs(5)
+    expect(reader.openNoteIds.value).toEqual([1, 2])
+    expect(restoredActiveId).toBe(2)
+  })
+
+  it('loadTabs returns an empty list and null when nothing is stored', () => {
+    const { openNoteIds, loadTabs } = useOpenTabs()
+    expect(loadTabs(999)).toBeNull()
+    expect(openNoteIds.value).toEqual([])
+  })
+
+  it('loadTabs degrades gracefully on corrupt stored JSON', () => {
+    localStorage.setItem('jotter-open-tabs:7', 'not valid json{{{')
+    const { openNoteIds, loadTabs } = useOpenTabs()
+    expect(loadTabs(7)).toBeNull()
+    expect(openNoteIds.value).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm run test -- useOpenTabs.spec.ts`
+Expected: FAIL with "Failed to resolve import './useOpenTabs'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/composables/useOpenTabs.ts
+import { ref, type Ref } from 'vue'
+
+interface StoredTabs {
+  openNoteIds: number[]
+  activeNoteId: number | null
+}
+
+const STORAGE_PREFIX = 'jotter-open-tabs:'
+
+export function useOpenTabs(): {
+  openNoteIds: Ref<number[]>
+  loadTabs: (workspaceId: number) => number | null
+  saveTabs: (workspaceId: number, activeNoteId: number | null) => void
+  openTab: (noteId: number) => void
+  closeTab: (noteId: number, activeNoteId: number | null) => number | null
+} {
+  const openNoteIds = ref<number[]>([])
+
+  function loadTabs(workspaceId: number): number | null {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${workspaceId}`)
+    if (!raw) {
+      openNoteIds.value = []
+      return null
+    }
+    try {
+      const parsed = JSON.parse(raw) as StoredTabs
+      openNoteIds.value = Array.isArray(parsed.openNoteIds) ? parsed.openNoteIds : []
+      return typeof parsed.activeNoteId === 'number' ? parsed.activeNoteId : null
+    } catch {
+      openNoteIds.value = []
+      return null
+    }
+  }
+
+  function saveTabs(workspaceId: number, activeNoteId: number | null) {
+    localStorage.setItem(
+      `${STORAGE_PREFIX}${workspaceId}`,
+      JSON.stringify({ openNoteIds: openNoteIds.value, activeNoteId })
+    )
+  }
+
+  function openTab(noteId: number) {
+    if (!openNoteIds.value.includes(noteId)) {
+      openNoteIds.value.push(noteId)
+    }
+  }
+
+  function closeTab(noteId: number, activeNoteId: number | null): number | null {
+    const index = openNoteIds.value.indexOf(noteId)
+    if (index === -1) return activeNoteId
+
+    openNoteIds.value.splice(index, 1)
+
+    if (activeNoteId !== noteId) return activeNoteId
+    if (openNoteIds.value.length === 0) return null
+
+    const nextIndex = Math.min(index, openNoteIds.value.length - 1)
+    return openNoteIds.value[nextIndex]
+  }
+
+  return { openNoteIds, loadTabs, saveTabs, openTab, closeTab }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm run test -- useOpenTabs.spec.ts`
+Expected: PASS, all 10 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useOpenTabs.ts frontend/src/composables/useOpenTabs.spec.ts
+git commit -m "feat: add useOpenTabs composable"
+```
+
+---
+
+### Task 2: `TabStrip.vue` component
+
+**Files:**
+- Create: `frontend/src/components/TabStrip.vue`
+- Test: `frontend/src/TabStrip.spec.ts`
+
+**Interfaces:**
+- Produces: `TabStrip` component — props `tabs: { id: number; title: string }[]`, `activeId: number | null`; emits `select-tab(noteId: number)`, `close-tab(noteId: number)`. Consumed by Task 3 (`App.vue`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/TabStrip.spec.ts
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import TabStrip from './components/TabStrip.vue'
+
+const tabs = [
+  { id: 1, title: 'First Note' },
+  { id: 2, title: 'Second Note' },
+]
+
+describe('TabStrip', () => {
+  it('renders nothing when there are no tabs', () => {
+    const wrapper = mount(TabStrip, { props: { tabs: [], activeId: null } })
+    expect(wrapper.find('.tab-strip').exists()).toBe(false)
+  })
+
+  it('renders one item per tab with the active one styled', () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 2 } })
+    const items = wrapper.findAll('[data-testid="tab-strip-item"]')
+    expect(items).toHaveLength(2)
+    expect(items[0].classes()).not.toContain('active')
+    expect(items[1].classes()).toContain('active')
+  })
+
+  it('emits select-tab when a tab is clicked', async () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 1 } })
+    await wrapper.findAll('[data-testid="tab-strip-item"]')[1].trigger('click')
+    expect(wrapper.emitted('select-tab')![0]).toEqual([2])
+  })
+
+  it('emits close-tab without also emitting select-tab when the close button is clicked', async () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 1 } })
+    await wrapper.findAll('[data-testid="tab-strip-close-btn"]')[0].trigger('click')
+    expect(wrapper.emitted('close-tab')![0]).toEqual([1])
+    expect(wrapper.emitted('select-tab')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm run test -- TabStrip.spec.ts`
+Expected: FAIL with "Failed to resolve import './components/TabStrip.vue'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```vue
+<!-- frontend/src/components/TabStrip.vue -->
+<template>
+  <div v-if="tabs.length > 0" class="tab-strip" role="tablist">
+    <div
+      v-for="tab in tabs"
+      :key="tab.id"
+      class="tab-strip-item"
+      :class="{ active: tab.id === activeId }"
+      role="tab"
+      :aria-selected="tab.id === activeId"
+      data-testid="tab-strip-item"
+      @click="$emit('select-tab', tab.id)"
+    >
+      <span class="tab-strip-title">{{ tab.title }}</span>
+      <button
+        type="button"
+        class="tab-strip-close-btn"
+        data-testid="tab-strip-close-btn"
+        :aria-label="`Close ${tab.title}`"
+        @click.stop="$emit('close-tab', tab.id)"
+      >&times;</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  tabs: { id: number; title: string }[]
+  activeId: number | null
+}>()
+
+defineEmits<{
+  (e: 'select-tab', noteId: number): void
+  (e: 'close-tab', noteId: number): void
+}>()
+</script>
+
+<style scoped>
+.tab-strip {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 var(--space-2);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  overflow-x: auto;
+}
+
+.tab-strip-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.tab-strip-item:hover {
+  background: var(--color-hover);
+}
+
+.tab-strip-item.active {
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.tab-strip-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tab-strip-close-btn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.tab-strip-close-btn:hover {
+  background: var(--color-surface-emphasis);
+}
+</style>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm run test -- TabStrip.spec.ts`
+Expected: PASS, all 4 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/TabStrip.vue frontend/src/TabStrip.spec.ts
+git commit -m "feat: add TabStrip component"
+```
+
+---
+
+### Task 3: Wire the tab strip into `App.vue`
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+- Modify: `frontend/src/App.spec.ts`
+
+**Interfaces:**
+- Consumes: `useOpenTabs` from Task 1 (`./composables/useOpenTabs`), `TabStrip` from Task 2 (`./components/TabStrip.vue`).
+- Produces: nothing consumed by later tasks — this is the last implementation task.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/App.spec.ts` (after the existing `describe('App tenant switching and persistence', ...)` block):
+
+```ts
+describe('App tab strip', () => {
+  it('opening the same note twice does not duplicate its tab', async () => {
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 10)
+    await flushPromises()
+
+    expect(wrapper.findAllComponents({ name: 'TabStrip' })[0].props('tabs')).toEqual([
+      { id: 10, title: 'Welcome Note' },
+    ])
+  })
+
+  it('opening a second note keeps the first tab present', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 11)
+    await flushPromises()
+
+    const tabs = wrapper.findComponent({ name: 'TabStrip' }).props('tabs')
+    expect(tabs.map((t: { id: number }) => t.id)).toEqual([10, 11])
+  })
+
+  it('closing the active tab switches to and loads a neighbor', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    vi.mocked(getNote).mockResolvedValueOnce({
+      id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Welcome', backlinks: [],
+    }).mockResolvedValueOnce({
+      id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Second', backlinks: [],
+    })
+    const wrapper = mount(App)
+    await flushPromises()
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 11)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'TabStrip' }).vm.$emit('close-tab', 11)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TabStrip' }).props('activeId')).toBe(10)
+    expect(wrapper.findComponent({ name: 'NoteEditor' }).props('note').id).toBe(10)
+  })
+
+  it('closing the last tab clears to the empty state', async () => {
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'TabStrip' }).vm.$emit('close-tab', 10)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'NoteEditor' }).exists()).toBe(false)
+    expect(wrapper.text()).toContain('No Note Selected')
+  })
+
+  it('deleting a note removes its tab', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ]).mockResolvedValueOnce([])
+    vi.mocked(deleteNote).mockResolvedValueOnce(undefined)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('delete-note', 10)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TabStrip' }).exists()).toBe(false)
+  })
+
+  it('restores the open tabs and active note from localStorage on remount', async () => {
+    vi.mocked(getNotes).mockResolvedValue([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    localStorage.setItem('jotter-open-tabs:1', JSON.stringify({ openNoteIds: [10, 11], activeNoteId: 11 }))
+    vi.mocked(getNote).mockResolvedValueOnce({
+      id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Second', backlinks: [],
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    const tabs = wrapper.findComponent({ name: 'TabStrip' }).props('tabs')
+    expect(tabs.map((t: { id: number }) => t.id)).toEqual([10, 11])
+    expect(wrapper.findComponent({ name: 'TabStrip' }).props('activeId')).toBe(11)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/jt.sh npm run test -- App.spec.ts`
+Expected: FAIL — `TabStrip` is never rendered, no `tabs`/`activeId` props to find.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports, right after the existing `import { resolveWikilinkTarget } from './services/wikilinks'` (`App.vue:271`):
+
+```ts
+import TabStrip from './components/TabStrip.vue'
+import { useOpenTabs } from './composables/useOpenTabs'
+```
+
+Add `watch` to the existing Vue import:
+
+```ts
+import { ref, computed, watch, onMounted } from 'vue'
+```
+
+Add the composable and derived computeds, right after the existing `const activeNoteDetail = ref<NoteDetail | null>(null)` (`App.vue:280`):
+
+```ts
+const { openNoteIds, loadTabs, saveTabs, openTab, closeTab } = useOpenTabs()
+
+const openTabsList = computed(() =>
+  openNoteIds.value
+    .map(id => {
+      const note = notes.value.find(n => n.id === id)
+      return note ? { id, title: note.title || note.path } : null
+    })
+    .filter((tab): tab is { id: number; title: string } => tab !== null)
+)
+
+const showTabStrip = computed(() =>
+  openNoteIds.value.length > 0 &&
+  !isGraphViewActive.value &&
+  !isAttachmentsActive.value &&
+  !isAuditLogActive.value &&
+  !isLinkReportActive.value &&
+  !isTableViewActive.value &&
+  !isBoardViewActive.value &&
+  !isCalendarViewActive.value &&
+  !isSearchActive.value
+)
+
+watch([openNoteIds, activeNoteId], () => {
+  if (!activeWorkspaceId.value) return
+  saveTabs(activeWorkspaceId.value, activeNoteId.value)
+}, { deep: true })
+
+async function handleCloseTab(noteId: number) {
+  const nextActiveId = closeTab(noteId, activeNoteId.value)
+  if (nextActiveId === activeNoteId.value) return
+  if (nextActiveId === null) {
+    activeNoteId.value = null
+    activeNoteDetail.value = null
+  } else {
+    await loadActiveNote(nextActiveId)
+  }
+}
+```
+
+(`isGraphViewActive`, `isAttachmentsActive`, `isAuditLogActive`, `isLinkReportActive`,
+`isTableViewActive`, `isBoardViewActive`, `isCalendarViewActive`, `isSearchActive` all
+already exist as refs elsewhere in this file — no new declarations needed for them.)
+
+Update `handleSelectNote` to open a tab first (`App.vue:558-568`):
+
+```ts
+async function handleSelectNote(noteId: number) {
+  openTab(noteId)
+  isMobileSidebarOpen.value = false
+  isSearchActive.value = false
+  isAttachmentsActive.value = false
+  isAuditLogActive.value = false
+  isLinkReportActive.value = false
+  isTableViewActive.value = false
+  isBoardViewActive.value = false
+  isCalendarViewActive.value = false
+  await loadActiveNote(noteId)
+}
+```
+
+Update `handleDeleteNote` to purge the closed note's tab instead of manually nulling `activeNoteId` (`App.vue:831-843`):
+
+```ts
+async function handleDeleteNote(noteId: number) {
+  if (!activeWorkspaceId.value) return
+  if (!confirm('Are you sure you want to delete this note?')) return
+  try {
+    await deleteNote(activeWorkspaceId.value, noteId)
+    const nextActiveId = closeTab(noteId, activeNoteId.value)
+    if (nextActiveId !== activeNoteId.value) {
+      if (nextActiveId === null) {
+        activeNoteId.value = null
+        activeNoteDetail.value = null
+      } else {
+        await loadActiveNote(nextActiveId)
+      }
+    }
+    await refreshNotesList()
+  } catch (err) {
+    console.error('Failed to delete note:', err)
+  }
+}
+```
+
+Update `initWorkspace` to restore tabs before the first `refreshNotesList()` call (`App.vue:406`):
+
+```ts
+    activeNoteId.value = loadTabs(activeWorkspaceId.value)
+    await refreshNotesList()
+    await refreshNotifications()
+```
+
+(This replaces the plain `await refreshNotesList()` line — `refreshNotesList`'s own
+pre-existing branching on `activeNoteId.value` already handles "restored id still
+exists → load it," "restored id no longer exists → pick first," and "nothing
+restored → pick first," so no changes are needed inside `refreshNotesList` itself.)
+
+Update `handleSwitchWorkspace` the same way (`App.vue:413-418`):
+
+```ts
+async function handleSwitchWorkspace(workspaceId: number) {
+  activeWorkspaceId.value = workspaceId
+  localStorage.setItem(WORKSPACE_STORAGE_KEY, String(workspaceId))
+  activeNoteId.value = loadTabs(workspaceId)
+  await refreshNotesList()
+  await refreshNotifications()
+}
+```
+
+Add the template, right before the existing `<main class="main-content">` (`App.vue:67`):
+
+```html
+<TabStrip
+  v-if="showTabStrip"
+  :tabs="openTabsList"
+  :active-id="activeNoteId"
+  @select-tab="handleSelectNote"
+  @close-tab="handleCloseTab"
+/>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/jt.sh npm run test -- App.spec.ts`
+Expected: PASS, including all pre-existing `App.spec.ts` cases (regression check — confirms `handleSelectNote`'s new first line and the `initWorkspace`/`handleSwitchWorkspace` changes didn't break existing workspace/tenant-switching behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.vue frontend/src/App.spec.ts
+git commit -m "feat: wire the tab strip into App.vue (G.4 scope A, #290)"
+```
+
+---
+
+### Task 4: Full regression run and push
+
+**Files:** none (verification task).
+
+- [ ] **Step 1: Run the full frontend test suite**
+
+Run: `./scripts/jt.sh npm test`
+Expected: PASS across the whole frontend suite, not just the three files touched above.
+
+- [ ] **Step 2: Run the full combined suite**
+
+Run: `./scripts/jt.sh test`
+Expected: backend + frontend both run. If the pre-existing, unrelated `ReleaseZipSecurityTest` failure (stray other-worktree paths leaking into the release zip scan — seen on the G.1/#292, G.2/#293, G.5/#294, and G.3/#295 branches) reappears, that's expected and not a regression from this change; any other backend failure is not expected and must be investigated.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feature/multi-pane-editing
+```
+
+- [ ] **Step 4: Open a PR**
+
+```bash
+gh pr create --title "feat: add tab strip (G.4 scope A, closes #290)" --body "$(cat <<'EOF'
+## Summary
+- Multiple notes now stay open as tabs — selecting any note (sidebar, backlinks, wikilinks, search, local graph, ...) opens/activates a tab for it, reusing one if already open
+- Tabs persist per workspace in localStorage, restored on reload
+- Closing the active tab activates its right neighbor (left neighbor if it was the last tab); closing the last tab returns to the existing empty state
+- Deleting a note purges its tab
+- Scope A only (this PR) — one NoteEditor mounted at a time, browser-tab semantics. True simultaneously-mounted split-screen (scope B) is separate future work, blocked on first making G.1/G.5's DOM-id-based lookups pane-scoped
+
+Closes #290. Source: docs/20260803-jotter-obsidian-ui-parity-audit.md §G.4, design: docs/superpowers/specs/2026-08-04-tab-strip-design.md, plan: docs/superpowers/plans/2026-08-04-tab-strip.md
+
+## Test plan
+- [x] Unit: useOpenTabs.spec.ts (10), TabStrip.spec.ts (4), App.spec.ts tab-strip cases (6) — full frontend suite passing
+- [x] Backend: passing except the pre-existing unrelated ReleaseZipSecurityTest failure (same as G.1/#292, G.2/#293, G.5/#294, G.3/#295)
+- [ ] Manual: open several notes via the sidebar, confirm tabs appear and persist across reload, close a tab and confirm it switches to a neighbor, close the last tab and confirm the empty state returns
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** "Always open/activate a tab" via `handleSelectNote`'s single added line (Task 3), tabs-by-id not path (Task 3's `openTabsList` computed reading live `notes.value`), localStorage persistence scoped per workspace (Task 1's `loadTabs`/`saveTabs`, Task 3's `watch` + `initWorkspace`/`handleSwitchWorkspace` wiring), close-tab neighbor logic incl. the corrected right-then-left behavior (Task 1), tab-strip visibility gated to note-viewing mode (Task 3's `showTabStrip`), deleted-note tab purge (Task 3's `handleDeleteNote` update), empty-state fallback on closing the last tab (Task 3's `handleCloseTab`). Testing section of the spec is covered 1:1 across Tasks 1-3. Out-of-scope items (split-screen/scope B, drag-to-reorder, modifier-key "open in new tab," tab overflow UI) are correctly absent from every task.
+
+**Placeholder scan:** No TBD/TODO markers; every step has literal code.
+
+**Type consistency:** `useOpenTabs()`'s return shape (`openNoteIds`, `loadTabs`, `saveTabs`, `openTab`, `closeTab`) defined once in Task 1, destructured identically in Task 3. `closeTab(noteId: number, activeNoteId: number | null): number | null` signature matches both of Task 3's call sites (`handleCloseTab`, `handleDeleteNote`). `TabStrip`'s `tabs`/`activeId` props and `select-tab`/`close-tab` emits from Task 2 match Task 3's `:tabs="openTabsList"` / `:active-id="activeNoteId"` / `@select-tab="handleSelectNote"` / `@close-tab="handleCloseTab"` template usage exactly.

--- a/docs/superpowers/specs/2026-08-04-tab-strip-design.md
+++ b/docs/superpowers/specs/2026-08-04-tab-strip-design.md
@@ -1,0 +1,163 @@
+# Tab Strip (Multi-Note Open, Single Active Pane) — Design
+
+Date: 2026-08-04
+Source: `docs/20260803-jotter-obsidian-ui-parity-audit.md` §G.4, issue #290
+(reopened, was tracked-not-implemented, filed via #291).
+
+## Problem
+
+`App.vue:147` mounts exactly one `NoteEditor` instance; there is no tab
+bar and no split-pane layout. Obsidian lets a user open several notes
+side by side or in tabs and keeps that layout across sessions. Jotter
+can show exactly one note at a time.
+
+## Scope decision
+
+G.4 splits into two genuinely separate projects:
+
+- **A. Tab strip, one note visible at a time** (this spec) — multiple
+  notes stay "open" as tabs; switching a tab unmounts the old
+  `NoteEditor` and mounts the new one (browser-tab semantics). Fixes
+  the audit's actual complaint without touching `NoteEditor.vue`'s
+  internals.
+- **B. True split-screen** (explicitly out of scope, separate future
+  work) — multiple `NoteEditor` instances mounted *simultaneously*. Not
+  attempted here: `document.getElementById(heading.id)`-style lookups
+  already exist in `NoteEditor.vue` (G.1's outline-scroll, G.5's embed
+  rendering) that would collide across two simultaneously-mounted panes
+  showing notes with matching heading text; plus per-pane right-drawers,
+  resizable layout, and drag-to-split are all real additional scope B
+  would require.
+
+## Decisions
+
+- **Every `select-note` action opens/activates a tab** (reusing one if
+  the note is already open) rather than replacing the active tab's
+  content. No modifier-key UX needed anywhere — all ~8 existing
+  `@select-note="handleSelectNote"` call sites across `App.vue`
+  (Sidebar, GraphView, LocalGraphPanel, BacklinksPanel,
+  OutgoingLinksPanel, search results, three collection views) keep
+  working completely unchanged, since "ensure a tab exists" becomes
+  `handleSelectNote`'s own behavior, not something each caller opts
+  into.
+- **Tabs store note *ids*, not paths** — a deliberate improvement over
+  the audit's literal "array of open note paths" suggestion. `App.vue`
+  already keeps `notes.value` (the id-keyed list backing the sidebar
+  tree) in sync on every note load (existing comment at
+  `App.vue:536-545`), so tab labels stay correct across renames for
+  free; paths would have gone stale the moment a note was renamed.
+- **Persisted to `localStorage`**, scoped per workspace id, same pattern
+  `composables/useCollapsiblePanel.ts` already uses for its own state
+  (`jotter-panel-collapsed:<key>` → here, `jotter-open-tabs:<workspaceId>`).
+
+## Architecture
+
+- **`composables/useOpenTabs.ts`** (new) — owns `openNoteIds: Ref<number[]>`.
+  `App.vue`'s existing `activeNoteId` ref stays the single source of
+  truth for "which tab is active"; the composable does not duplicate
+  it.
+  ```ts
+  interface StoredTabs {
+    openNoteIds: number[]
+    activeNoteId: number | null
+  }
+
+  function useOpenTabs(): {
+    openNoteIds: Ref<number[]>
+    loadTabs(workspaceId: number): number | null // returns the restored active id, or null
+    saveTabs(workspaceId: number, activeNoteId: number | null): void
+    openTab(noteId: number): void // appends if not already present
+    closeTab(noteId: number, activeNoteId: number | null): number | null
+      // removes noteId; returns the id that should become active next:
+      // - if the closed tab wasn't the active one, returns activeNoteId unchanged
+      // - if it was active: left neighbor, else right neighbor, else null (no tabs left)
+  }
+  ```
+  `loadTabs`/`saveTabs` degrade gracefully on missing or corrupt stored
+  JSON (empty list, `null` active) rather than throwing.
+
+- **`components/TabStrip.vue`** (new) — pure props-in/events-out, no
+  owned state:
+  ```ts
+  defineProps<{
+    tabs: { id: number; title: string }[]
+    activeId: number | null
+  }>()
+  defineEmits<{
+    (e: 'select-tab', noteId: number): void
+    (e: 'close-tab', noteId: number): void
+  }>()
+  ```
+  One item per tab, `active` styling on the current one, a close `×`
+  button per tab (`@click.stop` so closing doesn't also select).
+
+- **`App.vue`**:
+  - `handleSelectNote(noteId)` gains one line —
+    `openTab(noteId)` — before its existing body. Every other call site
+    is unchanged.
+  - `handleDeleteNote` additionally purges the deleted note from
+    `openNoteIds` via the same `closeTab` path (whether or not it was
+    the active tab), so a deleted note's tab never lingers as a ghost.
+  - A `computed` derives the tab-strip's `tabs` prop from
+    `openNoteIds.value.map(id => notes.value.find(n => n.id === id))`,
+    filtering out any id no longer present in `notes.value` (e.g. a
+    note deleted from another session/tab) rather than showing an
+    "Untitled" ghost.
+  - `<TabStrip>` renders as a sibling right above `<main>`, gated on a
+    computed that's true only when tabs exist *and* none of the
+    existing mutually-exclusive view flags (`isGraphViewActive`,
+    `isAttachmentsActive`, `isSearchActive`, etc.) are active — tabs
+    represent open *notes*, so they're hidden while another exclusive
+    view (search, attachments, graph, ...) is showing, matching the
+    verbose-but-explicit style `App.vue` already uses for these flags.
+  - On workspace load, `loadTabs(workspaceId)` restores `openNoteIds`
+    and the last-active note id; if that id still exists in the
+    freshly-fetched notes list, `handleSelectNote` it, else fall back
+    to the existing "select first note" behavior unchanged.
+  - A `watch` on `[openNoteIds, activeNoteId]` calls `saveTabs` whenever
+    either changes.
+
+## Edge cases
+
+- Closing the active tab → activates the left neighbor (or right, for
+  the first tab), matching standard browser-tab convention; not asked
+  as a design question since it's an unambiguous default, not a fork.
+- Closing the last remaining tab → `activeNoteId`/`activeNoteDetail`
+  both reset to `null`, falling into the existing "Empty State" branch
+  (`App.vue`'s current `v-else` block) — no new empty-state UI needed.
+- No unsaved-changes confirmation on tab close — `NoteEditor.vue`
+  already autosaves (#269), so there is nothing to lose by closing.
+- Restored `activeNoteId` from `localStorage` pointing at a note that
+  no longer exists (deleted while the tab was closed in a prior
+  session) → falls back to "select first note," same as the existing
+  cold-start path when there's no stored state at all.
+
+## Testing
+
+- Unit (`useOpenTabs.spec.ts`): `openTab` dedups; `closeTab` returns the
+  left neighbor when closing a middle/last active tab, the right
+  neighbor when closing the first, `null` when closing the last
+  remaining tab, and returns `activeNoteId` unchanged when closing a
+  *non*-active tab; `loadTabs`/`saveTabs` round-trip through
+  `localStorage`; `loadTabs` degrades gracefully on missing/corrupt
+  stored JSON.
+- Component (`TabStrip.spec.ts`): one item per tab, `active` class on
+  the right one, clicking a tab emits `select-tab`, clicking its close
+  button emits `close-tab` without also emitting `select-tab`.
+- `App.spec.ts` additions: selecting the same note twice doesn't
+  duplicate its tab; selecting a second note keeps the first tab
+  present; closing the active tab switches to and loads a neighbor;
+  closing the last tab clears to the empty state; deleting a note
+  removes its tab.
+
+## Out of scope
+
+- True split-screen / simultaneously-mounted multi-pane editing (B,
+  above) — separate future work, blocked on first fixing G.1/G.5's
+  `document.getElementById`-based DOM lookups to be pane-scoped.
+- Drag-to-reorder tabs.
+- Any modifier-key ("open in new tab") interaction — every selection
+  already opens/activates a tab per the Decisions section.
+- Tab overflow/scrolling UI for very large numbers of open tabs — no
+  cap or scroll affordance added; out of scope for v1, matching the L
+  estimate's own ceiling.

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -1,7 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App.vue'
-import { createNote, getWorkspaces, getAuthConfig, getTenants } from './services/api'
+import { createNote, getWorkspaces, getAuthConfig, getTenants, getNotes, getNote, deleteNote } from './services/api'
 
 vi.mock('./services/api', () => ({
   getWorkspaces: vi.fn().mockResolvedValue([
@@ -226,5 +226,108 @@ describe('App tenant switching and persistence', () => {
     expect(localStorage.getItem('jotter-active-tenant-id')).toBe('2')
     expect(getWorkspaces).toHaveBeenLastCalledWith(2)
     expect(wrapper.findComponent({ name: 'Sidebar' }).props('workspaceId')).toBe(9)
+  })
+})
+
+describe('App tab strip', () => {
+  it('opening the same note twice does not duplicate its tab', async () => {
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 10)
+    await flushPromises()
+
+    expect(wrapper.findAllComponents({ name: 'TabStrip' })[0].props('tabs')).toEqual([
+      { id: 10, title: 'Welcome Note' },
+    ])
+  })
+
+  it('opening a second note keeps the first tab present', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    vi.mocked(getNote).mockResolvedValueOnce({
+      id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Second', backlinks: [],
+    })
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 11)
+    await flushPromises()
+
+    const tabs = wrapper.findComponent({ name: 'TabStrip' }).props('tabs')
+    expect(tabs.map((t: { id: number }) => t.id)).toEqual([10, 11])
+  })
+
+  it('closing the active tab switches to and loads a neighbor', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    vi.mocked(getNote).mockResolvedValueOnce({
+      id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Welcome', backlinks: [],
+    }).mockResolvedValueOnce({
+      id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Second', backlinks: [],
+    })
+    const wrapper = mount(App)
+    await flushPromises()
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('select-note', 11)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'TabStrip' }).vm.$emit('close-tab', 11)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TabStrip' }).props('activeId')).toBe(10)
+    expect(wrapper.findComponent({ name: 'NoteEditor' }).props('note').id).toBe(10)
+  })
+
+  it('closing the last tab clears to the empty state', async () => {
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'TabStrip' }).vm.$emit('close-tab', 10)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'NoteEditor' }).exists()).toBe(false)
+    expect(wrapper.text()).toContain('No Note Selected')
+  })
+
+  it('deleting a note removes its tab', async () => {
+    vi.mocked(getNotes).mockResolvedValueOnce([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ]).mockResolvedValueOnce([])
+    vi.mocked(deleteNote).mockResolvedValueOnce(undefined)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    await wrapper.findComponent({ name: 'Sidebar' }).vm.$emit('delete-note', 10)
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TabStrip' }).exists()).toBe(false)
+  })
+
+  it('restores the open tabs and active note from localStorage on remount', async () => {
+    vi.mocked(getNotes).mockResolvedValue([
+      { id: 10, path: 'welcome.md', title: 'Welcome Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+      { id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null, updated_at: '2026-07-27T00:00:00Z' },
+    ])
+    localStorage.setItem('jotter-open-tabs:1', JSON.stringify({ openNoteIds: [10, 11], activeNoteId: 11 }))
+    vi.mocked(getNote).mockResolvedValueOnce({
+      id: 11, path: 'second.md', title: 'Second Note', frontmatter: null, sort_position: null,
+      updated_at: '2026-07-27T00:00:00Z', content: '# Second', backlinks: [],
+    })
+
+    const wrapper = mount(App)
+    await flushPromises()
+
+    const tabs = wrapper.findComponent({ name: 'TabStrip' }).props('tabs')
+    expect(tabs.map((t: { id: number }) => t.id)).toEqual([10, 11])
+    expect(wrapper.findComponent({ name: 'TabStrip' }).props('activeId')).toBe(11)
   })
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -63,6 +63,14 @@
 
     <ChangePasswordModal v-if="isChangePasswordOpen" @close="isChangePasswordOpen = false" />
 
+    <TabStrip
+      v-if="showTabStrip"
+      :tabs="openTabsList"
+      :active-id="activeNoteId"
+      @select-tab="handleSelectNote"
+      @close-tab="handleCloseTab"
+    />
+
     <!-- Main Content Area -->
     <main class="main-content">
       <!-- Graph View Mode -->
@@ -224,7 +232,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import Sidebar from './components/Sidebar.vue'
 import NoteEditor from './components/NoteEditor.vue'
 import SearchResults from './components/SearchResults.vue'
@@ -269,6 +277,8 @@ import {
 import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition } from './services/types'
 import { APP_VERSION } from './version'
 import { resolveWikilinkTarget } from './services/wikilinks'
+import TabStrip from './components/TabStrip.vue'
+import { useOpenTabs } from './composables/useOpenTabs'
 
 const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
@@ -278,6 +288,45 @@ const notes = ref<NoteMeta[]>([])
 const folderPositions = ref<FolderPosition[]>([])
 const activeNoteId = ref<number | null>(null)
 const activeNoteDetail = ref<NoteDetail | null>(null)
+
+const { openNoteIds, loadTabs, saveTabs, openTab, closeTab } = useOpenTabs()
+
+const openTabsList = computed(() =>
+  openNoteIds.value
+    .map(id => {
+      const note = notes.value.find(n => n.id === id)
+      return note ? { id, title: note.title || note.path } : null
+    })
+    .filter((tab): tab is { id: number; title: string } => tab !== null)
+)
+
+const showTabStrip = computed(() =>
+  openNoteIds.value.length > 0 &&
+  !isGraphViewActive.value &&
+  !isAttachmentsActive.value &&
+  !isAuditLogActive.value &&
+  !isLinkReportActive.value &&
+  !isTableViewActive.value &&
+  !isBoardViewActive.value &&
+  !isCalendarViewActive.value &&
+  !isSearchActive.value
+)
+
+watch([openNoteIds, activeNoteId], () => {
+  if (!activeWorkspaceId.value) return
+  saveTabs(activeWorkspaceId.value, activeNoteId.value)
+}, { deep: true })
+
+async function handleCloseTab(noteId: number) {
+  const nextActiveId = closeTab(noteId, activeNoteId.value)
+  if (nextActiveId === activeNoteId.value) return
+  if (nextActiveId === null) {
+    activeNoteId.value = null
+    activeNoteDetail.value = null
+  } else {
+    await loadActiveNote(nextActiveId)
+  }
+}
 
 const currentUser = ref<AuthUser | null>(null)
 const backendVersion = ref<string | null>(null)
@@ -403,6 +452,7 @@ async function initWorkspace() {
       localStorage.setItem(WORKSPACE_STORAGE_KEY, String(list[0].id))
     }
 
+    activeNoteId.value = loadTabs(activeWorkspaceId.value)
     await refreshNotesList()
     await refreshNotifications()
   } catch (err) {
@@ -413,6 +463,7 @@ async function initWorkspace() {
 async function handleSwitchWorkspace(workspaceId: number) {
   activeWorkspaceId.value = workspaceId
   localStorage.setItem(WORKSPACE_STORAGE_KEY, String(workspaceId))
+  activeNoteId.value = loadTabs(workspaceId)
   await refreshNotesList()
   await refreshNotifications()
 }
@@ -556,6 +607,7 @@ async function loadActiveNote(noteId: number) {
 }
 
 async function handleSelectNote(noteId: number) {
+  openTab(noteId)
   isMobileSidebarOpen.value = false
   isSearchActive.value = false
   isAttachmentsActive.value = false
@@ -833,9 +885,14 @@ async function handleDeleteNote(noteId: number) {
   if (!confirm('Are you sure you want to delete this note?')) return
   try {
     await deleteNote(activeWorkspaceId.value, noteId)
-    if (activeNoteId.value === noteId) {
-      activeNoteId.value = null
-      activeNoteDetail.value = null
+    const nextActiveId = closeTab(noteId, activeNoteId.value)
+    if (nextActiveId !== activeNoteId.value) {
+      if (nextActiveId === null) {
+        activeNoteId.value = null
+        activeNoteDetail.value = null
+      } else {
+        await loadActiveNote(nextActiveId)
+      }
     }
     await refreshNotesList()
   } catch (err) {

--- a/frontend/src/TabStrip.spec.ts
+++ b/frontend/src/TabStrip.spec.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import TabStrip from './components/TabStrip.vue'
+
+const tabs = [
+  { id: 1, title: 'First Note' },
+  { id: 2, title: 'Second Note' },
+]
+
+describe('TabStrip', () => {
+  it('renders nothing when there are no tabs', () => {
+    const wrapper = mount(TabStrip, { props: { tabs: [], activeId: null } })
+    expect(wrapper.find('.tab-strip').exists()).toBe(false)
+  })
+
+  it('renders one item per tab with the active one styled', () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 2 } })
+    const items = wrapper.findAll('[data-testid="tab-strip-item"]')
+    expect(items).toHaveLength(2)
+    expect(items[0].classes()).not.toContain('active')
+    expect(items[1].classes()).toContain('active')
+  })
+
+  it('emits select-tab when a tab is clicked', async () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 1 } })
+    await wrapper.findAll('[data-testid="tab-strip-item"]')[1].trigger('click')
+    expect(wrapper.emitted('select-tab')![0]).toEqual([2])
+  })
+
+  it('emits close-tab without also emitting select-tab when the close button is clicked', async () => {
+    const wrapper = mount(TabStrip, { props: { tabs, activeId: 1 } })
+    await wrapper.findAll('[data-testid="tab-strip-close-btn"]')[0].trigger('click')
+    expect(wrapper.emitted('close-tab')![0]).toEqual([1])
+    expect(wrapper.emitted('select-tab')).toBeUndefined()
+  })
+})

--- a/frontend/src/components/TabStrip.vue
+++ b/frontend/src/components/TabStrip.vue
@@ -1,0 +1,91 @@
+<template>
+  <div v-if="tabs.length > 0" class="tab-strip" role="tablist">
+    <div
+      v-for="tab in tabs"
+      :key="tab.id"
+      class="tab-strip-item"
+      :class="{ active: tab.id === activeId }"
+      role="tab"
+      :aria-selected="tab.id === activeId"
+      data-testid="tab-strip-item"
+      @click="$emit('select-tab', tab.id)"
+    >
+      <span class="tab-strip-title">{{ tab.title }}</span>
+      <button
+        type="button"
+        class="tab-strip-close-btn"
+        data-testid="tab-strip-close-btn"
+        :aria-label="`Close ${tab.title}`"
+        @click.stop="$emit('close-tab', tab.id)"
+      >&times;</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  tabs: { id: number; title: string }[]
+  activeId: number | null
+}>()
+
+defineEmits<{
+  (e: 'select-tab', noteId: number): void
+  (e: 'close-tab', noteId: number): void
+}>()
+</script>
+
+<style scoped>
+.tab-strip {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 var(--space-2);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  overflow-x: auto;
+}
+
+.tab-strip-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.tab-strip-item:hover {
+  background: var(--color-hover);
+}
+
+.tab-strip-item.active {
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.tab-strip-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tab-strip-close-btn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.tab-strip-close-btn:hover {
+  background: var(--color-surface-emphasis);
+}
+</style>

--- a/frontend/src/composables/useOpenTabs.spec.ts
+++ b/frontend/src/composables/useOpenTabs.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useOpenTabs } from './useOpenTabs'
+
+describe('useOpenTabs', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('openTab appends a new note id', () => {
+    const { openNoteIds, openTab } = useOpenTabs()
+    openTab(1)
+    openTab(2)
+    expect(openNoteIds.value).toEqual([1, 2])
+  })
+
+  it('openTab does not duplicate an already-open note id', () => {
+    const { openNoteIds, openTab } = useOpenTabs()
+    openTab(1)
+    openTab(2)
+    openTab(1)
+    expect(openNoteIds.value).toEqual([1, 2])
+  })
+
+  it('closeTab on a non-active tab leaves the active id unchanged', () => {
+    const { openNoteIds, openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    const next = closeTab(2, 1)
+    expect(next).toBe(1)
+    expect(openNoteIds.value).toEqual([1, 3])
+  })
+
+  it('closeTab on the active middle tab activates its right neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(2, 2)).toBe(3)
+  })
+
+  it('closeTab on the active first tab activates its right neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(1, 1)).toBe(2)
+  })
+
+  it('closeTab on the active last tab activates its left neighbor', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    ;[1, 2, 3].forEach(openTab)
+    expect(closeTab(3, 3)).toBe(2)
+  })
+
+  it('closeTab on the last remaining tab returns null', () => {
+    const { openTab, closeTab } = useOpenTabs()
+    openTab(1)
+    expect(closeTab(1, 1)).toBeNull()
+  })
+
+  it('saveTabs then loadTabs round-trips through localStorage', () => {
+    const writer = useOpenTabs()
+    ;[1, 2].forEach(writer.openTab)
+    writer.saveTabs(5, 2)
+
+    const reader = useOpenTabs()
+    const restoredActiveId = reader.loadTabs(5)
+    expect(reader.openNoteIds.value).toEqual([1, 2])
+    expect(restoredActiveId).toBe(2)
+  })
+
+  it('loadTabs returns an empty list and null when nothing is stored', () => {
+    const { openNoteIds, loadTabs } = useOpenTabs()
+    expect(loadTabs(999)).toBeNull()
+    expect(openNoteIds.value).toEqual([])
+  })
+
+  it('loadTabs degrades gracefully on corrupt stored JSON', () => {
+    localStorage.setItem('jotter-open-tabs:7', 'not valid json{{{')
+    const { openNoteIds, loadTabs } = useOpenTabs()
+    expect(loadTabs(7)).toBeNull()
+    expect(openNoteIds.value).toEqual([])
+  })
+})

--- a/frontend/src/composables/useOpenTabs.ts
+++ b/frontend/src/composables/useOpenTabs.ts
@@ -1,0 +1,62 @@
+import { ref, type Ref } from 'vue'
+
+interface StoredTabs {
+  openNoteIds: number[]
+  activeNoteId: number | null
+}
+
+const STORAGE_PREFIX = 'jotter-open-tabs:'
+
+export function useOpenTabs(): {
+  openNoteIds: Ref<number[]>
+  loadTabs: (workspaceId: number) => number | null
+  saveTabs: (workspaceId: number, activeNoteId: number | null) => void
+  openTab: (noteId: number) => void
+  closeTab: (noteId: number, activeNoteId: number | null) => number | null
+} {
+  const openNoteIds = ref<number[]>([])
+
+  function loadTabs(workspaceId: number): number | null {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${workspaceId}`)
+    if (!raw) {
+      openNoteIds.value = []
+      return null
+    }
+    try {
+      const parsed = JSON.parse(raw) as StoredTabs
+      openNoteIds.value = Array.isArray(parsed.openNoteIds) ? parsed.openNoteIds : []
+      return typeof parsed.activeNoteId === 'number' ? parsed.activeNoteId : null
+    } catch {
+      openNoteIds.value = []
+      return null
+    }
+  }
+
+  function saveTabs(workspaceId: number, activeNoteId: number | null) {
+    localStorage.setItem(
+      `${STORAGE_PREFIX}${workspaceId}`,
+      JSON.stringify({ openNoteIds: openNoteIds.value, activeNoteId })
+    )
+  }
+
+  function openTab(noteId: number) {
+    if (!openNoteIds.value.includes(noteId)) {
+      openNoteIds.value.push(noteId)
+    }
+  }
+
+  function closeTab(noteId: number, activeNoteId: number | null): number | null {
+    const index = openNoteIds.value.indexOf(noteId)
+    if (index === -1) return activeNoteId
+
+    openNoteIds.value.splice(index, 1)
+
+    if (activeNoteId !== noteId) return activeNoteId
+    if (openNoteIds.value.length === 0) return null
+
+    const nextIndex = Math.min(index, openNoteIds.value.length - 1)
+    return openNoteIds.value[nextIndex]
+  }
+
+  return { openNoteIds, loadTabs, saveTabs, openTab, closeTab }
+}


### PR DESCRIPTION
## Summary
- Multiple notes now stay open as tabs — selecting any note (sidebar, backlinks, wikilinks, search, local graph, ...) opens/activates a tab for it, reusing one if already open
- Tabs persist per workspace in localStorage, restored on reload
- Closing the active tab activates its right neighbor (left neighbor if it was the last tab); closing the last tab returns to the existing empty state
- Deleting a note purges its tab
- Scope A only (this PR) — one NoteEditor mounted at a time, browser-tab semantics. True simultaneously-mounted split-screen (scope B) is separate future work, blocked on first making G.1/G.5's DOM-id-based lookups pane-scoped

Closes #290. Source: docs/20260803-jotter-obsidian-ui-parity-audit.md §G.4, design: docs/superpowers/specs/2026-08-04-tab-strip-design.md, plan: docs/superpowers/plans/2026-08-04-tab-strip.md

## Test plan
- [x] Unit: useOpenTabs.spec.ts (10), TabStrip.spec.ts (4), App.spec.ts tab-strip cases (6) — full frontend suite: 369/369 passing
- [x] Backend: 165/166 passing (1 pre-existing unrelated failure: ReleaseZipSecurityTest, same as seen on the G.1/#292, G.2/#293, G.5/#294, G.3/#295 branches)
- [ ] Manual: open several notes via the sidebar, confirm tabs appear and persist across reload, close a tab and confirm it switches to a neighbor, close the last tab and confirm the empty state returns