### PR TITLE
feat: multiple boards / saved views (#303)

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Models\Board;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class BoardController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider
+    ) {}
+
+    public function index(Request $request, int $workspaceId): JsonResponse
+    {
+        if ($denied = $this->authorize($request, $workspaceId)) {
+            return $denied;
+        }
+
+        $boards = Board::query()
+            ->where('workspace_id', $workspaceId)
+            ->orderBy('sort_position')
+            ->orderBy('id')
+            ->get();
+
+        return response()->json(['data' => $boards]);
+    }
+
+    public function store(Request $request, int $workspaceId): JsonResponse
+    {
+        if ($denied = $this->authorize($request, $workspaceId)) {
+            return $denied;
+        }
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'group_property' => ['nullable', 'string', 'max:255'],
+            'filter_property' => ['nullable', 'string', 'max:255'],
+            'filter_value' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $board = Board::create([
+            'workspace_id' => $workspaceId,
+            'name' => $validated['name'],
+            'group_property' => $validated['group_property'] ?? null,
+            'filter_property' => $validated['filter_property'] ?? null,
+            'filter_value' => $validated['filter_value'] ?? null,
+            'sort_position' => Board::query()->where('workspace_id', $workspaceId)->count(),
+        ]);
+
+        return response()->json(['data' => $board], 201);
+    }
+
+    public function update(Request $request, int $workspaceId, int $boardId): JsonResponse
+    {
+        if ($denied = $this->authorize($request, $workspaceId)) {
+            return $denied;
+        }
+
+        $board = Board::query()->where('workspace_id', $workspaceId)->find($boardId);
+        if (! $board) {
+            return response()->json(['message' => 'Board not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'group_property' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'filter_property' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'filter_value' => ['sometimes', 'nullable', 'string', 'max:255'],
+        ]);
+
+        $board->update($validated);
+
+        return response()->json(['data' => $board]);
+    }
+
+    public function destroy(Request $request, int $workspaceId, int $boardId): JsonResponse
+    {
+        if ($denied = $this->authorize($request, $workspaceId)) {
+            return $denied;
+        }
+
+        $board = Board::query()->where('workspace_id', $workspaceId)->find($boardId);
+        if (! $board) {
+            return response()->json(['message' => 'Board not found.'], 404);
+        }
+
+        $board->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function authorize(Request $request, int $workspaceId): ?JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        return null;
+    }
+}

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Board extends Model
+{
+    protected $fillable = [
+        'workspace_id',
+        'name',
+        'group_property',
+        'filter_property',
+        'filter_value',
+        'sort_position',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/database/migrations/2026_08_04_000000_create_boards_table.php
+++ b/database/migrations/2026_08_04_000000_create_boards_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('boards')) {
+            Schema::create('boards', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+                $table->string('name');
+                $table->string('group_property')->nullable();
+                $table->string('filter_property')->nullable();
+                $table->string('filter_value')->nullable();
+                $table->integer('sort_position')->default(0);
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('boards');
+    }
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -119,17 +119,26 @@
       />
 
       <!-- Board (Collections) View Mode -->
-      <CollectionsBoardView
-        v-else-if="isBoardViewActive"
-        :page="collectionPage"
-        :loading="collectionLoading"
-        :group-property="collectionGroupProperty"
-        @select-note="handleSelectNote"
-        @page-change="handleCollectionPageChange"
-        @group-change="handleCollectionGroupChange"
-        @move-card="handleCollectionMoveCard"
-        @create-card="handleCollectionCreateCard"
-      />
+      <div v-else-if="isBoardViewActive" class="board-view-wrapper">
+        <BoardSwitcher
+          :boards="boards"
+          :active-board-id="activeBoardId"
+          @select-board="handleSelectBoard"
+          @create-board="handleCreateBoard"
+          @rename-board="handleRenameBoard"
+          @delete-board="handleDeleteBoard"
+        />
+        <CollectionsBoardView
+          :page="collectionPage"
+          :loading="collectionLoading"
+          :group-property="collectionGroupProperty"
+          @select-note="handleSelectNote"
+          @page-change="handleCollectionPageChange"
+          @group-change="handleCollectionGroupChange"
+          @move-card="handleCollectionMoveCard"
+          @create-card="handleCollectionCreateCard"
+        />
+      </div>
 
       <!-- Calendar (Collections) View Mode -->
       <CollectionsCalendarView
@@ -275,9 +284,14 @@ import {
   getNotifications,
   markNotificationRead,
   deleteNotification,
-  getAuthConfig
+  getAuthConfig,
+  getBoards,
+  createBoard,
+  updateBoard,
+  deleteBoard
 } from './services/api'
-import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition } from './services/types'
+import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition, Board } from './services/types'
+import BoardSwitcher from './components/BoardSwitcher.vue'
 import { APP_VERSION } from './version'
 import { resolveWikilinkTarget } from './services/wikilinks'
 import TabStrip from './components/TabStrip.vue'
