### PR TITLE
feat: drag-and-drop cards between board columns (#299)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -127,6 +127,7 @@
         @select-note="handleSelectNote"
         @page-change="handleCollectionPageChange"
         @group-change="handleCollectionGroupChange"
+        @move-card="handleCollectionMoveCard"
       />
 
       <!-- Calendar (Collections) View Mode -->
@@ -269,6 +270,7 @@ import {
   getLinkReport,
   publishWorkspace,
   getCollection,
+  setNoteProperty,
   getNotifications,
   markNotificationRead,
   deleteNotification,
@@ -734,6 +736,17 @@ function handleCollectionSort(key: string) {
 
 function handleCollectionGroupChange(property: string) {
   collectionGroupProperty.value = property || null
+}
+
+async function handleCollectionMoveCard(noteId: number, newValue: string) {
+  if (!activeWorkspaceId.value || !collectionGroupProperty.value) return
+  try {
+    await setNoteProperty(activeWorkspaceId.value, noteId, collectionGroupProperty.value, newValue)
+  } catch (err) {
+    console.error('Failed to move card:', err)
+  } finally {
+    await refreshCollection(collectionPage.value.current_page)
+  }
 }
 
 function handleCollectionDatePropertyChange(property: string) {

--- a/frontend/src/collectionUtils.spec.ts
+++ b/frontend/src/collectionUtils.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+
+function makeEl(dataset: Record<string, string>): HTMLElement {
+  const el = document.createElement('div')
+  Object.assign(el.dataset, dataset)
+  return el
+}
+
+describe('resolveCardMove', () => {
+  it('returns null when the card is dropped back in its own column', () => {
+    const column = makeEl({ columnKey: 'draft' })
+    const item = makeEl({ noteId: '1' })
+    expect(resolveCardMove(column, column, item)).toBeNull()
+  })
+
+  it('returns the note id and target column value when moved to a different column', () => {
+    const from = makeEl({ columnKey: 'draft' })
+    const to = makeEl({ columnKey: 'done' })
+    const item = makeEl({ noteId: '1' })
+    expect(resolveCardMove(from, to, item)).toEqual({ noteId: 1, newValue: 'done' })
+  })
+
+  it('resolves the ungrouped column to an empty string value (clears the property)', () => {
+    const from = makeEl({ columnKey: 'draft' })
+    const to = makeEl({ columnKey: UNGROUPED_LABEL })
+    const item = makeEl({ noteId: '1' })
+    expect(resolveCardMove(from, to, item)).toEqual({ noteId: 1, newValue: '' })
+  })
+
+  it('returns null when the dragged item has no note id', () => {
+    const from = makeEl({ columnKey: 'draft' })
+    const to = makeEl({ columnKey: 'done' })
+    const item = makeEl({})
+    expect(resolveCardMove(from, to, item)).toBeNull()
+  })
+})

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -40,13 +40,19 @@
           <span class="board-column-title">{{ column.label }}</span>
           <span class="count-badge">{{ column.notes.length }}</span>
         </div>
-        <div class="board-column-body">
+        <div
+          class="board-column-body"
+          data-testid="board-column-body"
+          :data-column-key="column.key"
+          :ref="(el) => setColumnBodyRef(column.key, el)"
+        >
           <button
             v-for="note in column.notes"
             :key="note.id"
             type="button"
             class="board-card"
             data-testid="board-card"
+            :data-note-id="note.id"
             @click="$emit('select-note', note.id)"
           >
             <span class="board-card-title">{{ note.title || note.path }}</span>
@@ -81,9 +87,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, nextTick, onBeforeUnmount, onMounted } from 'vue'
+import Sortable from 'sortablejs'
 import type { CollectionPage } from '../services/types'
-import { formatPropertyValue, propertyColumns as computePropertyColumns } from '../services/collectionUtils'
+import {
+  formatPropertyValue,
+  propertyColumns as computePropertyColumns,
+  resolveCardMove,
+  UNGROUPED_LABEL,
+} from '../services/collectionUtils'
 
 const props = defineProps<{
   page: CollectionPage
@@ -95,6 +107,7 @@ const emit = defineEmits<{
   (e: 'select-note', noteId: number): void
   (e: 'page-change', page: number): void
   (e: 'group-change', property: string): void
+  (e: 'move-card', noteId: number, newValue: string): void
 }>()
 
 const groupPropertyInput = ref(props.groupProperty || '')
@@ -108,8 +121,6 @@ function applyGroupProperty() {
 }
 
 const propertyColumns = computed(() => computePropertyColumns(props.page))
-
-const UNGROUPED_LABEL = 'No value'
 
 const columns = computed(() => {
   if (!props.groupProperty) return []
@@ -127,6 +138,61 @@ const columns = computed(() => {
   })
   return sortedKeys.map(key => ({ key, label: key, notes: groups.get(key)! }))
 })
+
+// Drag-and-drop between columns (#299): one Sortable instance per column
+// body, sharing a group so cards can move between them. onEnd resolves the
+// move via the pure resolveCardMove() rather than deciding inline, so the
+// decision logic is unit-testable without a real Sortable instance.
+const columnBodyRefs = new Map<string, HTMLElement>()
+
+function setColumnBodyRef(key: string, el: unknown) {
+  if (el instanceof HTMLElement) {
+    columnBodyRefs.set(key, el)
+  } else {
+    columnBodyRefs.delete(key)
+  }
+}
+
+let sortableInstances: Sortable[] = []
+
+function destroySortables() {
+  sortableInstances.forEach(s => s.destroy())
+  sortableInstances = []
+}
+
+function initSortables() {
+  destroySortables()
+  for (const el of columnBodyRefs.values()) {
+    sortableInstances.push(
+      Sortable.create(el, {
+        group: 'board-column',
+        animation: 150,
+        ghostClass: 'board-card-ghost',
+        // Native HTML5 drag-and-drop never fires from touch input, so the
+        // fallback (mouse/touch-event-based) simulation is required for
+        // touch support, same as the sidebar's note-tree drag-and-drop.
+        forceFallback: true,
+        onEnd(evt) {
+          const from = evt.from as HTMLElement
+          const to = evt.to as HTMLElement
+          const item = evt.item as HTMLElement
+          const move = resolveCardMove(from, to, item)
+          if (move) emit('move-card', move.noteId, move.newValue)
+        },
+      })
+    )
+  }
+}
+
+onMounted(() => {
+  nextTick(initSortables)
+})
+
+watch(columns, () => {
+  nextTick(initSortables)
+})
+
+onBeforeUnmount(destroySortables)
 </script>
 
 <style scoped>
@@ -276,6 +342,11 @@ const columns = computed(() => {
 
 .board-card:hover {
   background: var(--color-surface-emphasis);
+}
+
+.board-card-ghost {
+  background: var(--color-hover);
+  opacity: 0.6;
 }
 
 .board-card-title {

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -32,3 +32,27 @@ export function propertyColumns(page: CollectionPage): string[] {
   }
   return Array.from(names).sort()
 }
+
+export const UNGROUPED_LABEL = 'No value'
+
+/**
+ * Decides what a board drag-and-drop move means, from the Sortable `onEnd`
+ * event's `from`/`to`/`item` elements — pure so it's testable without
+ * spinning up a real Sortable instance. Returns null for a no-op (dropped
+ * back in the same column, or the dragged element has no note id).
+ */
+export function resolveCardMove(
+  from: HTMLElement,
+  to: HTMLElement,
+  item: HTMLElement
+): { noteId: number; newValue: string } | null {
+  if (from === to) return null
+
+  const noteId = Number(item.dataset.noteId)
+  if (!noteId) return null
+
+  const columnKey = to.dataset.columnKey
+  if (columnKey === undefined) return null
+
+  return { noteId, newValue: columnKey === UNGROUPED_LABEL ? '' : columnKey }
+}


### PR DESCRIPTION
## Summary
- Adds SortableJS-based drag-and-drop between board columns in `CollectionsBoardView.vue`
- Move decisions resolved via a pure, unit-tested `resolveCardMove()` helper
- Dropping a card updates the grouped property via `setNoteProperty` and refreshes the board

Closes #299

## Test plan
- [x] `collectionUtils.spec.ts` (4/4) — `resolveCardMove` unit tests
- [x] `CollectionsBoardView.spec.ts` (7/7) — no regressions
- [x] Full frontend suite (373/373)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>