### PR TITLE
fix: admin endpoints 403 under GrandpaSSOn auth (production bug)

### DIFF
--- a/app/Http/Controllers/AdminMembershipController.php
+++ b/app/Http/Controllers/AdminMembershipController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
+use App\Domain\Auth\AuthenticatedSubject;
 use App\Models\Membership;
 use App\Models\Workspace;
 use Illuminate\Http\JsonResponse;
@@ -59,7 +60,7 @@ final class AdminMembershipController extends Controller
             event: AuditEvent::MEMBERSHIP_GRANTED,
             tenantId: $workspace->tenant_id,
             workspaceId: $workspace->id,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_subject_id' => $validated['subject_id'],
                 'role' => $validated['role'],
@@ -89,7 +90,7 @@ final class AdminMembershipController extends Controller
             event: AuditEvent::MEMBERSHIP_UPDATED,
             tenantId: $workspace->tenant_id,
             workspaceId: $workspace->id,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_subject_id' => $member->subject_id,
                 'new_role' => $validated['role'],
@@ -116,7 +117,7 @@ final class AdminMembershipController extends Controller
             event: AuditEvent::MEMBERSHIP_REVOKED,
             tenantId: $workspace->tenant_id,
             workspaceId: $workspace->id,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_subject_id' => $subjectId,
             ]
