### PR TITLE
feat: swimlanes / second grouping dimension on the board (#304)

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -37,6 +37,7 @@ final class BoardController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'group_property' => ['nullable', 'string', 'max:255'],
+            'swimlane_property' => ['nullable', 'string', 'max:255'],
             'filter_property' => ['nullable', 'string', 'max:255'],
             'filter_value' => ['nullable', 'string', 'max:255'],
             'column_config' => ['nullable', 'array'],
@@ -46,6 +47,7 @@ final class BoardController extends Controller
             'workspace_id' => $workspaceId,
             'name' => $validated['name'],
             'group_property' => $validated['group_property'] ?? null,
+            'swimlane_property' => $validated['swimlane_property'] ?? null,
             'filter_property' => $validated['filter_property'] ?? null,
             'filter_value' => $validated['filter_value'] ?? null,
             'column_config' => $validated['column_config'] ?? null,
@@ -69,6 +71,7 @@ final class BoardController extends Controller
         $validated = $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
             'group_property' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'swimlane_property' => ['sometimes', 'nullable', 'string', 'max:255'],
             'filter_property' => ['sometimes', 'nullable', 'string', 'max:255'],
             'filter_value' => ['sometimes', 'nullable', 'string', 'max:255'],
             'column_config' => ['sometimes', 'nullable', 'array'],

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -11,6 +11,7 @@ class Board extends Model
         'workspace_id',
         'name',
         'group_property',
+        'swimlane_property',
         'filter_property',
         'filter_value',
         'column_config',

--- a/database/migrations/2026_08_04_000002_add_swimlane_property_to_boards_table.php
+++ b/database/migrations/2026_08_04_000002_add_swimlane_property_to_boards_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('boards', 'swimlane_property')) {
+            Schema::table('boards', function (Blueprint $table) {
+                $table->string('swimlane_property')->nullable()->after('group_property');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->dropColumn('swimlane_property');
+        });
+    }
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,11 +132,13 @@
           :page="collectionPage"
           :loading="collectionLoading"
           :group-property="collectionGroupProperty"
+          :swimlane-property="collectionSwimlaneProperty"
           :configurable="activeBoardId !== null"
           :column-config="activeBoardColumnConfig"
           @select-note="handleSelectNote"
           @page-change="handleCollectionPageChange"
           @group-change="handleCollectionGroupChange"
+          @swimlane-change="handleCollectionSwimlaneChange"
           @move-card="handleCollectionMoveCard"
           @create-card="handleCollectionCreateCard"
           @reorder-columns="handleReorderColumns"
@@ -390,6 +392,7 @@ const collectionFilterValue = ref('')
 const collectionSortKey = ref<string | null>(null)
 const collectionSortDir = ref<'asc' | 'desc'>('asc')
 const collectionGroupProperty = ref<string | null>(null)
+const collectionSwimlaneProperty = ref<string | null>(null)
 const collectionDateProperty = ref<string | null>(null)
 const boards = ref<Board[]>([])
 const activeBoardId = ref<number | null>(null)