@@ -372,6 +386,8 @@ const collectionSortKey = ref<string | null>(null)
 const collectionSortDir = ref<'asc' | 'desc'>('asc')
 const collectionGroupProperty = ref<string | null>(null)
 const collectionDateProperty = ref<string | null>(null)
+const boards = ref<Board[]>([])
+const activeBoardId = ref<number | null>(null)
 
 const availableTagsForSearch = computed(() => {
   const tagSet = new Set<string>()
@@ -684,6 +700,66 @@ async function handleToggleBoardView() {
     isTableViewActive.value = false
     isCalendarViewActive.value = false
     await refreshCollection()
+    await refreshBoards()
+  }
+}
+
+async function refreshBoards() {
+  if (!activeWorkspaceId.value) return
+  try {
+    boards.value = await getBoards(activeWorkspaceId.value)
+  } catch (err) {
+    console.error('Failed to load boards:', err)
+  }
+}
+
+async function handleSelectBoard(boardId: number | null) {
+  activeBoardId.value = boardId
+  const board = boards.value.find(b => b.id === boardId)
+  collectionGroupProperty.value = board?.group_property || null
+  collectionFilterProperty.value = board?.filter_property || ''
+  collectionFilterValue.value = board?.filter_value || ''
+  await refreshCollection(1)
+}
+
+async function handleCreateBoard(name: string) {
+  if (!activeWorkspaceId.value) return
+  try {
+    const board = await createBoard(activeWorkspaceId.value, {
+      name,
+      group_property: collectionGroupProperty.value,
+      filter_property: collectionFilterProperty.value || null,
+      filter_value: collectionFilterValue.value || null,
+    })
+    boards.value.push(board)
+    activeBoardId.value = board.id
+  } catch (err) {
+    console.error('Failed to create board:', err)
+  }
+}
+
+async function handleRenameBoard(boardId: number, name: string) {
+  if (!activeWorkspaceId.value) return
+  try {
+    const board = await updateBoard(activeWorkspaceId.value, boardId, { name })
+    const index = boards.value.findIndex(b => b.id === boardId)
+    if (index !== -1) boards.value[index] = board
+  } catch (err) {
+    console.error('Failed to rename board:', err)
+  }
+}
+
+async function handleDeleteBoard(boardId: number) {
+  if (!activeWorkspaceId.value) return
+  if (!confirm('Delete this board? This cannot be undone.')) return
+  try {
+    await deleteBoard(activeWorkspaceId.value, boardId)
+    boards.value = boards.value.filter(b => b.id !== boardId)
+    if (activeBoardId.value === boardId) {
+      activeBoardId.value = null
+    }
+  } catch (err) {
+    console.error('Failed to delete board:', err)
   }
 }
 
@@ -735,8 +811,15 @@ function handleCollectionSort(key: string) {
   }
 }
 