@@ -127,10 +128,25 @@ final class AdminMembershipController extends Controller
 
     private function authorizeAdmin(Request $request): void
     {
-        $user = $request->user();
-        if (! $user || ! $user->is_admin) {
+        if (config('jotter.auth_bypass', false)) {
+            return;
+        }
+
+        $subject = $this->currentSubject($request);
+        if (! $subject || ! $subject->isAdmin) {
             abort(403, 'Administrator access required.');
         }
+    }
+
+    /**
+     * AuthorizeWorkspaceAccess middleware resolves the caller via the app's own
+     * IdentityProvider (not Laravel's built-in auth guard — $request->user() is never
+     * populated by the GrandpaSSOn cookie-auth path, only by LocalIdentityProvider's
+     * password-login flow) and stashes the result here.
+     */
+    private function currentSubject(Request $request): ?AuthenticatedSubject
+    {
+        return $request->attributes->get('authenticated_subject');
     }
 
     private function ensureWorkspaceScope(Workspace $workspace, Membership $member): void

--- a/app/Http/Controllers/AdminUserController.php
+++ b/app/Http/Controllers/AdminUserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
+use App\Domain\Auth\AuthenticatedSubject;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -50,7 +51,7 @@ final class AdminUserController extends Controller
 
         $this->auditRecorder->record(
             event: AuditEvent::USER_CREATED,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'created_user_id' => $user->id,
                 'email' => $user->email,
@@ -78,7 +79,7 @@ final class AdminUserController extends Controller
 
         $this->auditRecorder->record(
             event: AuditEvent::USER_DEACTIVATED,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_user_id' => $user->id,
                 'email' => $user->email,
@@ -97,7 +98,7 @@ final class AdminUserController extends Controller
 
         $this->auditRecorder->record(
             event: AuditEvent::USER_REACTIVATED,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_user_id' => $user->id,
                 'email' => $user->email,
@@ -122,7 +123,7 @@ final class AdminUserController extends Controller
 
         $this->auditRecorder->record(
             event: AuditEvent::USER_PASSWORD_RESET,
-            actorId: (string) $request->user()?->id,
+            actorId: $this->currentSubject($request)?->subjectId,
             metadata: [
                 'target_user_id' => $user->id,
                 'email' => $user->email,
@@ -169,10 +170,25 @@ final class AdminUserController extends Controller
 
     private function authorizeAdmin(Request $request): void
     {
-        $user = $request->user();
-        if (! $user || ! $user->is_admin) {
+        if (config('jotter.auth_bypass', false)) {
+            return;
+        }
+
+        $subject = $this->currentSubject($request);
+        if (! $subject || ! $subject->isAdmin) {
             abort(403, 'Administrator access required.');
         }
+    }
+
+    /**
+     * AuthorizeWorkspaceAccess middleware resolves the caller via the app's own
+     * IdentityProvider (not Laravel's built-in auth guard — $request->user() is never
+     * populated by the GrandpaSSOn cookie-auth path, only by LocalIdentityProvider's
+     * password-login flow) and stashes the result here.
+     */
+    private function currentSubject(Request $request): ?AuthenticatedSubject
+    {
+        return $request->attributes->get('authenticated_subject');
     }
 
     private function ensureLocalProvider(): void

--- a/app/Http/Controllers/AdminWorkspaceController.php
+++ b/app/Http/Controllers/AdminWorkspaceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
+use App\Domain\Auth\AuthenticatedSubject;
 use App\Domain\Vault\Exceptions\PathTraversalRejected;
 use App\Domain\Vault\VaultRootGuard;
 use App\Models\Workspace;
@@ -108,9 +109,24 @@ final class AdminWorkspaceController extends Controller
 
     private function authorizeAdmin(Request $request): void
     {
-        $user = $request->user();
-        if (! $user || ! $user->is_admin) {
+        if (config('jotter.auth_bypass', false)) {
+            return;
+        }
+
+        $subject = $this->currentSubject($request);
+        if (! $subject || ! $subject->isAdmin) {
             abort(403, 'Administrator access required.');
         }
+    }
+
+    /**
+     * AuthorizeWorkspaceAccess middleware resolves the caller via the app's own
+     * IdentityProvider (not Laravel's built-in auth guard — $request->user() is never
+     * populated by the GrandpaSSOn cookie-auth path, only by LocalIdentityProvider's
+     * password-login flow) and stashes the result here.
+     */
+    private function currentSubject(Request $request): ?AuthenticatedSubject
+    {
+        return $request->attributes->get('authenticated_subject');
     }
 }

--- a/tests/Feature/GrandpaSSOnAdminEscalationTest.php
+++ b/tests/Feature/GrandpaSSOnAdminEscalationTest.php
@@ -29,6 +29,7 @@ final class GrandpaSSOnAdminEscalationTest extends TestCase
         parent::setUp();
 
         config(['jotter.sso.db_prefix' => self::PREFIX]);
+        config(['jotter.auth_provider' => 'grandpasson']);
 
         Schema::create(self::PREFIX.'users', function ($table) {
             $table->string('id', 36)->primary();
@@ -93,6 +94,48 @@ final class GrandpaSSOnAdminEscalationTest extends TestCase
         $subject = $this->resolveWithCookie($sessionId);
 
         $this->assertNull($subject);
+    }
+
+    /**
+     * Regression for the AdminUserController/AdminWorkspaceController/AdminMembershipController
+     * `authorizeAdmin()` bug: those checked Laravel's built-in `$request->user()`, which is only
+     * ever populated by LocalIdentityProvider's password-login flow (via `Auth::guard('web')
+     * ->login()`). The GrandpaSSOn AUTHSESSID-cookie path never touches that guard at all — it
+     * only produces an `AuthenticatedSubject` and relies on the `authenticated_subject` request
+     * attribute `AuthorizeWorkspaceAccess` middleware already sets. Every existing admin-endpoint
+     * test used `actingAs()`, which populates the guard directly and so never exercised this real
+     * request path — this test goes through the actual HTTP/cookie flow instead.
+     *
+     * AUTHSESSID is set via the raw $_COOKIE superglobal, not the test client's withCookie()
+     * (which round-trips through Laravel's EncryptCookies/DecryptCookies middleware). The real
+     * GrandpaSSOn cookie is plaintext, set by a different app entirely, so
+     * GrandpaSSOnIdentityProvider::resolveIdentity() deliberately falls back to reading
+     * $_COOKIE directly for it — matching that here is what makes this test exercise the real
+     * production code path instead of failing decryption on a cookie Laravel never encrypted.
+     */
+    public function test_an_admin_sso_user_can_reach_admin_endpoints_via_the_authsessid_cookie(): void
+    {
+        User::factory()->create(['email' => 'admin-sso-user@example.com', 'is_admin' => true]);
+        $ssoUserId = $this->insertSsoUser('admin-sso-user@example.com', 'Admin SSO User');
+        $sessionId = $this->insertSsoSession($ssoUserId, time() + 3600);
+
+        $_COOKIE['AUTHSESSID'] = $sessionId;
+        $response = $this->getJson('/api/admin/users');
+        unset($_COOKIE['AUTHSESSID']);
+
+        $response->assertOk();
+    }
+
+    public function test_a_non_admin_sso_user_still_gets_403_from_admin_endpoints(): void
+    {
+        $ssoUserId = $this->insertSsoUser('member-sso-user@example.com', 'Member SSO User');
+        $sessionId = $this->insertSsoSession($ssoUserId, time() + 3600);
+
+        $_COOKIE['AUTHSESSID'] = $sessionId;
+        $response = $this->getJson('/api/admin/users');
+        unset($_COOKIE['AUTHSESSID']);
+
+        $response->assertStatus(403);
     }
 
     private function insertSsoUser(string $email, string $displayName, string $status = 'active'): string


### PR DESCRIPTION
## Summary
Production bug: admin panel returns 403 on all `/api/admin/*` endpoints for GrandpaSSOn-SSO-authenticated admins (even though `/auth/me` correctly reports `is_admin: true`).

**Root cause:** `AdminUserController`/`AdminWorkspaceController`/`AdminMembershipController`'s `authorizeAdmin()` checked Laravel's built-in `$request->user()`, which is only populated by `LocalIdentityProvider`'s password-login flow (`Auth::guard('web')->login()`). The GrandpaSSOn AUTHSESSID-cookie auth path never touches that guard — it only produces an `AuthenticatedSubject` and relies on the `authenticated_subject` request attribute `AuthorizeWorkspaceAccess` middleware already sets correctly for workspace-scoped routes.

Every existing admin-endpoint test used `actingAs()`, which populates the guard directly and so never exercised the real cookie-auth request path — this bug predates today's session entirely and is unrelated to the G.1-G.4 feature work merged earlier today.

**Fix:** all three controllers now resolve the caller via the same `authenticated_subject` attribute the middleware already sets, matching the pattern that route-level workspace authorization already used correctly. Also preserved `auth_bypass`'s existing "skip all authorization" semantics, which the old code got by accident (via `$request->user()` being independent of the bypass flag).

## Test plan
- [x] New regression tests in `GrandpaSSOnAdminEscalationTest.php` exercise the real HTTP/cookie path (not `actingAs()`) — confirmed both tests fail against the old code (403/401) and pass against the fix
- [x] Full backend suite: 168/168 passing (no regressions, no pre-existing failures)