### PR TITLE
feat: surface and filter tags on the board (#306)

### DIFF
--- a/frontend/src/CollectionsBoardView.spec.ts
+++ b/frontend/src/CollectionsBoardView.spec.ts
@@ -11,13 +11,15 @@ const page: CollectionPage = {
       id: 1, path: 'a.md', title: 'A',
       properties: [
         { id: 1, note_id: 1, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
-      ]
+      ],
+      tags: [{ id: 1, name: 'urgent' }]
     },
     {
       id: 2, path: 'b.md', title: 'B',
       properties: [
         { id: 2, note_id: 2, name: 'status', type: 'string', value_string: 'done', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
-      ]
+      ],
+      tags: [{ id: 2, name: 'work' }]
     },
     {
       id: 3, path: 'c.md', title: 'C',
@@ -94,6 +96,28 @@ describe('CollectionsBoardView', () => {
     await draftColumn.get('[data-testid="board-add-card-form"]').trigger('submit')
     expect(wrapper.emitted('create-card')![0]).toEqual(['New task', 'draft'])
     expect(draftColumn.find('[data-testid="board-add-card-input"]').exists()).toBe(false)
+  })
+
+  it('shows tag pills on the card face', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    expect(wrapper.find('[data-testid="board-card-tag"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('urgent')
+    expect(wrapper.text()).toContain('work')
+  })
+
+  it('offers a tag filter with every tag present on the page', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    const options = wrapper.findAll('[data-testid="board-tag-filter"] option').map(o => o.text())
+    expect(options).toContain('urgent')
+    expect(options).toContain('work')
+  })
+
+  it('filters cards to only those carrying the selected tag', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    await wrapper.get('[data-testid="board-tag-filter"]').setValue('urgent')
+    const cards = wrapper.findAll('[data-testid="board-card"]')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].text()).toContain('A')
   })
 
   it('does not emit create-card for a blank title', async () => {

--- a/frontend/src/collectionUtils.spec.ts
+++ b/frontend/src/collectionUtils.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import { allTagNames, filterNotesByTag, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import type { CollectionNote, CollectionPage } from './services/types'
+
+function makeNote(id: number, tags: string[]): CollectionNote {
+  return { id, path: `${id}.md`, title: `Note ${id}`, properties: [], tags: tags.map((name, i) => ({ id: i, name })) }
+}
 
 function makeEl(dataset: Record<string, string>): HTMLElement {
   const el = document.createElement('div')
@@ -33,5 +38,34 @@ describe('resolveCardMove', () => {
     const to = makeEl({ columnKey: 'done' })
     const item = makeEl({})
     expect(resolveCardMove(from, to, item)).toBeNull()
+  })
+})
+
+describe('noteTagNames', () => {
+  it('returns the note tag names, empty array when untagged', () => {
+    expect(noteTagNames(makeNote(1, ['urgent', 'work']))).toEqual(['urgent', 'work'])
+    expect(noteTagNames(makeNote(2, []))).toEqual([])
+  })
+})
+
+describe('allTagNames', () => {
+  it('returns the sorted, deduplicated set of tags across a page', () => {
+    const page: CollectionPage = {
+      data: [makeNote(1, ['work', 'urgent']), makeNote(2, ['work']), makeNote(3, [])],
+      current_page: 1, last_page: 1, per_page: 50, total: 3,
+    }
+    expect(allTagNames(page)).toEqual(['urgent', 'work'])
+  })
+})
+
+describe('filterNotesByTag', () => {
+  const notes = [makeNote(1, ['work']), makeNote(2, ['personal']), makeNote(3, ['work', 'personal'])]
+
+  it('returns all notes when no tag is selected', () => {
+    expect(filterNotesByTag(notes, '')).toEqual(notes)
+  })
+
+  it('returns only notes carrying the selected tag', () => {
+    expect(filterNotesByTag(notes, 'personal')).toEqual([notes[1], notes[2]])
   })
 })

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -20,6 +20,16 @@
         <option v-for="col in propertyColumns" :key="col" :value="col" />
       </datalist>
       <button type="submit" class="btn-group-apply" data-testid="board-group-apply">Group</button>
+      <select
+        v-if="allTags.length > 0"
+        v-model="tagFilter"
+        aria-label="Filter by tag"
+        data-testid="board-tag-filter"
+        class="tag-filter-select"
+      >
+        <option value="">All tags</option>
+        <option v-for="tag in allTags" :key="tag" :value="tag">{{ tag }}</option>
+      </select>
     </form>
 
     <div v-if="loading" class="panel-empty">
@@ -57,6 +67,14 @@
           >
             <span class="board-card-title">{{ note.title || note.path }}</span>
             <span class="board-card-path">{{ note.path }}</span>
+            <span v-if="noteTagNames(note).length > 0" class="board-card-tags">
+              <span
+                v-for="tag in noteTagNames(note)"
+                :key="tag"
+                class="board-card-tag"
+                data-testid="board-card-tag"
+              >{{ tag }}</span>
+            </span>
           </button>
         </div>
         <form
@@ -118,7 +136,10 @@ import { computed, ref, watch, nextTick, onBeforeUnmount, onMounted } from 'vue'
 import Sortable from 'sortablejs'
 import type { CollectionPage } from '../services/types'
 import {
+  allTagNames,
+  filterNotesByTag,
   formatPropertyValue,
+  noteTagNames,
   propertyColumns as computePropertyColumns,
   resolveCardMove,
   UNGROUPED_LABEL,
@@ -150,10 +171,14 @@ function applyGroupProperty() {
 
 const propertyColumns = computed(() => computePropertyColumns(props.page))
 
+const tagFilter = ref('')
+const allTags = computed(() => allTagNames(props.page))
+
 const columns = computed(() => {
   if (!props.groupProperty) return []
+  const notes = filterNotesByTag(props.page.data, tagFilter.value)
   const groups = new Map<string, typeof props.page.data>()
-  for (const note of props.page.data) {
+  for (const note of notes) {
     const label = formatPropertyValue(note, props.groupProperty)
     const key = label === '—' ? UNGROUPED_LABEL : label
     if (!groups.has(key)) groups.set(key, [])
@@ -461,6 +486,31 @@ function submitAddCard(columnKey: string) {
   color: var(--color-text-muted);
   font-family: var(--font-mono, monospace);
   font-size: 0.7rem;
+}
+
+.board-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.board-card-tag {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  padding: 0.05rem 0.4rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.7rem;
+}
+
+.tag-filter-select {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
 }
 
 .pagination-bar {

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -33,6 +33,23 @@ export function propertyColumns(page: CollectionPage): string[] {
   return Array.from(names).sort()
 }
 
+export function noteTagNames(note: CollectionNote): string[] {
+  return (note.tags ?? []).map(t => t.name)
+}
+
+export function allTagNames(page: CollectionPage): string[] {
+  const names = new Set<string>()
+  for (const note of page.data) {
+    for (const name of noteTagNames(note)) names.add(name)
+  }
+  return Array.from(names).sort()
+}
+
+export function filterNotesByTag(notes: CollectionNote[], tag: string): CollectionNote[] {
+  if (!tag) return notes
+  return notes.filter(note => noteTagNames(note).includes(tag))
+}
+
 export const UNGROUPED_LABEL = 'No value'
 
 /**

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -173,11 +173,17 @@ export interface RawNoteProperty {
   value_json: unknown | null
 }
 
+export interface CollectionTag {
+  id: number
+  name: string
+}
+
 export interface CollectionNote {
   id: number
   path: string
   title: string
   properties: RawNoteProperty[]
+  tags?: CollectionTag[]
 }
 
 export interface CollectionPage {

--- a/tests/Feature/MilestoneCFinalTest.php
+++ b/tests/Feature/MilestoneCFinalTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
 use App\Models\NoteComment;
 use App\Models\Notification;
+use App\Models\Tag;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Models\Workspace;
@@ -107,5 +109,34 @@ final class MilestoneCFinalTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('total', 1)
             ->assertJsonPath('data.0.title', 'High Priority');
+    }
+
+    public function test_collections_response_includes_each_notes_tags(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'test-tags', 'name' => 'Test Tags']);
+        $vaultPath = storage_path('app/vaults/m_c_tags_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'tags',
+            'name' => 'Tags Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+        $storage->write($workspace, 'tagged.md', "# Tagged Note");
+
+        $note = Note::where('workspace_id', $workspace->id)->where('path', 'tagged.md')->firstOrFail();
+        $tag = Tag::create(['workspace_id' => $workspace->id, 'name' => 'urgent']);
+        $note->tags()->attach($tag);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/collections");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.tags.0.name', 'urgent');
     }
 }


### PR DESCRIPTION
## Summary
- Card faces show each note's tags as pills
- New tag-filter select above the board narrows visible cards by tag
- Regression test confirms the collections endpoint's already-eager-loaded `tags` relation reaches the response

Closes #306

## Test plan
- [x] `collectionUtils.spec.ts` (8/8, 4 new)
- [x] `CollectionsBoardView.spec.ts` (13/13, 3 new)
- [x] Full frontend suite (383/383)
- [x] Full backend suite (169/169)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>