-function handleCollectionGroupChange(property: string) {
+async function handleCollectionGroupChange(property: string) {
   collectionGroupProperty.value = property || null
+  if (activeWorkspaceId.value && activeBoardId.value !== null) {
+    try {
+      await updateBoard(activeWorkspaceId.value, activeBoardId.value, { group_property: collectionGroupProperty.value })
+    } catch (err) {
+      console.error('Failed to save board view:', err)
+    }
+  }
 }
 
 async function handleCollectionCreateCard(title: string, columnValue: string) {
@@ -983,6 +1066,18 @@ async function handleWikilinkNavigation(target: string) {
 </script>
 
 <style>
+.board-view-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: var(--space-6) var(--space-6) 0;
+}
+
+.board-view-wrapper > .collections-board-view {
+  padding: 0;
+}
+
 /* Global reset */
 *, *::before, *::after {
   box-sizing: border-box;

--- a/frontend/src/BoardSwitcher.spec.ts
+++ b/frontend/src/BoardSwitcher.spec.ts
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import BoardSwitcher from './components/BoardSwitcher.vue'
+import type { Board } from './services/types'
+
+const boards: Board[] = [
+  { id: 1, workspace_id: 1, name: 'Sprint', group_property: 'status', filter_property: null, filter_value: null, sort_position: 0 },
+  { id: 2, workspace_id: 1, name: 'Roadmap', group_property: 'quarter', filter_property: null, filter_value: null, sort_position: 1 },
+]
+
+describe('BoardSwitcher', () => {
+  it('lists an unsaved option plus every board', () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: null } })
+    const options = wrapper.findAll('option').map(o => o.text())
+    expect(options).toEqual(['Unsaved view', 'Sprint', 'Roadmap'])
+  })
+
+  it('emits select-board with the board id on change', async () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: null } })
+    await wrapper.get('[data-testid="board-switcher-select"]').setValue('2')
+    expect(wrapper.emitted('select-board')![0]).toEqual([2])
+  })
+
+  it('emits select-board with null when switching back to unsaved', async () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: 1 } })
+    await wrapper.get('[data-testid="board-switcher-select"]').setValue('')
+    expect(wrapper.emitted('select-board')![0]).toEqual([null])
+  })
+
+  it('emits create-board with the entered name', async () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: null } })
+    await wrapper.get('[data-testid="board-new-button"]').trigger('click')
+    await wrapper.get('[data-testid="board-new-input"]').setValue('Backlog')
+    await wrapper.get('[data-testid="board-new-form"]').trigger('submit')
+    expect(wrapper.emitted('create-board')![0]).toEqual(['Backlog'])
+  })
+
+  it('shows rename and delete controls only when a board is active', () => {
+    const unsaved = mount(BoardSwitcher, { props: { boards, activeBoardId: null } })
+    expect(unsaved.find('[data-testid="board-rename-button"]').exists()).toBe(false)
+    expect(unsaved.find('[data-testid="board-delete-button"]').exists()).toBe(false)
+
+    const active = mount(BoardSwitcher, { props: { boards, activeBoardId: 1 } })
+    expect(active.find('[data-testid="board-rename-button"]').exists()).toBe(true)
+    expect(active.find('[data-testid="board-delete-button"]').exists()).toBe(true)
+  })
+
+  it('emits rename-board with the new name', async () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: 1 } })
+    await wrapper.get('[data-testid="board-rename-button"]').trigger('click')
+    await wrapper.get('[data-testid="board-rename-input"]').setValue('Sprint 2')
+    await wrapper.get('[data-testid="board-rename-form"]').trigger('submit')
+    expect(wrapper.emitted('rename-board')![0]).toEqual([1, 'Sprint 2'])
+  })
+
+  it('emits delete-board when delete is confirmed', async () => {
+    const wrapper = mount(BoardSwitcher, { props: { boards, activeBoardId: 1 } })
+    await wrapper.get('[data-testid="board-delete-button"]').trigger('click')
+    expect(wrapper.emitted('delete-board')![0]).toEqual([1])
+  })
+})

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -15,7 +15,7 @@ vi.mock('axios', () => {
   }
 })
 
