### PR TITLE
feat: card-level checklists as a separate structure (#305)

### DIFF
--- a/app/Http/Controllers/NoteChecklistItemController.php
+++ b/app/Http/Controllers/NoteChecklistItemController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Models\Note;
+use App\Models\NoteChecklistItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class NoteChecklistItemController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider
+    ) {}
+
+    public function index(Request $request, int $workspaceId, int $noteId): JsonResponse
+    {
+        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
+            return $denied;
+        }
+
+        $items = NoteChecklistItem::query()->where('note_id', $noteId)->orderBy('sort_position')->orderBy('id')->get();
+
+        return response()->json(['data' => $items]);
+    }
+
+    public function store(Request $request, int $workspaceId, int $noteId): JsonResponse
+    {
+        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
+            return $denied;
+        }
+
+        $validated = $request->validate([
+            'text' => ['required', 'string', 'max:500'],
+        ]);
+
+        $item = NoteChecklistItem::create([
+            'note_id' => $noteId,
+            'text' => $validated['text'],
+            'done' => false,
+            'sort_position' => NoteChecklistItem::query()->where('note_id', $noteId)->count(),
+        ]);
+
+        return response()->json(['data' => $item], 201);
+    }
+
+    public function update(Request $request, int $workspaceId, int $noteId, int $itemId): JsonResponse
+    {
+        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
+            return $denied;
+        }
+
+        $item = NoteChecklistItem::query()->where('note_id', $noteId)->find($itemId);
+        if (! $item) {
+            return response()->json(['message' => 'Checklist item not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'text' => ['sometimes', 'string', 'max:500'],
+            'done' => ['sometimes', 'boolean'],
+        ]);
+
+        $item->update($validated);
+
+        return response()->json(['data' => $item]);
+    }
+
+    public function destroy(Request $request, int $workspaceId, int $noteId, int $itemId): JsonResponse
+    {
+        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
+            return $denied;
+        }
+
+        $item = NoteChecklistItem::query()->where('note_id', $noteId)->find($itemId);
+        if (! $item) {
+            return response()->json(['message' => 'Checklist item not found.'], 404);
+        }
+
+        $item->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function authorizeAndFindNote(Request $request, int $workspaceId, int $noteId): ?JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $note = Note::query()->where('workspace_id', $workspaceId)->where('id', $noteId)->first();
+        if (! $note) {
+            return response()->json(['message' => 'Note not found.'], 404);
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/WorkspaceCollectionController.php
+++ b/app/Http/Controllers/WorkspaceCollectionController.php
@@ -31,7 +31,11 @@ final class WorkspaceCollectionController extends Controller
         $query = Note::query()
             ->where('workspace_id', $workspaceId)
             ->with(['properties', 'tags'])
-            ->withCount('comments');
+            ->withCount('comments')
+            ->withCount('checklistItems as checklist_total')
+            ->withCount(['checklistItems as checklist_done' => function ($cQuery) {
+                $cQuery->where('done', true);
+            }]);
 
         if ($propertyKey !== null && $propertyKey !== '') {
             $query->whereHas('properties', function ($pQuery) use ($propertyKey, $propertyValue) {
@@ -68,28 +72,6 @@ final class WorkspaceCollectionController extends Controller
         $perPage = min(100, max(1, (int) $request->query('per_page', 25)));
         $notes = $query->orderBy('title')->paginate($perPage);
 
-        $notes->getCollection()->transform(function (Note $note) {
-            $checklist = self::checklistProgress($note->search_content ?? '');
-            $note->setAttribute('checklist_total', $checklist['total']);
-            $note->setAttribute('checklist_done', $checklist['done']);
-
-            return $note;
-        });
-
         return response()->json($notes);
-    }
-
-    /**
-     * @return array{total: int, done: int}
-     */
-    private static function checklistProgress(string $body): array
-    {
-        preg_match_all('/^\s*[-*]\s+\[([ xX])\]/m', $body, $matches);
-        $marks = $matches[1] ?? [];
-
-        return [
-            'total' => count($marks),
-            'done' => count(array_filter($marks, fn (string $m) => strtolower($m) === 'x')),
-        ];
     }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -60,4 +60,9 @@ class Note extends Model
     {
         return $this->hasMany(NoteComment::class);
     }
+
+    public function checklistItems(): HasMany
+    {
+        return $this->hasMany(NoteChecklistItem::class)->orderBy('sort_position')->orderBy('id');
+    }
 }

--- a/app/Models/NoteChecklistItem.php
+++ b/app/Models/NoteChecklistItem.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NoteChecklistItem extends Model
+{
+    protected $fillable = [
+        'note_id',
+        'text',
+        'done',
+        'sort_position',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'done' => 'boolean',
+        ];
+    }
+
+    public function note(): BelongsTo
+    {
+        return $this->belongsTo(Note::class);
+    }
+}

--- a/database/migrations/2026_08_04_000003_create_note_checklist_items_table.php
+++ b/database/migrations/2026_08_04_000003_create_note_checklist_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('note_checklist_items')) {
+            Schema::create('note_checklist_items', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('note_id')->constrained('notes')->cascadeOnDelete();
+                $table->string('text');
+                $table->boolean('done')->default(false);
+                $table->integer('sort_position')->default(0);
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('note_checklist_items');
+    }
+};

