### PR TITLE
feat: per-board column configuration (#301)

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -39,6 +39,7 @@ final class BoardController extends Controller
             'group_property' => ['nullable', 'string', 'max:255'],
             'filter_property' => ['nullable', 'string', 'max:255'],
             'filter_value' => ['nullable', 'string', 'max:255'],
+            'column_config' => ['nullable', 'array'],
         ]);
 
         $board = Board::create([
@@ -47,6 +48,7 @@ final class BoardController extends Controller
             'group_property' => $validated['group_property'] ?? null,
             'filter_property' => $validated['filter_property'] ?? null,
             'filter_value' => $validated['filter_value'] ?? null,
+            'column_config' => $validated['column_config'] ?? null,
             'sort_position' => Board::query()->where('workspace_id', $workspaceId)->count(),
         ]);
 
@@ -69,6 +71,7 @@ final class BoardController extends Controller
             'group_property' => ['sometimes', 'nullable', 'string', 'max:255'],
             'filter_property' => ['sometimes', 'nullable', 'string', 'max:255'],
             'filter_value' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'column_config' => ['sometimes', 'nullable', 'array'],
         ]);
 
         $board->update($validated);

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -13,8 +13,16 @@ class Board extends Model
         'group_property',
         'filter_property',
         'filter_value',
+        'column_config',
         'sort_position',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'column_config' => 'array',
+        ];
+    }
 
     public function workspace(): BelongsTo
     {

--- a/database/migrations/2026_08_04_000001_add_column_config_to_boards_table.php
+++ b/database/migrations/2026_08_04_000001_add_column_config_to_boards_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('boards', 'column_config')) {
+            Schema::table('boards', function (Blueprint $table) {
+                $table->json('column_config')->nullable()->after('filter_value');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->dropColumn('column_config');
+        });
+    }
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,11 +132,16 @@
           :page="collectionPage"
           :loading="collectionLoading"
           :group-property="collectionGroupProperty"
+          :configurable="activeBoardId !== null"
+          :column-config="activeBoardColumnConfig"
           @select-note="handleSelectNote"
           @page-change="handleCollectionPageChange"
           @group-change="handleCollectionGroupChange"
           @move-card="handleCollectionMoveCard"
           @create-card="handleCollectionCreateCard"
+          @reorder-columns="handleReorderColumns"
+          @toggle-column-collapse="handleToggleColumnCollapse"
+          @update-column="handleUpdateColumn"
         />
       </div>
 
@@ -290,7 +295,7 @@ import {
   updateBoard,
   deleteBoard
 } from './services/api'
-import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition, Board } from './services/types'
+import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, SearchFilters, AttachmentItem, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, FolderPosition, Board, BoardColumnConfig } from './services/types'
 import BoardSwitcher from './components/BoardSwitcher.vue'
 import { APP_VERSION } from './version'
 import { resolveWikilinkTarget } from './services/wikilinks'
@@ -711,6 +716,47 @@ async function refreshBoards() {
   } catch (err) {
     console.error('Failed to load boards:', err)
   }