-import { moveNote, reorderNoteTree, getFolderPositions } from './services/api'
+import { moveNote, reorderNoteTree, getFolderPositions, createBoard, updateBoard, deleteBoard } from './services/api'
 import axios from 'axios'
 
 const instance = (axios.create as ReturnType<typeof vi.fn>).mock.results[0].value
@@ -43,5 +43,20 @@ describe('note-tree API functions', () => {
   it('getFolderPositions gets the order endpoint and returns the data array', async () => {
     const result = await getFolderPositions(1)
     expect(result).toEqual([{ folder_path: 'docs', sort_position: 0 }])
+  })
+
+  it('createBoard posts the board attrs to the boards endpoint', async () => {
+    await createBoard(1, { name: 'Sprint', group_property: 'status' })
+    expect(instance.post).toHaveBeenCalledWith('/workspaces/1/boards', { name: 'Sprint', group_property: 'status' })
+  })
+
+  it('updateBoard puts the changed attrs to the board endpoint', async () => {
+    await updateBoard(1, 5, { name: 'Renamed' })
+    expect(instance.put).toHaveBeenCalledWith('/workspaces/1/boards/5', { name: 'Renamed' })
+  })
+
+  it('deleteBoard deletes the board endpoint', async () => {
+    await deleteBoard(1, 5)
+    expect(instance.delete).toHaveBeenCalledWith('/workspaces/1/boards/5')
   })
 })