--- a/frontend/src/ChecklistPanel.spec.ts
+++ b/frontend/src/ChecklistPanel.spec.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ChecklistPanel from './components/ChecklistPanel.vue'
+import type { NoteChecklistItem } from './services/types'
+
+const items: NoteChecklistItem[] = [
+  { id: 1, note_id: 1, text: 'Write tests', done: true, sort_position: 0 },
+  { id: 2, note_id: 1, text: 'Ship it', done: false, sort_position: 1 },
+]
+
+describe('ChecklistPanel', () => {
+  it('shows an empty state when there are no items', () => {
+    const wrapper = mount(ChecklistPanel, { props: { items: [] } })
+    expect(wrapper.text()).toContain('No checklist items yet.')
+  })
+
+  it('renders each item with its checked state', () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    const rows = wrapper.findAll('[data-testid="checklist-item"]')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('Write tests')
+    expect((rows[0].get('[data-testid="checklist-item-checkbox"]').element as HTMLInputElement).checked).toBe(true)
+    expect((rows[1].get('[data-testid="checklist-item-checkbox"]').element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('shows progress as done/total', () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    expect(wrapper.text()).toContain('1/2')
+  })
+
+  it('emits toggle-item with the item id when a checkbox is clicked', async () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    await wrapper.findAll('[data-testid="checklist-item-checkbox"]')[1].trigger('click')
+    expect(wrapper.emitted('toggle-item')![0]).toEqual([2])
+  })
+
+  it('emits delete-item with the item id', async () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    await wrapper.findAll('[data-testid="checklist-item-delete-btn"]')[0].trigger('click')
+    expect(wrapper.emitted('delete-item')![0]).toEqual([1])
+  })
+
+  it('emits add-item with the trimmed text and clears the input', async () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    await wrapper.get('[data-testid="checklist-item-input"]').setValue('  New item  ')
+    await wrapper.get('[data-testid="checklist-item-form"]').trigger('submit')
+    expect(wrapper.emitted('add-item')![0]).toEqual(['New item'])
+    expect((wrapper.get('[data-testid="checklist-item-input"]').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('does not emit add-item for a blank entry', async () => {
+    const wrapper = mount(ChecklistPanel, { props: { items } })
+    await wrapper.get('[data-testid="checklist-item-form"]').trigger('submit')
+    expect(wrapper.emitted('add-item')).toBeFalsy()
+  })
+})

--- a/frontend/src/components/ChecklistPanel.vue
+++ b/frontend/src/components/ChecklistPanel.vue
@@ -1,0 +1,191 @@
+<template>
+  <aside class="checklist-panel" :class="{ 'panel-collapsed': collapsed }" aria-label="Checklist">
+    <PanelHeader title="Checklist" :count="items.length" :collapsed="collapsed" @toggle="toggle">
+      <template #icon>
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <polyline points="9 11 12 14 22 4"></polyline>
+          <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+        </svg>
+      </template>
+    </PanelHeader>
+
+    <div v-show="!collapsed" class="checklist-body">
+      <p v-if="items.length > 0" class="checklist-progress">{{ doneCount }}/{{ items.length }}</p>
+
+      <div v-if="items.length === 0" class="checklist-empty">
+        <p>No checklist items yet.</p>
+      </div>
+
+      <ul v-else class="checklist-list">
+        <li v-for="item in items" :key="item.id" class="checklist-item" data-testid="checklist-item">
+          <input
+            type="checkbox"
+            :checked="item.done"
+            data-testid="checklist-item-checkbox"
+            :aria-label="`Mark '${item.text}' ${item.done ? 'not done' : 'done'}`"
+            @click="$emit('toggle-item', item.id)"
+          />
+          <span class="checklist-item-text" :class="{ 'checklist-item-done': item.done }">{{ item.text }}</span>
+          <button
+            class="btn-delete-checklist-item"
+            data-testid="checklist-item-delete-btn"
+            :aria-label="`Delete '${item.text}'`"
+            title="Delete item"
+            @click="$emit('delete-item', item.id)"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="3 6 5 6 21 6"></polyline>
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+            </svg>
+          </button>
+        </li>
+      </ul>
+
+      <form class="checklist-item-form" data-testid="checklist-item-form" @submit.prevent="handleSubmit">
+        <input
+          v-model="newText"
+          type="text"
+          placeholder="Add a checklist item"
+          aria-label="New checklist item"
+          data-testid="checklist-item-input"
+          class="checklist-item-input"
+        />
+        <button type="submit" class="btn-add-checklist-item" data-testid="checklist-item-submit-btn" :disabled="!newText.trim()">
+          Add
+        </button>
+      </form>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
+import type { NoteChecklistItem } from '../services/types'
+
+const props = defineProps<{
+  items: NoteChecklistItem[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'add-item', text: string): void
+  (e: 'toggle-item', itemId: number): void
+  (e: 'delete-item', itemId: number): void
+}>()
+
+const { collapsed, toggle } = useCollapsiblePanel('checklist', false)
+
+const newText = ref('')
+
+const doneCount = computed(() => props.items.filter(i => i.done).length)
+
+function handleSubmit() {
+  const text = newText.value.trim()
+  if (!text) return
+  emit('add-item', text)
+  newText.value = ''
+}
+</script>
+
+<style scoped>
+.checklist-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.checklist-panel.panel-collapsed {
+  padding-bottom: 0;
+}
+
+.checklist-progress {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  margin-bottom: var(--space-2);
+}
+
+.checklist-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.checklist-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+}
+
+.checklist-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.checklist-item-text {
+  flex: 1;
+  color: var(--color-text);
+}
+
+.checklist-item-done {
+  text-decoration: line-through;
+  color: var(--color-text-muted);
+}
+
+.btn-delete-checklist-item {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-delete-checklist-item:hover {
+  color: var(--color-status-danger);
+  background: color-mix(in srgb, var(--color-status-danger) 12%, transparent);
+}
+
+.checklist-item-form {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.checklist-item-input {
+  flex: 1;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+}
+
+.btn-add-checklist-item {
+  background: var(--color-action);
+  color: var(--color-neutral-0);
+  border: none;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  min-height: 32px;
+}
+
+.btn-add-checklist-item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -135,6 +135,17 @@
 
         <button
           class="btn-attach"
+          data-testid="checklist-drawer-btn"
+          title="Checklist"
+          :aria-expanded="isChecklistDrawerOpen"
+          @click="isChecklistDrawerOpen = !isChecklistDrawerOpen"
+        >
+          <span>☑</span>
+          <span v-if="checklistItems.length">{{ checklistItems.filter(i => i.done).length }}/{{ checklistItems.length }}</span>
+        </button>
+
+        <button
+          class="btn-attach"
           data-testid="attach-file-btn"
           :disabled="isUploading"
           @click="triggerFileInput"
@@ -389,6 +400,35 @@
       </aside>
     </Teleport>
 
+    <!-- Checklist Drawer: teleported to the same right-drawer mount point as
+         Comments. Card-level checklist as a genuinely separate structure
+         from the note's own Markdown content (#305) — a note-scoped list of
+         checklist_items rows, not derived from `- [ ]` syntax in the body. -->
+    <Teleport to="#app-right-drawer">
+      <aside
+        v-if="isChecklistDrawerOpen"
+        class="comments-drawer"
+        data-testid="checklist-drawer"
+      >
+        <div class="comments-drawer-header">
+          <h3>Checklist</h3>
+          <button
+            type="button"
+            class="drawer-close-btn"
+            data-testid="checklist-drawer-close-btn"
+            aria-label="Close checklist"
+            @click="isChecklistDrawerOpen = false"
+          >&times;</button>
+        </div>
+        <ChecklistPanel
+          :items="checklistItems"
+          @add-item="handleAddChecklistItem"
+          @toggle-item="handleToggleChecklistItem"
+          @delete-item="handleDeleteChecklistItem"
+        />
+      </aside>
+    </Teleport>
+
     <!-- Outline Drawer: teleported to the same right-drawer mount point as
          Comments (#262), listing the note's headings for quick navigation
          (G.1, #286). -->
@@ -480,12 +520,13 @@
 
 <script setup lang="ts">
 import { ref, reactive, watch, computed, nextTick, onUnmounted, onMounted } from 'vue'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, UnlinkedMention, OutgoingLink } from '../services/types'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, NoteChecklistItem, UnlinkedMention, OutgoingLink } from '../services/types'
 import {
   uploadAttachment,
   getNoteRevisions, getNoteRevision, restoreNoteRevision,
   setNoteProperty, deleteNoteProperty,
   getNoteComments, addNoteComment, deleteNoteComment,
+  getChecklistItems, createChecklistItem, updateChecklistItem, deleteChecklistItem,
   getUnlinkedMentions, getNote, updateNote,
   getOutgoingLinks
 } from '../services/api'
@@ -495,6 +536,7 @@ import OutgoingLinksPanel from './OutgoingLinksPanel.vue'
 import UnlinkedMentionsPanel from './UnlinkedMentionsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import PropertiesPanel from './PropertiesPanel.vue'
+import ChecklistPanel from './ChecklistPanel.vue'
 import CommentsPanel from './CommentsPanel.vue'
 import CoverImageModal from './CoverImageModal.vue'
 import SlashMenu from './SlashMenu.vue'
@@ -694,6 +736,8 @@ const revisionPreviewLoading = ref(false)
 
 const comments = ref<NoteComment[]>([])
 const commentsError = ref<string | null>(null)
+const checklistItems = ref<NoteChecklistItem[]>([])
+const isChecklistDrawerOpen = ref(false)
 // Deliberately NOT reset on note switch (see the watcher below) — like a
 // sidebar, staying open while browsing between notes is the expected
 // drawer behavior, not per-note ephemeral UI state.
@@ -909,6 +953,7 @@ watch(() => props.note, (newNote) => {
   showCommentComposer.value = false
   showHistory.value = false
   loadComments(newNote.id)
+  loadChecklistItems(newNote.id)
   loadUnlinkedMentions(newNote.id)
   loadOutgoingLinks(newNote.id)
 }, { immediate: true })
@@ -920,6 +965,48 @@ async function loadComments(noteId: number) {
     comments.value = await getNoteComments(props.workspaceId, noteId)
   } catch (err) {
     console.error('Failed to load comments:', err)
+  }
+}
+
+async function loadChecklistItems(noteId: number) {
+  if (!props.workspaceId) return
+  try {
+    checklistItems.value = await getChecklistItems(props.workspaceId, noteId)
+  } catch (err) {
+    console.error('Failed to load checklist items:', err)
+  }
+}
+
+async function handleAddChecklistItem(text: string) {
+  if (!props.workspaceId) return
+  try {
+    const item = await createChecklistItem(props.workspaceId, props.note.id, text)
+    checklistItems.value.push(item)
+  } catch (err) {
+    console.error('Failed to add checklist item:', err)
+  }
+}
+
+async function handleToggleChecklistItem(itemId: number) {
+  if (!props.workspaceId) return
+  const item = checklistItems.value.find(i => i.id === itemId)
+  if (!item) return
+  try {
+    const updated = await updateChecklistItem(props.workspaceId, props.note.id, itemId, { done: !item.done })
+    const index = checklistItems.value.findIndex(i => i.id === itemId)
+    if (index !== -1) checklistItems.value[index] = updated
+  } catch (err) {
+    console.error('Failed to toggle checklist item:', err)
+  }
+}
+
+async function handleDeleteChecklistItem(itemId: number) {
+  if (!props.workspaceId) return
+  try {
+    await deleteChecklistItem(props.workspaceId, props.note.id, itemId)
+    checklistItems.value = checklistItems.value.filter(i => i.id !== itemId)
+  } catch (err) {
+    console.error('Failed to delete checklist item:', err)
   }
 }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board } from './types'
+import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -245,6 +245,30 @@ export async function addNoteComment(
 
 export async function deleteNoteComment(workspaceId: number, noteId: number, commentId: number): Promise<void> {
   await api.delete(`/workspaces/${workspaceId}/notes/${noteId}/comments/${commentId}`)
+}
+
+export async function getChecklistItems(workspaceId: number, noteId: number): Promise<NoteChecklistItem[]> {
+  const response = await api.get<{ data: NoteChecklistItem[] }>(`/workspaces/${workspaceId}/notes/${noteId}/checklist-items`)
+  return response.data.data
+}
+
+export async function createChecklistItem(workspaceId: number, noteId: number, text: string): Promise<NoteChecklistItem> {
+  const response = await api.post<{ data: NoteChecklistItem }>(`/workspaces/${workspaceId}/notes/${noteId}/checklist-items`, { text })
+  return response.data.data
+}
+
+export async function updateChecklistItem(
+  workspaceId: number,
+  noteId: number,
+  itemId: number,
+  attrs: Partial<{ text: string; done: boolean }>
+): Promise<NoteChecklistItem> {
+  const response = await api.put<{ data: NoteChecklistItem }>(`/workspaces/${workspaceId}/notes/${noteId}/checklist-items/${itemId}`, attrs)
+  return response.data.data
+}
+
+export async function deleteChecklistItem(workspaceId: number, noteId: number, itemId: number): Promise<void> {
+  await api.delete(`/workspaces/${workspaceId}/notes/${noteId}/checklist-items/${itemId}`)
 }
 
 export interface ImportResult {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -197,6 +197,14 @@ export interface BoardColumnConfig {
   collapsed?: boolean
 }
 
+export interface NoteChecklistItem {
+  id: number
+  note_id: number
+  text: string
+  done: boolean
+  sort_position: number
+}
+
 export interface Board {
   id: number
   workspace_id: number

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,10 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::get('/workspaces/{workspace}/notes/{note}/comments', [\App\Http\Controllers\WorkspaceCommentController::class, 'index']);
     Route::post('/workspaces/{workspace}/notes/{note}/comments', [\App\Http\Controllers\WorkspaceCommentController::class, 'store']);
     Route::delete('/workspaces/{workspace}/notes/{note}/comments/{comment}', [\App\Http\Controllers\WorkspaceCommentController::class, 'destroy']);
+    Route::get('/workspaces/{workspace}/notes/{note}/checklist-items', [\App\Http\Controllers\NoteChecklistItemController::class, 'index']);
+    Route::post('/workspaces/{workspace}/notes/{note}/checklist-items', [\App\Http\Controllers\NoteChecklistItemController::class, 'store']);
+    Route::put('/workspaces/{workspace}/notes/{note}/checklist-items/{item}', [\App\Http\Controllers\NoteChecklistItemController::class, 'update']);
+    Route::delete('/workspaces/{workspace}/notes/{note}/checklist-items/{item}', [\App\Http\Controllers\NoteChecklistItemController::class, 'destroy']);
 
     Route::get('/workspaces/{workspace}/notifications', [\App\Http\Controllers\WorkspaceNotificationController::class, 'index']);
     Route::post('/workspaces/{workspace}/notifications/{notification}/read', [\App\Http\Controllers\WorkspaceNotificationController::class, 'markAsRead']);

--- a/tests/Feature/MilestoneCFinalTest.php
+++ b/tests/Feature/MilestoneCFinalTest.php
@@ -156,9 +156,14 @@ final class MilestoneCFinalTest extends TestCase
 
         /** @var VaultStorage $storage */
         $storage = $this->app->make(VaultStorage::class);
-        $storage->write($workspace, 'checklist.md', "# Checklist\n\n- [x] done one\n- [ ] todo one\n- [ ] todo two\n");
+        $storage->write($workspace, 'checklist.md', '# Checklist');
 
         $note = Note::where('workspace_id', $workspace->id)->where('path', 'checklist.md')->firstOrFail();
+        // Checklist progress is a genuinely separate card-level structure
+        // (#305), not derived from the note's markdown task-list syntax.
+        \App\Models\NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'done one', 'done' => true, 'sort_position' => 0]);
+        \App\Models\NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'todo one', 'done' => false, 'sort_position' => 1]);
+        \App\Models\NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'todo two', 'done' => false, 'sort_position' => 2]);
         NoteComment::create([
             'workspace_id' => $workspace->id,
             'note_id' => $note->id,

--- a/tests/Feature/NoteChecklistItemControllerTest.php
+++ b/tests/Feature/NoteChecklistItemControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
+use App\Models\NoteChecklistItem;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class NoteChecklistItemControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeNote(): array
+    {
+        $tenant = Tenant::create(['slug' => 'checklist-test-'.uniqid(), 'name' => 'Checklist Test']);
+        $vaultPath = storage_path('app/vaults/checklist_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'checklist-'.uniqid(),
+            'name' => 'Checklist Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = app(VaultStorage::class);
+        $storage->write($workspace, 'card.md', '# Card');
+        $note = Note::where('workspace_id', $workspace->id)->where('path', 'card.md')->firstOrFail();
+
+        return [$workspace, $note];
+    }
+
+    public function test_creates_and_lists_checklist_items_in_order(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+
+        $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items", ['text' => 'First'])
+            ->assertCreated()
+            ->assertJsonPath('data.text', 'First')
+            ->assertJsonPath('data.done', false);
+
+        $this->actingAs($admin)->postJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items", ['text' => 'Second'])
+            ->assertCreated();
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.text', 'First')
+            ->assertJsonPath('data.1.text', 'Second');
+    }
+
+    public function test_toggles_an_items_done_state(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+        $item = NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'Ship it', 'done' => false, 'sort_position' => 0]);
+
+        $response = $this->actingAs($admin)->putJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items/{$item->id}",
+            ['done' => true]
+        );
+
+        $response->assertOk()->assertJsonPath('data.done', true);
+        $this->assertTrue($item->fresh()->done);
+    }
+
+    public function test_deletes_an_item(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+        $item = NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'Doomed', 'done' => false, 'sort_position' => 0]);
+
+        $response = $this->actingAs($admin)->deleteJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items/{$item->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('note_checklist_items', ['id' => $item->id]);
+    }
+
+    public function test_the_collections_endpoint_derives_checklist_progress_from_this_structure_not_markdown(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+
+        // The note body has no markdown task-list syntax at all — checklist
+        // progress must come purely from note_checklist_items.
+        NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'A', 'done' => true, 'sort_position' => 0]);
+        NoteChecklistItem::create(['note_id' => $note->id, 'text' => 'B', 'done' => false, 'sort_position' => 1]);
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/collections");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.checklist_total', 2)
+            ->assertJsonPath('data.0.checklist_done', 1);
+    }
+
+    public function test_cannot_manage_checklist_items_in_a_workspace_the_user_is_unauthorized_for(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        [$workspace, $note] = $this->makeNote();
+
+        $response = $this->actingAs($user)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items");
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- New `note_checklist_items` table (text, done, sort_position) + `NoteChecklistItemController` — a genuinely separate card-level structure, per the explicit scope decision on #305, not derived from the note's Markdown task-list syntax
- New `ChecklistPanel.vue` drawer in `NoteEditor.vue`, mirroring the existing `CommentsPanel` pattern (add/toggle/delete items)
- Board card face's `checklist_total`/`checklist_done` (from #302) now source from this table via `withCount`, replacing the regex-over-markdown approach — reconciling with the chosen data model

Closes #305

## Test plan
- [x] `NoteChecklistItemControllerTest` (5/5, new)
- [x] `ChecklistPanel.spec.ts` (7/7, new)
- [x] `MilestoneCFinalTest` updated for the new checklist source
- [x] `vue-tsc` build clean
- [x] Full frontend suite (421/421)
- [x] Full backend suite (183/183)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>