@@ -763,6 +766,7 @@ async function handleSelectBoard(boardId: number | null) {
   activeBoardId.value = boardId
   const board = boards.value.find(b => b.id === boardId)
   collectionGroupProperty.value = board?.group_property || null
+  collectionSwimlaneProperty.value = board?.swimlane_property || null
   collectionFilterProperty.value = board?.filter_property || ''
   collectionFilterValue.value = board?.filter_value || ''
   await refreshCollection(1)
@@ -774,6 +778,7 @@ async function handleCreateBoard(name: string) {
     const board = await createBoard(activeWorkspaceId.value, {
       name,
       group_property: collectionGroupProperty.value,
+      swimlane_property: collectionSwimlaneProperty.value,
       filter_property: collectionFilterProperty.value || null,
       filter_value: collectionFilterValue.value || null,
     })
@@ -868,13 +873,27 @@ async function handleCollectionGroupChange(property: string) {
   }
 }
 
-async function handleCollectionCreateCard(title: string, columnValue: string) {
+async function handleCollectionSwimlaneChange(property: string) {
+  collectionSwimlaneProperty.value = property || null
+  if (activeWorkspaceId.value && activeBoardId.value !== null) {
+    try {
+      await updateBoard(activeWorkspaceId.value, activeBoardId.value, { swimlane_property: collectionSwimlaneProperty.value })
+    } catch (err) {
+      console.error('Failed to save board view:', err)
+    }
+  }
+}
+
+async function handleCollectionCreateCard(title: string, columnValue: string, rowValue: string | null) {
   if (!activeWorkspaceId.value || !collectionGroupProperty.value) return
   try {
     const path = `untitled-${Date.now().toString(36)}.md`
     const created = await createNote(activeWorkspaceId.value, path, `# ${title}\n\nWrite your thoughts here...`)
     if (columnValue) {
       await setNoteProperty(activeWorkspaceId.value, created.id, collectionGroupProperty.value, columnValue)
+    }
+    if (rowValue && collectionSwimlaneProperty.value) {
+      await setNoteProperty(activeWorkspaceId.value, created.id, collectionSwimlaneProperty.value, rowValue)
     }
     await refreshCollection(collectionPage.value.current_page)
   } catch (err) {

--- a/frontend/src/BoardSwitcher.spec.ts
+++ b/frontend/src/BoardSwitcher.spec.ts
@@ -4,8 +4,8 @@ import BoardSwitcher from './components/BoardSwitcher.vue'
 import type { Board } from './services/types'
 
 const boards: Board[] = [
-  { id: 1, workspace_id: 1, name: 'Sprint', group_property: 'status', filter_property: null, filter_value: null, column_config: null, sort_position: 0 },
-  { id: 2, workspace_id: 1, name: 'Roadmap', group_property: 'quarter', filter_property: null, filter_value: null, column_config: null, sort_position: 1 },
+  { id: 1, workspace_id: 1, name: 'Sprint', group_property: 'status', swimlane_property: null, filter_property: null, filter_value: null, column_config: null, sort_position: 0 },
+  { id: 2, workspace_id: 1, name: 'Roadmap', group_property: 'quarter', swimlane_property: null, filter_property: null, filter_value: null, column_config: null, sort_position: 1 },
 ]
 
 describe('BoardSwitcher', () => {

--- a/frontend/src/CollectionsBoardView.spec.ts
+++ b/frontend/src/CollectionsBoardView.spec.ts
@@ -94,7 +94,7 @@ describe('CollectionsBoardView', () => {
     await draftColumn.get('[data-testid="board-add-card-button"]').trigger('click')
     await draftColumn.get('[data-testid="board-add-card-input"]').setValue('New task')
     await draftColumn.get('[data-testid="board-add-card-form"]').trigger('submit')
-    expect(wrapper.emitted('create-card')![0]).toEqual(['New task', 'draft'])
+    expect(wrapper.emitted('create-card')![0]).toEqual(['New task', 'draft', null])
     expect(draftColumn.find('[data-testid="board-add-card-input"]').exists()).toBe(false)
   })
 
@@ -201,6 +201,75 @@ describe('CollectionsBoardView', () => {
     })
     const draftColumn = wrapper.findAll('[data-testid="board-column"]').find(c => c.text().includes('draft'))!
     expect(draftColumn.find('[data-testid="board-column-wip-warning"]').exists()).toBe(true)
+  })
+
+  it('renders a single unlabeled row when no swimlane property is set', () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    expect(wrapper.findAll('[data-testid="board-row"]')).toHaveLength(1)
+    expect(wrapper.find('[data-testid="board-row-label"]').exists()).toBe(false)
+  })
+
+  it('emits swimlane-change with the trimmed property name on change', async () => {
+    const wrapper = mount(CollectionsBoardView, { props: { page, groupProperty: 'status' } })
+    await wrapper.get('[data-testid="board-swimlane-property"]').setValue('  assignee  ')
+    await wrapper.get('[data-testid="board-swimlane-property"]').trigger('change')
+    expect(wrapper.emitted('swimlane-change')![0]).toEqual(['assignee'])
+  })
+
+  it('splits notes into one row per swimlane value, each with the same columns', () => {
+    const swimlanePage: CollectionPage = {
+      ...page,
+      data: [
+        {
+          id: 5, path: 'e.md', title: 'E',
+          properties: [
+            { id: 6, note_id: 5, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+            { id: 7, note_id: 5, name: 'assignee', type: 'string', value_string: 'alice', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+          ],
+        },
+        {
+          id: 6, path: 'f.md', title: 'F',
+          properties: [
+            { id: 8, note_id: 6, name: 'status', type: 'string', value_string: 'done', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+            { id: 9, note_id: 6, name: 'assignee', type: 'string', value_string: 'bob', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+          ],
+        },
+      ],
+    }
+    const wrapper = mount(CollectionsBoardView, {
+      props: { page: swimlanePage, groupProperty: 'status', swimlaneProperty: 'assignee' },
+    })
+    const rows = wrapper.findAll('[data-testid="board-row"]')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('alice')
+    expect(rows[0].findAll('[data-testid="board-column"]')).toHaveLength(2)
+    const aliceCards = rows[0].findAll('[data-testid="board-card"]')
+    expect(aliceCards).toHaveLength(1)
+    expect(aliceCards[0].text()).toContain('E')
+  })
+
+  it('emits create-card with the row value alongside the column value', async () => {
+    const swimlanePage: CollectionPage = {
+      ...page,
+      data: [
+        {
+          id: 5, path: 'e.md', title: 'E',
+          properties: [
+            { id: 6, note_id: 5, name: 'status', type: 'string', value_string: 'draft', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+            { id: 7, note_id: 5, name: 'assignee', type: 'string', value_string: 'alice', value_numeric: null, value_boolean: null, value_datetime: null, value_json: null },
+          ],
+        },
+      ],
+    }
+    const wrapper = mount(CollectionsBoardView, {
+      props: { page: swimlanePage, groupProperty: 'status', swimlaneProperty: 'assignee' },
+    })
+    const aliceRow = wrapper.findAll('[data-testid="board-row"]')[0]
+    const draftColumn = aliceRow.findAll('[data-testid="board-column"]').find(c => c.text().includes('draft'))!
+    await draftColumn.get('[data-testid="board-add-card-button"]').trigger('click')
+    await draftColumn.get('[data-testid="board-add-card-input"]').setValue('New task')
+    await draftColumn.get('[data-testid="board-add-card-form"]').trigger('submit')
+    expect(wrapper.emitted('create-card')![0]).toEqual(['New task', 'draft', 'alice'])
   })
 
   it('does not emit create-card for a blank title', async () => {

--- a/frontend/src/collectionUtils.spec.ts
+++ b/frontend/src/collectionUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { allTagNames, applyColumnConfig, coverImageUrl, filterNotesByTag, firstDateProperty, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
+import { allTagNames, applyColumnConfig, coverImageUrl, filterNotesByTag, firstDateProperty, groupNotesIntoColumns, groupNotesIntoSwimlaneRows, noteTagNames, resolveCardMove, UNGROUPED_LABEL } from './services/collectionUtils'
 import type { BoardColumn } from './services/collectionUtils'
 import type { CollectionNote, CollectionPage, RawNoteProperty } from './services/types'
 
@@ -99,6 +99,32 @@ describe('firstDateProperty', () => {
 
   it('returns null when there is no datetime property', () => {
     expect(firstDateProperty(makeNote(1, [], [stringProp('status', 'open')]))).toBeNull()
+  })
+})
+
+describe('groupNotesIntoColumns', () => {
+  it('groups notes by the property value, with a column for missing values sorted last', () => {
+    const notes = [
+      makeNote(1, [], [stringProp('status', 'draft')]),
+      makeNote(2, [], [stringProp('status', 'done')]),
+      makeNote(3, [], []),
+    ]
+    const result = groupNotesIntoColumns(notes, 'status')
+    expect(result.map(c => c.key)).toEqual(['done', 'draft', UNGROUPED_LABEL])
+    expect(result.find(c => c.key === 'draft')!.notes).toEqual([notes[0]])
+  })
+})
+
+describe('groupNotesIntoSwimlaneRows', () => {
+  it('groups notes by the swimlane property value, sorted, missing values last', () => {
+    const notes = [
+      makeNote(1, [], [stringProp('assignee', 'bob')]),
+      makeNote(2, [], [stringProp('assignee', 'alice')]),
+      makeNote(3, [], []),
+    ]
+    const result = groupNotesIntoSwimlaneRows(notes, 'assignee')
+    expect(result.map(r => r.key)).toEqual(['alice', 'bob', UNGROUPED_LABEL])
+    expect(result.find(r => r.key === 'bob')!.notes).toEqual([notes[0]])
   })
 })
 

--- a/frontend/src/components/CollectionsBoardView.vue
+++ b/frontend/src/components/CollectionsBoardView.vue
@@ -20,6 +20,16 @@
         <option v-for="col in propertyColumns" :key="col" :value="col" />
       </datalist>
       <button type="submit" class="btn-group-apply" data-testid="board-group-apply">Group</button>
+      <input
+        v-model="swimlanePropertyInput"
+        type="text"
+        placeholder="Swimlane by property (optional)"
+        aria-label="Swimlane by property name"
+        data-testid="board-swimlane-property"
+        class="group-input"
+        :list="'board-property-options'"
+        @change="applySwimlaneProperty"
+      />
       <select
         v-if="allTags.length > 0"
         v-model="tagFilter"
@@ -44,9 +54,12 @@
       <p>Choose a property above to group notes into columns.</p>
     </div>
 
-    <div v-else class="board-scroll">
+    <div v-else class="board-rows">
+    <div v-for="row in displayRows" :key="row.key" class="board-row" data-testid="board-row">
+      <div v-if="row.label !== null" class="board-row-label" data-testid="board-row-label">{{ row.label }}</div>
+      <div class="board-scroll">
       <div
-        v-for="(column, index) in columns"
+        v-for="(column, index) in row.columns"
         :key="column.key"
         class="board-column"
         :style="column.color ? { borderTopColor: column.color, borderTopWidth: '3px' } : {}"
@@ -89,7 +102,7 @@
             type="button"
             class="btn-column-reorder"
             data-testid="board-column-move-right"
-            :disabled="index === columns.length - 1"
+            :disabled="index === row.columns.length - 1"
             @click="moveColumn(column.key, 1)"
           >▶</button>
         </div>
@@ -132,7 +145,8 @@
           class="board-column-body"
           data-testid="board-column-body"
           :data-column-key="column.key"
-          :ref="(el) => setColumnBodyRef(column.key, el)"
+          :data-row-key="row.key"
+          :ref="(el) => setColumnBodyRef(row.key, column.key, el)"
         >
           <button
             v-for="note in column.notes"
@@ -182,10 +196,10 @@
           </button>
         </div>
         <form
-          v-if="addCardColumnKey === column.key"
+          v-if="addCardRowKey === row.key && addCardColumnKey === column.key"
           class="board-add-card-form"
           data-testid="board-add-card-form"
-          @submit.prevent="submitAddCard(column.key)"
+          @submit.prevent="submitAddCard(row.key, column.key)"
         >
           <input
             v-model="addCardTitle"
@@ -204,11 +218,13 @@
           type="button"
           class="btn-add-card"
           data-testid="board-add-card-button"
-          @click="openAddCard(column.key)"
+          @click="openAddCard(row.key, column.key)"
         >
           + Add card
         </button>
       </div>
+      </div>
+    </div>
     </div>
 
     <div v-if="page.last_page > 1" class="pagination-bar">
@@ -245,7 +261,8 @@ import {
   coverImageUrl,
   filterNotesByTag,
   firstDateProperty,
-  formatPropertyValue,
+  groupNotesIntoColumns,
+  groupNotesIntoSwimlaneRows,
   noteTagNames,
   propertyColumns as computePropertyColumns,
   resolveCardMove,
@@ -256,6 +273,7 @@ const props = defineProps<{
   page: CollectionPage
   loading?: boolean
   groupProperty?: string | null
+  swimlaneProperty?: string | null
   configurable?: boolean
   columnConfig?: BoardColumnConfig[] | null
 }>()
@@ -264,21 +282,31 @@ const emit = defineEmits<{
   (e: 'select-note', noteId: number): void
   (e: 'page-change', page: number): void
   (e: 'group-change', property: string): void
+  (e: 'swimlane-change', property: string): void
   (e: 'move-card', noteId: number, newValue: string): void
-  (e: 'create-card', title: string, columnValue: string): void
+  (e: 'create-card', title: string, columnValue: string, rowValue: string | null): void
   (e: 'reorder-columns', keys: string[]): void
   (e: 'toggle-column-collapse', key: string): void
   (e: 'update-column', key: string, attrs: { label: string; color: string | null; wip_limit: number | null }): void
 }>()
 
 const groupPropertyInput = ref(props.groupProperty || '')
+const swimlanePropertyInput = ref(props.swimlaneProperty || '')
 
 watch(() => props.groupProperty, (value) => {
   groupPropertyInput.value = value || ''
 })
 
+watch(() => props.swimlaneProperty, (value) => {
+  swimlanePropertyInput.value = value || ''
+})
+
 function applyGroupProperty() {
   emit('group-change', groupPropertyInput.value.trim())
+}
+
+function applySwimlaneProperty() {
+  emit('swimlane-change', swimlanePropertyInput.value.trim())
 }
 
 const propertyColumns = computed(() => computePropertyColumns(props.page))
@@ -286,23 +314,34 @@ const propertyColumns = computed(() => computePropertyColumns(props.page))
 const tagFilter = ref('')
 const allTags = computed(() => allTagNames(props.page))
 
+const filteredNotes = computed(() => filterNotesByTag(props.page.data, tagFilter.value))
+
 const columns = computed(() => {
   if (!props.groupProperty) return []
-  const notes = filterNotesByTag(props.page.data, tagFilter.value)
-  const groups = new Map<string, typeof props.page.data>()
-  for (const note of notes) {
-    const label = formatPropertyValue(note, props.groupProperty)
-    const key = label === '—' ? UNGROUPED_LABEL : label
-    if (!groups.has(key)) groups.set(key, [])
-    groups.get(key)!.push(note)
-  }
-  const sortedKeys = Array.from(groups.keys()).sort((a, b) => {
-    if (a === UNGROUPED_LABEL) return 1
-    if (b === UNGROUPED_LABEL) return -1
-    return a.localeCompare(b)
-  })
-  const derived = sortedKeys.map(key => ({ key, label: key, notes: groups.get(key)! }))
+  const derived = groupNotesIntoColumns(filteredNotes.value, props.groupProperty)
   return applyColumnConfig(derived, props.columnConfig)
+})
+
+interface DisplayRow {
+  key: string
+  label: string | null
+  columns: ReturnType<typeof applyColumnConfig>
+}
+
+const displayRows = computed<DisplayRow[]>(() => {
+  if (!props.groupProperty) return []
+  if (!props.swimlaneProperty) {
+    return [{ key: '__all__', label: null, columns: columns.value }]
+  }
+  return groupNotesIntoSwimlaneRows(filteredNotes.value, props.swimlaneProperty).map(row => {
+    const rowColumns = groupNotesIntoColumns(row.notes, props.groupProperty!)
+    const byKey = new Map(rowColumns.map(c => [c.key, c.notes]))
+    return {
+      key: row.key,
+      label: row.label,
+      columns: columns.value.map(col => ({ ...col, notes: byKey.get(col.key) ?? [] })),
+    }
+  })
 })
 
 const editingColumnKey = ref<string | null>(null)
@@ -336,16 +375,20 @@ function submitColumnEdit(key: string) {
 }
 
 // Drag-and-drop between columns (#299): one Sortable instance per column
-// body, sharing a group so cards can move between them. onEnd resolves the
-// move via the pure resolveCardMove() rather than deciding inline, so the
-// decision logic is unit-testable without a real Sortable instance.
+// body, keyed by "rowKey::columnKey" since swimlanes (#304) repeat the same
+// column key across rows. Each row is its own Sortable group so a card can
+// only move between columns within its own swimlane, never across rows.
+// onEnd resolves the move via the pure resolveCardMove() rather than
+// deciding inline, so the decision logic is unit-testable without a real
+// Sortable instance.
 const columnBodyRefs = new Map<string, HTMLElement>()
 
-function setColumnBodyRef(key: string, el: unknown) {
+function setColumnBodyRef(rowKey: string, columnKey: string, el: unknown) {
+  const compositeKey = `${rowKey}::${columnKey}`
   if (el instanceof HTMLElement) {
-    columnBodyRefs.set(key, el)
+    columnBodyRefs.set(compositeKey, el)
   } else {
-    columnBodyRefs.delete(key)
+    columnBodyRefs.delete(compositeKey)
   }
 }
 
@@ -358,10 +401,11 @@ function destroySortables() {
 
 function initSortables() {
   destroySortables()
-  for (const el of columnBodyRefs.values()) {
+  for (const [compositeKey, el] of columnBodyRefs.entries()) {
+    const rowKey = compositeKey.split('::')[0]
     sortableInstances.push(
       Sortable.create(el, {
-        group: 'board-column',
+        group: `board-column-row-${rowKey}`,
         animation: 150,
         ghostClass: 'board-card-ghost',
         // Native HTML5 drag-and-drop never fires from touch input, so the
@@ -384,31 +428,35 @@ onMounted(() => {
   nextTick(initSortables)
 })
 
-watch(columns, () => {
+watch(displayRows, () => {
   nextTick(initSortables)
 })
 
 onBeforeUnmount(destroySortables)
 
-// Card creation from the board (#300): one column has its add-card form
-// open at a time, tracked by column key.
+// Card creation from the board (#300): one column (within one row) has its
+// add-card form open at a time.
+const addCardRowKey = ref<string | null>(null)
 const addCardColumnKey = ref<string | null>(null)
 const addCardTitle = ref('')
 
-function openAddCard(key: string) {
-  addCardColumnKey.value = key
+function openAddCard(rowKey: string, columnKey: string) {
+  addCardRowKey.value = rowKey
+  addCardColumnKey.value = columnKey
   addCardTitle.value = ''
 }
 
 function cancelAddCard() {
+  addCardRowKey.value = null
   addCardColumnKey.value = null
   addCardTitle.value = ''
 }
 
-function submitAddCard(columnKey: string) {
+function submitAddCard(rowKey: string, columnKey: string) {
   const title = addCardTitle.value.trim()
   if (!title) return
-  emit('create-card', title, columnKey === UNGROUPED_LABEL ? '' : columnKey)
+  const rowValue = rowKey === '__all__' ? null : rowKey === UNGROUPED_LABEL ? '' : rowKey
+  emit('create-card', title, columnKey === UNGROUPED_LABEL ? '' : columnKey, rowValue)
   cancelAddCard()
 }
 </script>
@@ -496,11 +544,25 @@ function submitAddCard(columnKey: string) {
   padding: var(--space-8) 0;
 }
 
+.board-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.board-row-label {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-1);
+}
+
 .board-scroll {
   display: flex;
   gap: var(--space-4);
   overflow-x: auto;
-  flex: 1;
   align-items: flex-start;
   padding-bottom: var(--space-2);
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -325,7 +325,7 @@ export async function getBoards(workspaceId: number): Promise<Board[]> {
 
 export async function createBoard(
   workspaceId: number,
-  attrs: { name: string; group_property?: string | null; filter_property?: string | null; filter_value?: string | null }
+  attrs: { name: string; group_property?: string | null; swimlane_property?: string | null; filter_property?: string | null; filter_value?: string | null }
 ): Promise<Board> {
   const response = await api.post<{ data: Board }>(`/workspaces/${workspaceId}/boards`, attrs)
   return response.data.data
@@ -334,7 +334,7 @@ export async function createBoard(
 export async function updateBoard(
   workspaceId: number,
   boardId: number,
-  attrs: Partial<{ name: string; group_property: string | null; filter_property: string | null; filter_value: string | null; column_config: Board['column_config'] }>
+  attrs: Partial<{ name: string; group_property: string | null; swimlane_property: string | null; filter_property: string | null; filter_value: string | null; column_config: Board['column_config'] }>
 ): Promise<Board> {
   const response = await api.put<{ data: Board }>(`/workspaces/${workspaceId}/boards/${boardId}`, attrs)
   return response.data.data

--- a/frontend/src/services/collectionUtils.ts
+++ b/frontend/src/services/collectionUtils.ts
@@ -68,6 +68,42 @@ export interface BoardColumn {
   notes: CollectionNote[]
 }
 
+function sortGroupKeys(keys: string[]): string[] {
+  return keys.sort((a, b) => {
+    if (a === UNGROUPED_LABEL) return 1
+    if (b === UNGROUPED_LABEL) return -1
+    return a.localeCompare(b)
+  })
+}
+
+export function groupNotesIntoColumns(notes: CollectionNote[], groupProperty: string): BoardColumn[] {
+  const groups = new Map<string, CollectionNote[]>()
+  for (const note of notes) {
+    const label = formatPropertyValue(note, groupProperty)
+    const key = label === '—' ? UNGROUPED_LABEL : label
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(note)
+  }
+  return sortGroupKeys(Array.from(groups.keys())).map(key => ({ key, label: key, notes: groups.get(key)! }))
+}
+
+export interface SwimlaneRow {
+  key: string
+  label: string
+  notes: CollectionNote[]
+}
+
+export function groupNotesIntoSwimlaneRows(notes: CollectionNote[], swimlaneProperty: string): SwimlaneRow[] {
+  const groups = new Map<string, CollectionNote[]>()
+  for (const note of notes) {
+    const label = formatPropertyValue(note, swimlaneProperty)
+    const key = label === '—' ? UNGROUPED_LABEL : label
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(note)
+  }
+  return sortGroupKeys(Array.from(groups.keys())).map(key => ({ key, label: key, notes: groups.get(key)! }))
+}
+
 export interface ConfiguredBoardColumn extends BoardColumn {
   color: string | null
   wipLimit: number | null

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -202,6 +202,7 @@ export interface Board {
   workspace_id: number
   name: string
   group_property: string | null
+  swimlane_property: string | null
   filter_property: string | null
   filter_value: string | null
   column_config: BoardColumnConfig[] | null

--- a/tests/Feature/BoardControllerTest.php
+++ b/tests/Feature/BoardControllerTest.php
@@ -111,6 +111,20 @@ final class BoardControllerTest extends TestCase
         $this->assertEquals($columnConfig, $board->fresh()->column_config);
     }
 
+    public function test_persists_swimlane_property(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $workspace = $this->makeWorkspace();
+        $board = Board::create(['workspace_id' => $workspace->id, 'name' => 'Original']);
+
+        $response = $this->actingAs($admin)->putJson("/api/workspaces/{$workspace->id}/boards/{$board->id}", [
+            'swimlane_property' => 'assignee',
+        ]);
+
+        $response->assertOk()->assertJsonPath('data.swimlane_property', 'assignee');
+        $this->assertSame('assignee', $board->fresh()->swimlane_property);
+    }
+
     public function test_deletes_a_board(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);


### PR DESCRIPTION
## Summary
- Boards can group by a second "swimlane" property; each value becomes a row sharing the same column set/config
- Cards drag only within their own row (Sortable scoped per row) — cross-swimlane drag would need to change two properties at once, out of scope
- Creating a card inside a swimlane row sets both the column and swimlane properties
- Extracted `groupNotesIntoColumns()`/`groupNotesIntoSwimlaneRows()` pure helpers, reused by both the single-row and swimlane cases
- Persisted per board via new `swimlane_property` column

Closes #304

## Test plan
- [x] `BoardControllerTest` (8/8, 1 new)
- [x] `collectionUtils.spec.ts` (17/17, 2 new)
- [x] `CollectionsBoardView.spec.ts` (25/25, 4 new)
- [x] `vue-tsc` build clean
- [x] Full frontend suite (414/414)
- [x] Full backend suite (178/178)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>