--- a/frontend/src/components/BoardSwitcher.vue
+++ b/frontend/src/components/BoardSwitcher.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="board-switcher">
+    <select
+      class="board-switcher-select"
+      data-testid="board-switcher-select"
+      :value="activeBoardId ?? ''"
+      aria-label="Switch board"
+      @change="handleSelect"
+    >
+      <option value="">Unsaved view</option>
+      <option v-for="board in boards" :key="board.id" :value="board.id">{{ board.name }}</option>
+    </select>
+
+    <form
+      v-if="isCreating"
+      class="board-name-form"
+      data-testid="board-new-form"
+      @submit.prevent="submitCreate"
+    >
+      <input
+        v-model="draftName"
+        type="text"
+        placeholder="Board name"
+        aria-label="New board name"
+        data-testid="board-new-input"
+        class="board-name-input"
+        autofocus
+      />
+      <button type="submit" class="btn-board-confirm">Create</button>
+      <button type="button" class="btn-board-cancel" @click="isCreating = false">Cancel</button>
+    </form>
+    <button v-else type="button" class="btn-board-action" data-testid="board-new-button" @click="startCreate">
+      + New board
+    </button>
+
+    <template v-if="activeBoardId !== null">
+      <form
+        v-if="isRenaming"
+        class="board-name-form"
+        data-testid="board-rename-form"
+        @submit.prevent="submitRename"
+      >
+        <input
+          v-model="draftName"
+          type="text"
+          placeholder="Board name"
+          aria-label="Rename board"
+          data-testid="board-rename-input"
+          class="board-name-input"
+          autofocus
+        />
+        <button type="submit" class="btn-board-confirm">Save</button>
+        <button type="button" class="btn-board-cancel" @click="isRenaming = false">Cancel</button>
+      </form>
+      <button v-else type="button" class="btn-board-action" data-testid="board-rename-button" @click="startRename">
+        Rename
+      </button>
+      <button
+        type="button"
+        class="btn-board-action btn-board-delete"
+        data-testid="board-delete-button"
+        @click="$emit('delete-board', activeBoardId)"
+      >
+        Delete
+      </button>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { Board } from '../services/types'
+
+const props = defineProps<{
+  boards: Board[]
+  activeBoardId: number | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-board', boardId: number | null): void
+  (e: 'create-board', name: string): void
+  (e: 'rename-board', boardId: number, name: string): void
+  (e: 'delete-board', boardId: number): void
+}>()
+
+const isCreating = ref(false)
+const isRenaming = ref(false)
+const draftName = ref('')
+
+function handleSelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  emit('select-board', value === '' ? null : Number(value))
+}
+
+function startCreate() {
+  isCreating.value = true
+  draftName.value = ''
+}
+
+function submitCreate() {
+  const name = draftName.value.trim()
+  if (!name) return
+  emit('create-board', name)
+  isCreating.value = false
+  draftName.value = ''
+}
+
+function startRename() {
+  const current = props.boards.find(b => b.id === props.activeBoardId)
+  draftName.value = current?.name ?? ''
+  isRenaming.value = true
+}
+
+function submitRename() {
+  const name = draftName.value.trim()
+  if (!name || props.activeBoardId === null) return
+  emit('rename-board', props.activeBoardId, name)
+  isRenaming.value = false
+  draftName.value = ''
+}
+</script>
+
+<style scoped>
+.board-switcher {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-2);
+}
+
+.board-switcher-select {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.board-name-form {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.board-name-input {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.btn-board-action,
+.btn-board-confirm,
+.btn-board-cancel {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text-muted);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.btn-board-confirm {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+}
+
+.btn-board-delete:hover {
+  background: var(--color-danger, #d33);
+  color: var(--color-neutral-0);
+}
+</style>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem } from './types'
+import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -316,6 +316,32 @@ export async function getCollection(
 
   const response = await api.get<CollectionPage>(`/workspaces/${workspaceId}/collections?${params.toString()}`)
   return response.data
+}
+
+export async function getBoards(workspaceId: number): Promise<Board[]> {
+  const response = await api.get<{ data: Board[] }>(`/workspaces/${workspaceId}/boards`)
+  return response.data.data
+}
+
+export async function createBoard(
+  workspaceId: number,
+  attrs: { name: string; group_property?: string | null; filter_property?: string | null; filter_value?: string | null }
+): Promise<Board> {
+  const response = await api.post<{ data: Board }>(`/workspaces/${workspaceId}/boards`, attrs)
+  return response.data.data
+}
+
+export async function updateBoard(
+  workspaceId: number,
+  boardId: number,
+  attrs: Partial<{ name: string; group_property: string | null; filter_property: string | null; filter_value: string | null }>
+): Promise<Board> {
+  const response = await api.put<{ data: Board }>(`/workspaces/${workspaceId}/boards/${boardId}`, attrs)
+  return response.data.data
+}
+
+export async function deleteBoard(workspaceId: number, boardId: number): Promise<void> {
+  await api.delete(`/workspaces/${workspaceId}/boards/${boardId}`)
 }
 
 export async function getLinkReport(workspaceId: number): Promise<LinkReport> {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -189,6 +189,16 @@ export interface CollectionNote {
   comments_count?: number
 }
 
+export interface Board {
+  id: number
+  workspace_id: number
+  name: string
+  group_property: string | null
+  filter_property: string | null
+  filter_value: string | null
+  sort_position: number
+}
+
 export interface CollectionPage {
   data: CollectionNote[]
   current_page: number

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,10 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::delete('/workspaces/{workspace}/notifications/{notification}', [\App\Http\Controllers\WorkspaceNotificationController::class, 'destroy']);
 
     Route::get('/workspaces/{workspace}/collections', [\App\Http\Controllers\WorkspaceCollectionController::class, 'index']);
+    Route::get('/workspaces/{workspace}/boards', [\App\Http\Controllers\BoardController::class, 'index']);
+    Route::post('/workspaces/{workspace}/boards', [\App\Http\Controllers\BoardController::class, 'store']);
+    Route::put('/workspaces/{workspace}/boards/{board}', [\App\Http\Controllers\BoardController::class, 'update']);
+    Route::delete('/workspaces/{workspace}/boards/{board}', [\App\Http\Controllers\BoardController::class, 'destroy']);
     Route::post('/workspaces/{workspace}/notes', [WorkspaceNoteController::class, 'store']);
     Route::post('/workspaces/{workspace}/notes/from-template', [\App\Http\Controllers\WorkspaceTemplateController::class, 'createFromTemplate']);
     Route::match(['get', 'post'], '/workspaces/{workspace}/daily/{date?}', [\App\Http\Controllers\WorkspaceTemplateController::class, 'dailyNote']);

--- a/tests/Feature/BoardControllerTest.php
+++ b/tests/Feature/BoardControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Board;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class BoardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeWorkspace(): Workspace
+    {
+        $tenant = Tenant::create(['slug' => 'board-test-'.uniqid(), 'name' => 'Board Test']);
+        $vaultPath = storage_path('app/vaults/board_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        return Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'board-'.uniqid(),
+            'name' => 'Board Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+    }
+
+    public function test_lists_boards_for_a_workspace_ordered_by_sort_position(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+        Board::create(['workspace_id' => $workspace->id, 'name' => 'Second', 'sort_position' => 1]);
+        Board::create(['workspace_id' => $workspace->id, 'name' => 'First', 'sort_position' => 0]);
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/boards");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.name', 'First')
+            ->assertJsonPath('data.1.name', 'Second');
+    }
+
+    public function test_creates_a_board(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+
+        $response = $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/boards", [
+            'name' => 'Sprint Board',
+            'group_property' => 'status',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', 'Sprint Board')
+            ->assertJsonPath('data.group_property', 'status');
+
+        $this->assertDatabaseHas('boards', ['workspace_id' => $workspace->id, 'name' => 'Sprint Board']);
+    }
+
+    public function test_creating_a_board_requires_a_name(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+
+        $response = $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/boards", []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_updates_a_boards_view_configuration(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+        $board = Board::create(['workspace_id' => $workspace->id, 'name' => 'Original']);
+
+        $response = $this->actingAs($admin)->putJson("/api/workspaces/{$workspace->id}/boards/{$board->id}", [
+            'name' => 'Renamed',
+            'group_property' => 'priority',
+            'filter_property' => 'assignee',
+            'filter_value' => 'alice',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'Renamed')
+            ->assertJsonPath('data.group_property', 'priority')
+            ->assertJsonPath('data.filter_property', 'assignee')
+            ->assertJsonPath('data.filter_value', 'alice');
+    }
+
+    public function test_deletes_a_board(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+        $board = Board::create(['workspace_id' => $workspace->id, 'name' => 'Doomed']);
+
+        $response = $this->actingAs($admin)->deleteJson("/api/workspaces/{$workspace->id}/boards/{$board->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('boards', ['id' => $board->id]);
+    }
+
+    public function test_cannot_manage_boards_in_a_workspace_the_user_is_unauthorized_for(): void
+    {
+        $admin = User::factory()->create(['is_admin' => false]);
+        $workspace = $this->makeWorkspace();
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/boards");
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- New `boards` table + `Board` model, scoped per workspace
- `BoardController` (index/store/update/destroy), workspace-authorized
- `BoardSwitcher.vue`: switch/create/rename/delete saved boards from the board toolbar
- Changing the group property while a board is active auto-saves it back to that board

Closes #303. Prerequisite for #301 (column configuration, scoped per board).

## Test plan
- [x] `BoardControllerTest` (6/6, new)
- [x] `BoardSwitcher.spec.ts` (7/7, new)
- [x] `api.spec.ts` (6/6, 3 new)
- [x] Full frontend suite (398/398)
- [x] Full backend suite (176/176)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>