+}
+
+const activeBoardColumnConfig = computed(() => {
+  const board = boards.value.find(b => b.id === activeBoardId.value)
+  return board?.column_config ?? null
+})
+
+async function persistColumnConfig(config: BoardColumnConfig[]) {
+  if (!activeWorkspaceId.value || activeBoardId.value === null) return
+  try {
+    const board = await updateBoard(activeWorkspaceId.value, activeBoardId.value, { column_config: config })
+    const index = boards.value.findIndex(b => b.id === board.id)
+    if (index !== -1) boards.value[index] = board
+  } catch (err) {
+    console.error('Failed to save column configuration:', err)
+  }
+}
+
+function handleReorderColumns(keys: string[]) {
+  const existing = activeBoardColumnConfig.value ?? []
+  const byKey = new Map(existing.map(c => [c.key, c]))
+  const config = keys.map(key => byKey.get(key) ?? { key })
+  persistColumnConfig(config)
+}
+
+function handleToggleColumnCollapse(key: string) {
+  const existing = activeBoardColumnConfig.value ?? []
+  const found = existing.find(c => c.key === key)
+  const config = found
+    ? existing.map(c => (c.key === key ? { ...c, collapsed: !c.collapsed } : c))
+    : [...existing, { key, collapsed: true }]
+  persistColumnConfig(config)
+}
+
+function handleUpdateColumn(key: string, attrs: { label: string; color: string | null; wip_limit: number | null }) {
+  const existing = activeBoardColumnConfig.value ?? []
+  const found = existing.find(c => c.key === key)
+  const config = found
+    ? existing.map(c => (c.key === key ? { ...c, ...attrs } : c))
+    : [...existing, { key, ...attrs }]
+  persistColumnConfig(config)
 }
 
 async function handleSelectBoard(boardId: number | null) {

--- a/frontend/src/BoardSwitcher.spec.ts
+++ b/frontend/src/BoardSwitcher.spec.ts
@@ -4,8 +4,8 @@ import BoardSwitcher from './components/BoardSwitcher.vue'
 import type { Board } from './services/types'
 
 const boards: Board[] = [
-  { id: 1, workspace_id: 1, name: 'Sprint', group_property: 'status', filter_property: null, filter_value: null, sort_position: 0 },
-  { id: 2, workspace_id: 1, name: 'Roadmap', group_property: 'quarter', filter_property: null, filter_value: null, sort_position: 1 },
+  { id: 1, workspace_id: 1, name: 'Sprint', group_property: 'status', filter_property: null, filter_value: null, column_config: null, sort_position: 0 },
+  { id: 2, workspace_id: 1, name: 'Roadmap', group_property: 'quarter', filter_property: null, filter_value: null, column_config: null, sort_position: 1 },
 ]
 
 describe('BoardSwitcher', () => {

--- a/frontend/src/CollectionsBoardView.spec.ts
+++ b/frontend/src/CollectionsBoardView.spec.ts
@@ -144,6 +144,65 @@ describe('CollectionsBoardView', () => {
     expect(cards[0].text()).toContain('A')
   })
 
+  it('does not show column config controls by default', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    expect(wrapper.find('[data-testid="board-column-move-right"]').exists()).toBe(false)
+  })
+
+  it('shows reorder, collapse, and edit controls per column when configurable', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status', configurable: true } })
+    expect(wrapper.findAll('[data-testid="board-column-move-left"]').length).toBeGreaterThan(0)
+    expect(wrapper.findAll('[data-testid="board-column-move-right"]').length).toBeGreaterThan(0)
+    expect(wrapper.findAll('[data-testid="board-column-collapse-toggle"]').length).toBe(3)
+    expect(wrapper.findAll('[data-testid="board-column-edit-button"]').length).toBe(3)
+  })
+
+  it('emits reorder-columns with the swapped key order', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status', configurable: true } })
+    const firstColumn = wrapper.findAll('[data-testid="board-column"]')[0]
+    await firstColumn.get('[data-testid="board-column-move-right"]').trigger('click')
+    expect(wrapper.emitted('reorder-columns')![0][0]).toEqual(['draft', 'done', 'No value'])
+  })
+
+  it('emits toggle-column-collapse with the column key', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status', configurable: true } })
+    const firstColumn = wrapper.findAll('[data-testid="board-column"]')[0]
+    await firstColumn.get('[data-testid="board-column-collapse-toggle"]').trigger('click')
+    expect(wrapper.emitted('toggle-column-collapse')).toBeTruthy()
+  })
+
+  it('hides the column body when the column is collapsed', () => {
+    const wrapper = mount(CollectionsBoardView, {
+      props: {
+        page, groupProperty: 'status', configurable: true,
+        columnConfig: [{ key: 'draft', collapsed: true }],
+      },
+    })
+    const draftColumn = wrapper.findAll('[data-testid="board-column"]').find(c => c.text().includes('draft'))!
+    expect(draftColumn.find('[data-testid="board-column-body"]').exists()).toBe(false)
+  })
+
+  it('emits update-column with the edited label, color, and wip limit', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status', configurable: true } })
+    const draftColumn = wrapper.findAll('[data-testid="board-column"]').find(c => c.text().includes('draft'))!
+    await draftColumn.get('[data-testid="board-column-edit-button"]').trigger('click')
+    await draftColumn.get('[data-testid="board-column-label-input"]').setValue('In Progress')
+    await draftColumn.get('[data-testid="board-column-wip-input"]').setValue('2')
+    await draftColumn.get('[data-testid="board-column-edit-form"]').trigger('submit')
+    expect(wrapper.emitted('update-column')![0]).toEqual(['draft', { label: 'In Progress', color: null, wip_limit: 2 }])
+  })
+
+  it('flags a column over its WIP limit', () => {
+    const wrapper = mount(CollectionsBoardView, {
+      props: {
+        page, groupProperty: 'status', configurable: true,
+        columnConfig: [{ key: 'draft', wip_limit: 0 }],
+      },
+    })
+    const draftColumn = wrapper.findAll('[data-testid="board-column"]').find(c => c.text().includes('draft'))!
+    expect(draftColumn.find('[data-testid="board-column-wip-warning"]').exists()).toBe(true)
+  })
+
   it('does not emit create-card for a blank title', async () => {
     const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
     const draftColumn = wrapper.findAll('[data-testid="board-column"]')

--- a/frontend/src/collectionUtils.spec.ts
+++ b/frontend/src/collectionUtils.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { allTagNames, coverImageUrl, filterNotesByTag, firstDateProperty, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import { allTagNames, applyColumnConfig, coverImageUrl, filterNotesByTag, firstDateProperty, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import type { BoardColumn } from './services/collectionUtils'
 import type { CollectionNote, CollectionPage, RawNoteProperty } from './services/types'
 
 function makeNote(id: number, tags: string[], properties: RawNoteProperty[] = []): CollectionNote {
@@ -98,5 +99,36 @@ describe('firstDateProperty', () => {
 
   it('returns null when there is no datetime property', () => {
     expect(firstDateProperty(makeNote(1, [], [stringProp('status', 'open')]))).toBeNull()
+  })
+})
+
+describe('applyColumnConfig', () => {
+  const columns: BoardColumn[] = [
+    { key: 'draft', label: 'draft', notes: [] },
+    { key: 'done', label: 'done', notes: [] },
+    { key: 'review', label: 'review', notes: [] },
+  ]
+
+  it('returns derived columns unchanged, defaulted, when there is no config', () => {
+    expect(applyColumnConfig(columns, null)).toEqual([
+      { key: 'draft', label: 'draft', notes: [], color: null, wipLimit: null, collapsed: false },
+      { key: 'done', label: 'done', notes: [], color: null, wipLimit: null, collapsed: false },
+      { key: 'review', label: 'review', notes: [], color: null, wipLimit: null, collapsed: false },
+    ])
+  })
+
+  it('reorders columns to match the config order and applies overrides', () => {
+    const result = applyColumnConfig(columns, [
+      { key: 'done', label: 'Done!', color: '#22c55e', wip_limit: 3, collapsed: false },
+      { key: 'draft', collapsed: true },
+    ])
+    expect(result.map(c => c.key)).toEqual(['done', 'draft', 'review'])
+    expect(result[0]).toMatchObject({ label: 'Done!', color: '#22c55e', wipLimit: 3 })
+    expect(result[1]).toMatchObject({ label: 'draft', collapsed: true })
+  })
+
+  it('drops config entries for columns no longer present in the data', () => {
+    const result = applyColumnConfig(columns, [{ key: 'archived', label: 'Archived' }])
+    expect(result.map(c => c.key)).toEqual(['draft', 'done', 'review'])
   })
 })

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -45,12 +45,90 @@
     </div>
 
     <div v-else class="board-scroll">
-      <div v-for="column in columns" :key="column.key" class="board-column" data-testid="board-column">
+      <div
+        v-for="(column, index) in columns"
+        :key="column.key"
+        class="board-column"
+        :style="column.color ? { borderTopColor: column.color, borderTopWidth: '3px' } : {}"
+        data-testid="board-column"
+      >
         <div class="board-column-header">
+          <template v-if="configurable">
+            <button
+              type="button"
+              class="btn-column-reorder"
+              data-testid="board-column-move-left"
+              :disabled="index === 0"
+              @click="moveColumn(column.key, -1)"
+            >◀</button>
+          </template>
+          <button
+            v-if="configurable"
+            type="button"
+            class="btn-column-collapse"
+            data-testid="board-column-collapse-toggle"
+            @click="$emit('toggle-column-collapse', column.key)"
+          >{{ column.collapsed ? '▸' : '▾' }}</button>
           <span class="board-column-title">{{ column.label }}</span>
-          <span class="count-badge">{{ column.notes.length }}</span>
+          <span
+            class="count-badge"
+            :class="{ 'count-badge-over-limit': column.wipLimit !== null && column.notes.length > column.wipLimit }"
+            data-testid="board-column-wip-warning"
+            v-if="column.wipLimit !== null && column.notes.length > column.wipLimit"
+          >{{ column.notes.length }}/{{ column.wipLimit }}</span>
+          <span v-else class="count-badge">{{ column.notes.length }}</span>
+          <button
+            v-if="configurable"
+            type="button"
+            class="btn-column-edit"
+            data-testid="board-column-edit-button"
+            @click="openColumnEdit(column)"
+          >⚙</button>
+          <button
+            v-if="configurable"
+            type="button"
+            class="btn-column-reorder"
+            data-testid="board-column-move-right"
+            :disabled="index === columns.length - 1"
+            @click="moveColumn(column.key, 1)"
+          >▶</button>
         </div>
+        <form
+          v-if="editingColumnKey === column.key"
+          class="board-column-edit-form"
+          data-testid="board-column-edit-form"
+          @submit.prevent="submitColumnEdit(column.key)"
+        >
+          <input
+            v-model="columnEditLabel"
+            type="text"
+            placeholder="Column label"
+            aria-label="Column label"
+            data-testid="board-column-label-input"
+            class="column-edit-input"
+          />
+          <select v-model="columnEditColor" aria-label="Column color" data-testid="board-column-color-select" class="column-edit-input">
+            <option value="">No color</option>
+            <option value="#ef4444">Red</option>
+            <option value="#f59e0b">Amber</option>
+            <option value="#22c55e">Green</option>
+            <option value="#3b82f6">Blue</option>
+            <option value="#a855f7">Purple</option>
+          </select>
+          <input
+            v-model="columnEditWipLimit"
+            type="number"
+            min="0"
+            placeholder="WIP limit"
+            aria-label="WIP limit"
+            data-testid="board-column-wip-input"
+            class="column-edit-input"
+          />
+          <button type="submit" class="btn-add-card-confirm">Save</button>
+          <button type="button" class="btn-add-card-cancel" @click="editingColumnKey = null">Cancel</button>
+        </form>
         <div
+          v-if="!column.collapsed"
           class="board-column-body"
           data-testid="board-column-body"
           :data-column-key="column.key"
@@ -160,9 +238,10 @@
 <script setup lang="ts">
 import { computed, ref, watch, nextTick, onBeforeUnmount, onMounted } from 'vue'
 import Sortable from 'sortablejs'
-import type { CollectionPage } from '../services/types'
+import type { BoardColumnConfig, CollectionPage } from '../services/types'
 import {
   allTagNames,
+  applyColumnConfig,
   coverImageUrl,
   filterNotesByTag,
   firstDateProperty,
@@ -177,6 +256,8 @@ const props = defineProps<{
   page: CollectionPage
   loading?: boolean
   groupProperty?: string | null
+  configurable?: boolean
+  columnConfig?: BoardColumnConfig[] | null
 }>()
 
 const emit = defineEmits<{
@@ -185,6 +266,9 @@ const emit = defineEmits<{
   (e: 'group-change', property: string): void
   (e: 'move-card', noteId: number, newValue: string): void
   (e: 'create-card', title: string, columnValue: string): void
+  (e: 'reorder-columns', keys: string[]): void
+  (e: 'toggle-column-collapse', key: string): void
+  (e: 'update-column', key: string, attrs: { label: string; color: string | null; wip_limit: number | null }): void
 }>()
 
 const groupPropertyInput = ref(props.groupProperty || '')
@@ -217,8 +301,39 @@ const columns = computed(() => {
     if (b === UNGROUPED_LABEL) return -1
     return a.localeCompare(b)
   })
-  return sortedKeys.map(key => ({ key, label: key, notes: groups.get(key)! }))
+  const derived = sortedKeys.map(key => ({ key, label: key, notes: groups.get(key)! }))
+  return applyColumnConfig(derived, props.columnConfig)
 })
+
+const editingColumnKey = ref<string | null>(null)
+const columnEditLabel = ref('')
+const columnEditColor = ref('')
+const columnEditWipLimit = ref('')
+
+function moveColumn(key: string, direction: -1 | 1) {
+  const keys = columns.value.map(c => c.key)
+  const idx = keys.indexOf(key)
+  const swapIdx = idx + direction
+  if (swapIdx < 0 || swapIdx >= keys.length) return
+  ;[keys[idx], keys[swapIdx]] = [keys[swapIdx], keys[idx]]
+  emit('reorder-columns', keys)
+}
+
+function openColumnEdit(column: { key: string; label: string; color: string | null; wipLimit: number | null }) {
+  editingColumnKey.value = column.key
+  columnEditLabel.value = column.label
+  columnEditColor.value = column.color ?? ''
+  columnEditWipLimit.value = column.wipLimit !== null ? String(column.wipLimit) : ''
+}
+
+function submitColumnEdit(key: string) {
+  emit('update-column', key, {
+    label: columnEditLabel.value.trim(),
+    color: columnEditColor.value || null,
+    wip_limit: columnEditWipLimit.value !== '' ? Number(columnEditWipLimit.value) : null,
+  })
+  editingColumnKey.value = null
+}
 
 // Drag-and-drop between columns (#299): one Sortable instance per column
 // body, sharing a group so cards can move between them. onEnd resolves the
@@ -411,9 +526,49 @@ function submitAddCard(columnKey: string) {
   border-bottom: 1px solid var(--color-border);
 }
 
+.btn-column-reorder,
+.btn-column-collapse,
+.btn-column-edit {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0 var(--space-1);
+}
+
+.btn-column-reorder:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.count-badge-over-limit {
+  background: var(--color-danger, #d33);
+  color: var(--color-neutral-0);
+}
+
+.board-column-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.column-edit-input {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
 .board-column-title {
   font-weight: 600;
   font-size: 0.85rem;
+  flex: 1;
   color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -334,7 +334,7 @@ export async function createBoard(
 export async function updateBoard(
   workspaceId: number,
   boardId: number,
-  attrs: Partial<{ name: string; group_property: string | null; filter_property: string | null; filter_value: string | null }>
+  attrs: Partial<{ name: string; group_property: string | null; filter_property: string | null; filter_value: string | null; column_config: Board['column_config'] }>
 ): Promise<Board> {
   const response = await api.put<{ data: Board }>(`/workspaces/${workspaceId}/boards/${boardId}`, attrs)
   return response.data.data

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -1,4 +1,4 @@
-import type { CollectionNote, CollectionPage, RawNoteProperty } from './types'
+import type { BoardColumnConfig, CollectionNote, CollectionPage, RawNoteProperty } from './types'
 
 export function rawValue(prop: RawNoteProperty): string | number | boolean | unknown | null {
   switch (prop.type) {
@@ -60,6 +60,54 @@ export function coverImageUrl(note: CollectionNote): string | null {
 export function firstDateProperty(note: CollectionNote): { name: string; value: string } | null {
   const prop = note.properties.find(p => p.type === 'datetime' && p.value_datetime)
   return prop ? { name: prop.name, value: prop.value_datetime as string } : null
+}
+
+export interface BoardColumn {
+  key: string
+  label: string
+  notes: CollectionNote[]
+}
+
+export interface ConfiguredBoardColumn extends BoardColumn {
+  color: string | null
+  wipLimit: number | null
+  collapsed: boolean
+}
+
+/**
+ * Merges the derived columns (from distinct property values present in the
+ * page) with the board's persisted per-column config — order, label
+ * override, color, WIP limit, collapsed. Columns with no config keep their
+ * derived order, appended after configured ones. Config entries for values
+ * no longer present in the data are dropped rather than shown empty.
+ */
+export function applyColumnConfig(
+  columns: BoardColumn[],
+  config: BoardColumnConfig[] | null | undefined
+): ConfiguredBoardColumn[] {
+  const byKey = new Map(columns.map(c => [c.key, c]))
+  const configured: ConfiguredBoardColumn[] = []
+  const seen = new Set<string>()
+
+  for (const entry of config ?? []) {
+    const column = byKey.get(entry.key)
+    if (!column) continue
+    configured.push({
+      ...column,
+      label: entry.label || column.label,
+      color: entry.color ?? null,
+      wipLimit: entry.wip_limit ?? null,
+      collapsed: entry.collapsed ?? false,
+    })
+    seen.add(entry.key)
+  }
+
+  for (const column of columns) {
+    if (seen.has(column.key)) continue
+    configured.push({ ...column, color: null, wipLimit: null, collapsed: false })
+  }
+
+  return configured
 }
 
 export const UNGROUPED_LABEL = 'No value'

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -189,6 +189,14 @@ export interface CollectionNote {
   comments_count?: number
 }
 
+export interface BoardColumnConfig {
+  key: string
+  label?: string | null
+  color?: string | null
+  wip_limit?: number | null
+  collapsed?: boolean
+}
+
 export interface Board {
   id: number
   workspace_id: number
@@ -196,6 +204,7 @@ export interface Board {
   group_property: string | null
   filter_property: string | null
   filter_value: string | null
+  column_config: BoardColumnConfig[] | null
   sort_position: number
 }
 

--- a/tests/Feature/BoardControllerTest.php
+++ b/tests/Feature/BoardControllerTest.php
@@ -88,6 +88,29 @@ final class BoardControllerTest extends TestCase
             ->assertJsonPath('data.filter_value', 'alice');
     }
 
+    public function test_persists_column_configuration(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+        $board = Board::create(['workspace_id' => $workspace->id, 'name' => 'Original']);
+
+        $columnConfig = [
+            ['key' => 'done', 'label' => 'Done', 'color' => '#22c55e', 'wip_limit' => 3, 'collapsed' => false],
+            ['key' => 'draft', 'label' => 'Draft', 'color' => null, 'wip_limit' => null, 'collapsed' => true],
+        ];
+
+        $response = $this->actingAs($admin)->putJson("/api/workspaces/{$workspace->id}/boards/{$board->id}", [
+            'column_config' => $columnConfig,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.column_config.0.key', 'done')
+            ->assertJsonPath('data.column_config.0.wip_limit', 3)
+            ->assertJsonPath('data.column_config.1.collapsed', true);
+
+        $this->assertEquals($columnConfig, $board->fresh()->column_config);
+    }
+
     public function test_deletes_a_board(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);


### PR DESCRIPTION
## Summary
- New `column_config` JSON column on `boards`
- Columns can be reordered (◀/▶), renamed, colored, given a WIP limit, and collapsed
- Merge logic lives in a pure, unit-tested `applyColumnConfig()`
- Controls only appear when a saved board is active — an unsaved view has nothing to persist config to (this is why #301 was blocked on #303)

Closes #301

## Test plan
- [x] `BoardControllerTest` (7/7, 1 new)
- [x] `collectionUtils.spec.ts` (15/15, 3 new)
- [x] `CollectionsBoardView.spec.ts` (21/21, 7 new)
- [x] Full frontend suite (408/408)
- [x] Full backend suite (177/177)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>