### PR TITLE
feat: rich board card face — cover, due date, checklist, comments (#302)

### DIFF
--- a/app/Http/Controllers/WorkspaceCollectionController.php
+++ b/app/Http/Controllers/WorkspaceCollectionController.php
@@ -30,7 +30,8 @@ final class WorkspaceCollectionController extends Controller
 
         $query = Note::query()
             ->where('workspace_id', $workspaceId)
-            ->with(['properties', 'tags']);
+            ->with(['properties', 'tags'])
+            ->withCount('comments');
 
         if ($propertyKey !== null && $propertyKey !== '') {
             $query->whereHas('properties', function ($pQuery) use ($propertyKey, $propertyValue) {
@@ -67,6 +68,28 @@ final class WorkspaceCollectionController extends Controller
         $perPage = min(100, max(1, (int) $request->query('per_page', 25)));
         $notes = $query->orderBy('title')->paginate($perPage);
 
+        $notes->getCollection()->transform(function (Note $note) {
+            $checklist = self::checklistProgress($note->search_content ?? '');
+            $note->setAttribute('checklist_total', $checklist['total']);
+            $note->setAttribute('checklist_done', $checklist['done']);
+
+            return $note;
+        });
+
         return response()->json($notes);
+    }
+
+    /**
+     * @return array{total: int, done: int}
+     */
+    private static function checklistProgress(string $body): array
+    {
+        preg_match_all('/^\s*[-*]\s+\[([ xX])\]/m', $body, $matches);
+        $marks = $matches[1] ?? [];
+
+        return [
+            'total' => count($marks),
+            'done' => count(array_filter($marks, fn (string $m) => strtolower($m) === 'x')),
+        ];
     }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -55,4 +55,9 @@ class Note extends Model
     {
         return $this->hasMany(NoteProperty::class);
     }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(NoteComment::class);
+    }
 }

--- a/frontend/src/CollectionsBoardView.spec.ts
+++ b/frontend/src/CollectionsBoardView.spec.ts
@@ -98,6 +98,30 @@ describe('CollectionsBoardView', () => {
     expect(draftColumn.find('[data-testid="board-add-card-input"]').exists()).toBe(false)
   })
 
+  it('shows a cover image, due date, checklist progress, and comment count on the card face', () => {
+    const richPage: CollectionPage = {
+      ...page,
+      data: [
+        {
+          id: 4, path: 'd.md', title: 'D',
+          properties: [
+            { id: 3, note_id: 4, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+            { id: 4, note_id: 4, name: 'cover', type: 'string', value_string: 'https://example.com/cover.png', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+            { id: 5, note_id: 4, name: 'due', type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: '2026-08-10', value_json: null },
+          ],
+          checklist_total: 3,
+          checklist_done: 1,
+          comments_count: 2,
+        },
+      ],
+    }
+    const wrapper = mount(CollectionsBoardView, { props: { page: richPage, groupProperty: 'status' } })
+    expect(wrapper.find('[data-testid="board-card-cover"]').attributes('src')).toBe('https://example.com/cover.png')
+    expect(wrapper.find('[data-testid="board-card-due"]').text()).toContain('2026-08-10')
+    expect(wrapper.find('[data-testid="board-card-checklist"]').text()).toContain('1/3')
+    expect(wrapper.find('[data-testid="board-card-comments"]').text()).toContain('2')
+  })
+
   it('shows tag pills on the card face', () => {
     const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
     expect(wrapper.find('[data-testid="board-card-tag"]').exists()).toBe(true)

--- a/frontend/src/collectionUtils.spec.ts
+++ b/frontend/src/collectionUtils.spec.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { allTagNames, filterNotesByTag, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
-import type { CollectionNote, CollectionPage } from './services/types'
+import { allTagNames, coverImageUrl, filterNotesByTag, firstDateProperty, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import type { CollectionNote, CollectionPage, RawNoteProperty } from './services/types'
 
-function makeNote(id: number, tags: string[]): CollectionNote {
-  return { id, path: `${id}.md`, title: `Note ${id}`, properties: [], tags: tags.map((name, i) => ({ id: i, name })) }
+function makeNote(id: number, tags: string[], properties: RawNoteProperty[] = []): CollectionNote {
+  return { id, path: `${id}.md`, title: `Note ${id}`, properties, tags: tags.map((name, i) => ({ id: i, name })) }
+}
+
+function stringProp(name: string, value: string): RawNoteProperty {
+  return { id: 1, note_id: 1, name, type: 'string', value_string: value, value_numeric: null, value_boolean: null, value_datetime: null, value_json: null }
+}
+
+function dateProp(name: string, value: string): RawNoteProperty {
+  return { id: 2, note_id: 1, name, type: 'datetime', value_string: null, value_numeric: null, value_boolean: null, value_datetime: value, value_json: null }
 }
 
 function makeEl(dataset: Record<string, string>): HTMLElement {
@@ -67,5 +75,28 @@ describe('filterNotesByTag', () => {
 
   it('returns only notes carrying the selected tag', () => {
     expect(filterNotesByTag(notes, 'personal')).toEqual([notes[1], notes[2]])
+  })
+})
+
+describe('coverImageUrl', () => {
+  it('returns the cover property value when set', () => {
+    const note = makeNote(1, [], [stringProp('cover', 'https://example.com/img.png')])
+    expect(coverImageUrl(note)).toBe('https://example.com/img.png')
+  })
+
+  it('returns null when there is no cover property or it is blank', () => {
+    expect(coverImageUrl(makeNote(1, []))).toBeNull()
+    expect(coverImageUrl(makeNote(1, [], [stringProp('cover', '  ')]))).toBeNull()
+  })
+})
+
+describe('firstDateProperty', () => {
+  it('returns the first datetime property name and value', () => {
+    const note = makeNote(1, [], [stringProp('status', 'open'), dateProp('due', '2026-08-10')])
+    expect(firstDateProperty(note)).toEqual({ name: 'due', value: '2026-08-10' })
+  })
+
+  it('returns null when there is no datetime property', () => {
+    expect(firstDateProperty(makeNote(1, [], [stringProp('status', 'open')]))).toBeNull()
   })
 })

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -65,6 +65,13 @@
             :data-note-id="note.id"
             @click="$emit('select-note', note.id)"
           >
+            <img
+              v-if="coverImageUrl(note)"
+              class="board-card-cover"
+              data-testid="board-card-cover"
+              :src="coverImageUrl(note)!"
+              alt=""
+            />
             <span class="board-card-title">{{ note.title || note.path }}</span>
             <span class="board-card-path">{{ note.path }}</span>
             <span v-if="noteTagNames(note).length > 0" class="board-card-tags">
@@ -74,6 +81,25 @@
                 class="board-card-tag"
                 data-testid="board-card-tag"
               >{{ tag }}</span>
+            </span>
+            <span class="board-card-meta">
+              <span v-if="firstDateProperty(note)" class="board-card-due" data-testid="board-card-due">
+                {{ firstDateProperty(note)!.value }}
+              </span>
+              <span
+                v-if="note.checklist_total && note.checklist_total > 0"
+                class="board-card-checklist"
+                data-testid="board-card-checklist"
+              >
+                ☑ {{ note.checklist_done ?? 0 }}/{{ note.checklist_total }}
+              </span>
+              <span
+                v-if="note.comments_count && note.comments_count > 0"
+                class="board-card-comments"
+                data-testid="board-card-comments"
+              >
+                💬 {{ note.comments_count }}
+              </span>
             </span>
           </button>
         </div>
@@ -137,7 +163,9 @@ import Sortable from 'sortablejs'
 import type { CollectionPage } from '../services/types'
 import {
   allTagNames,
+  coverImageUrl,
   filterNotesByTag,
+  firstDateProperty,
   formatPropertyValue,
   noteTagNames,
   propertyColumns as computePropertyColumns,
@@ -486,6 +514,23 @@ function submitAddCard(columnKey: string) {
   color: var(--color-text-muted);
   font-family: var(--font-mono, monospace);
   font-size: 0.7rem;
+}
+
+.board-card-cover {
+  width: 100%;
+  height: 96px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-1);
+}
+
+.board-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
 }
 
 .board-card-tags {

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -50,6 +50,18 @@ export function filterNotesByTag(notes: CollectionNote[], tag: string): Collecti
   return notes.filter(note => noteTagNames(note).includes(tag))
 }
 
+export function coverImageUrl(note: CollectionNote): string | null {
+  const prop = findProperty(note, 'cover')
+  if (!prop || prop.type !== 'string') return null
+  const value = prop.value_string
+  return value && value.trim() !== '' ? value : null
+}
+
+export function firstDateProperty(note: CollectionNote): { name: string; value: string } | null {
+  const prop = note.properties.find(p => p.type === 'datetime' && p.value_datetime)
+  return prop ? { name: prop.name, value: prop.value_datetime as string } : null
+}
+
 export const UNGROUPED_LABEL = 'No value'
 
 /**

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -184,6 +184,9 @@ export interface CollectionNote {
   title: string
   properties: RawNoteProperty[]
   tags?: CollectionTag[]
+  checklist_total?: number
+  checklist_done?: number
+  comments_count?: number
 }
 
 export interface CollectionPage {

--- a/tests/Feature/MilestoneCFinalTest.php
+++ b/tests/Feature/MilestoneCFinalTest.php
@@ -139,4 +139,40 @@ final class MilestoneCFinalTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('data.0.tags.0.name', 'urgent');
     }
+
+    public function test_collections_response_includes_checklist_progress_and_comment_count(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'test-card-face', 'name' => 'Test Card Face']);
+        $vaultPath = storage_path('app/vaults/m_c_card_face_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'card-face',
+            'name' => 'Card Face Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+        $storage->write($workspace, 'checklist.md', "# Checklist\n\n- [x] done one\n- [ ] todo one\n- [ ] todo two\n");
+
+        $note = Note::where('workspace_id', $workspace->id)->where('path', 'checklist.md')->firstOrFail();
+        NoteComment::create([
+            'workspace_id' => $workspace->id,
+            'note_id' => $note->id,
+            'user_id' => $admin->id,
+            'actor_name' => $admin->name,
+            'content' => 'A comment',
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->getJson("/api/workspaces/{$workspace->id}/collections");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.checklist_total', 3)
+            ->assertJsonPath('data.0.checklist_done', 1)
+            ->assertJsonPath('data.0.comments_count', 1);
+    }
 }


### PR DESCRIPTION
## Summary
- Card face shows a cover image (existing "cover" note property), a due-date badge (first datetime property), checklist progress, and comment count
- Checklist progress computed server-side from the note's raw markdown body (already stored verbatim in `search_content`), no extra file I/O
- Comment count via new `Note::comments()` relation + `withCount`

Closes #302

## Test plan
- [x] `collectionUtils.spec.ts` (12/12, 4 new)
- [x] `CollectionsBoardView.spec.ts` (14/14, 1 new)
- [x] `MilestoneCFinalTest` (4/4, 1 new)
- [x] Full frontend suite (388/388)
- [x] Full backend suite (170/170)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>