### PR TITLE
feat: per-card activity feed (#308)

### DIFF
--- a/app/Domain/Audit/AuditRecorder.php
+++ b/app/Domain/Audit/AuditRecorder.php
@@ -14,7 +14,8 @@ final class AuditRecorder
         ?int $tenantId = null,
         ?int $workspaceId = null,
         ?string $actorId = null,
-        array $metadata = []
+        array $metadata = [],
+        ?int $noteId = null
     ): AuditLog {
         $ip = request()->ip() ?? '127.0.0.1';
 
@@ -24,6 +25,7 @@ final class AuditRecorder
         return AuditLog::query()->create([
             'tenant_id' => $tenantId,
             'workspace_id' => $workspaceId,
+            'note_id' => $noteId,
             'actor_subject_id' => $actorId,
             'actor_type' => $actorId ? 'user' : 'system',
             'actor_id' => $actorId,

--- a/app/Http/Controllers/NoteChecklistItemController.php
+++ b/app/Http/Controllers/NoteChecklistItemController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Models\Note;
 use App\Models\NoteChecklistItem;
@@ -11,13 +13,15 @@ use Illuminate\Http\Request;
 final class NoteChecklistItemController extends Controller
 {
     public function __construct(
-        private readonly IdentityProvider $identityProvider
+        private readonly IdentityProvider $identityProvider,
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder
     ) {}
 
     public function index(Request $request, int $workspaceId, int $noteId): JsonResponse
     {
-        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
-            return $denied;
+        $note = $this->authorizeAndFindNote($request, $workspaceId, $noteId);
+        if ($note instanceof JsonResponse) {
+            return $note;
         }
 
         $items = NoteChecklistItem::query()->where('note_id', $noteId)->orderBy('sort_position')->orderBy('id')->get();
@@ -27,8 +31,9 @@ final class NoteChecklistItemController extends Controller
 
     public function store(Request $request, int $workspaceId, int $noteId): JsonResponse
     {
-        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
-            return $denied;
+        $note = $this->authorizeAndFindNote($request, $workspaceId, $noteId);
+        if ($note instanceof JsonResponse) {
+            return $note;
         }
 
         $validated = $request->validate([
@@ -42,13 +47,16 @@ final class NoteChecklistItemController extends Controller
             'sort_position' => NoteChecklistItem::query()->where('note_id', $noteId)->count(),
         ]);
 
+        $this->recordActivity($request, $note, 'checklist_item_created', ['text' => $item->text]);
+
         return response()->json(['data' => $item], 201);
     }
 
     public function update(Request $request, int $workspaceId, int $noteId, int $itemId): JsonResponse
     {
-        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
-            return $denied;
+        $note = $this->authorizeAndFindNote($request, $workspaceId, $noteId);
+        if ($note instanceof JsonResponse) {
+            return $note;
         }
 
         $item = NoteChecklistItem::query()->where('note_id', $noteId)->find($itemId);
@@ -63,13 +71,18 @@ final class NoteChecklistItemController extends Controller
 
         $item->update($validated);
 
+        if (array_key_exists('done', $validated)) {
+            $this->recordActivity($request, $note, $validated['done'] ? 'checklist_item_checked' : 'checklist_item_unchecked', ['text' => $item->text]);
+        }
+
         return response()->json(['data' => $item]);
     }
 
     public function destroy(Request $request, int $workspaceId, int $noteId, int $itemId): JsonResponse
     {
-        if ($denied = $this->authorizeAndFindNote($request, $workspaceId, $noteId)) {
-            return $denied;
+        $note = $this->authorizeAndFindNote($request, $workspaceId, $noteId);
+        if ($note instanceof JsonResponse) {
+            return $note;
         }
 
         $item = NoteChecklistItem::query()->where('note_id', $noteId)->find($itemId);
@@ -82,7 +95,7 @@ final class NoteChecklistItemController extends Controller
         return response()->json(null, 204);
     }
 
-    private function authorizeAndFindNote(Request $request, int $workspaceId, int $noteId): ?JsonResponse
+    private function authorizeAndFindNote(Request $request, int $workspaceId, int $noteId): Note|JsonResponse
     {
         $subject = $this->identityProvider->resolveIdentity($request);
         if (! $subject) {
@@ -98,6 +111,19 @@ final class NoteChecklistItemController extends Controller
             return response()->json(['message' => 'Note not found.'], 404);
         }
 
-        return null;
+        return $note;
+    }
+
+    private function recordActivity(Request $request, Note $note, string $action, array $metadata): void
+    {
+        $subject = $request->attributes->get('authenticated_subject');
+        $this->auditRecorder->record(
+            event: AuditEvent::NOTE_UPDATED,
+            tenantId: $note->workspace->tenant_id,
+            workspaceId: $note->workspace_id,
+            actorId: $subject?->subjectId,
+            metadata: array_merge(['action' => $action], $metadata),
+            noteId: $note->id
+        );
     }
 }

--- a/app/Http/Controllers/WorkspaceNoteActivityController.php
+++ b/app/Http/Controllers/WorkspaceNoteActivityController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Models\AuditLog;
+use App\Models\Note;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class WorkspaceNoteActivityController extends Controller
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider
+    ) {}
+
+    public function index(Request $request, int $workspaceId, int $noteId): JsonResponse
+    {
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        $note = Note::query()->where('workspace_id', $workspaceId)->where('id', $noteId)->first();
+        if (! $note) {
+            return response()->json(['message' => 'Note not found.'], 404);
+        }
+
+        $logs = AuditLog::query()
+            ->where('note_id', $noteId)
+            ->latest('id')
+            ->limit(50)
+            ->get()
+            ->map(fn (AuditLog $log) => [
+                'id' => $log->id,
+                'event' => $log->event,
+                'metadata' => $log->metadata,
+                'actor_subject_id' => $log->actor_subject_id,
+                'created_at' => $log->created_at?->toIso8601String(),
+            ]);
+
+        return response()->json(['data' => $logs]);
+    }
+}

--- a/app/Http/Controllers/WorkspacePropertyController.php
+++ b/app/Http/Controllers/WorkspacePropertyController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
 use App\Domain\Vault\MarkdownDocument;
 use App\Domain\Vault\NotePropertyType;
 use App\Domain\Vault\VaultStorage;
@@ -31,7 +33,7 @@ final class WorkspacePropertyController extends Controller
         return response()->json(['data' => $properties]);
     }
 
-    public function setProperty(Request $request, Workspace $workspace, Note $note, VaultStorage $storage): JsonResponse
+    public function setProperty(Request $request, Workspace $workspace, Note $note, VaultStorage $storage, AuditRecorder $auditRecorder): JsonResponse
     {
         $this->ensureScopedNote($workspace, $note);
 
@@ -49,6 +51,16 @@ final class WorkspacePropertyController extends Controller
 
         $newContent = MarkdownDocument::compose($frontmatter, $parsed->body);
         $updatedNote = $storage->write($workspace, $note->path, $newContent);
+
+        $subject = $request->attributes->get('authenticated_subject');
+        $auditRecorder->record(
+            event: AuditEvent::NOTE_UPDATED,
+            tenantId: $workspace->tenant_id,
+            workspaceId: $workspace->id,
+            actorId: $subject?->subjectId,
+            metadata: ['action' => 'property_set', 'name' => $validated['name'], 'value' => $validated['value']],
+            noteId: $note->id
+        );
 
         return response()->json(['data' => $this->metadata($updatedNote)]);
     }

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -15,6 +15,7 @@ class AuditLog extends Model
     protected $fillable = [
         'tenant_id',
         'workspace_id',
+        'note_id',
         'actor_subject_id',
         'event',
         'metadata',

--- a/database/migrations/2026_08_04_000004_add_note_id_to_audit_log_table.php
+++ b/database/migrations/2026_08_04_000004_add_note_id_to_audit_log_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('audit_log', 'note_id')) {
+            Schema::table('audit_log', function (Blueprint $table) {
+                $table->foreignId('note_id')->nullable()->after('workspace_id')->constrained('notes')->nullOnDelete();
+                $table->index(['note_id', 'created_at'], 'audit_log_note_created_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('audit_log', function (Blueprint $table) {
+            $table->dropForeign(['note_id']);
+            $table->dropIndex('audit_log_note_created_index');
+            $table->dropColumn('note_id');
+        });
+    }
+};

--- a/frontend/src/ActivityPanel.spec.ts
+++ b/frontend/src/ActivityPanel.spec.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ActivityPanel from './components/ActivityPanel.vue'
+import type { NoteActivityEntry } from './services/types'
+
+const entries: NoteActivityEntry[] = [
+  { id: 1, event: 'note.updated', metadata: { action: 'property_set', name: 'status', value: 'done' }, actor_subject_id: '1', created_at: '2026-08-04T12:00:00Z' },
+  { id: 2, event: 'note.updated', metadata: { action: 'checklist_item_checked', text: 'Ship it' }, actor_subject_id: '1', created_at: '2026-08-04T11:00:00Z' },
+  { id: 3, event: 'note.updated', metadata: { action: 'checklist_item_created', text: 'Write tests' }, actor_subject_id: '1', created_at: '2026-08-04T10:00:00Z' },
+]
+
+describe('ActivityPanel', () => {
+  it('shows an empty state when there is no activity', () => {
+    const wrapper = mount(ActivityPanel, { props: { entries: [] } })
+    expect(wrapper.text()).toContain('No activity yet.')
+  })
+
+  it('renders a human-readable description for each entry type', () => {
+    const wrapper = mount(ActivityPanel, { props: { entries } })
+    const items = wrapper.findAll('[data-testid="activity-item"]')
+    expect(items).toHaveLength(3)
+    expect(items[0].text()).toContain('status')
+    expect(items[0].text()).toContain('done')
+    expect(items[1].text()).toContain('Ship it')
+    expect(items[2].text()).toContain('Write tests')
+  })
+})

--- a/frontend/src/components/ActivityPanel.vue
+++ b/frontend/src/components/ActivityPanel.vue
@@ -1,0 +1,108 @@
+<template>
+  <aside class="activity-panel" :class="{ 'panel-collapsed': collapsed }" aria-label="Activity">
+    <PanelHeader title="Activity" :count="entries.length" :collapsed="collapsed" @toggle="toggle">
+      <template #icon>
+        <svg class="icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
+          <circle cx="12" cy="12" r="10"></circle>
+          <polyline points="12 6 12 12 16 14"></polyline>
+        </svg>
+      </template>
+    </PanelHeader>
+
+    <div v-show="!collapsed" class="activity-body">
+      <div v-if="entries.length === 0" class="activity-empty">
+        <p>No activity yet.</p>
+      </div>
+
+      <ul v-else class="activity-list">
+        <li v-for="entry in entries" :key="entry.id" class="activity-item" data-testid="activity-item">
+          <span class="activity-text">{{ describe(entry) }}</span>
+          <span class="activity-date">{{ formatDate(entry.created_at) }}</span>
+        </li>
+      </ul>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import PanelHeader from './PanelHeader.vue'
+import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
+import type { NoteActivityEntry } from '../services/types'
+
+defineProps<{
+  entries: NoteActivityEntry[]
+}>()
+
+const { collapsed, toggle } = useCollapsiblePanel('activity', false)
+
+function describe(entry: NoteActivityEntry): string {
+  const meta = (entry.metadata ?? {}) as Record<string, unknown>
+  switch (meta.action) {
+    case 'property_set':
+      return `Set ${meta.name} to ${meta.value}`
+    case 'checklist_item_created':
+      return `Added checklist item "${meta.text}"`
+    case 'checklist_item_checked':
+      return `Checked off "${meta.text}"`
+    case 'checklist_item_unchecked':
+      return `Unchecked "${meta.text}"`
+    default:
+      return entry.event
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+    })
+  } catch {
+    return iso
+  }
+}
+</script>
+
+<style scoped>
+.activity-panel {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+  font-size: 0.875rem;
+  color: var(--color-text);
+}
+
+.activity-panel.panel-collapsed {
+  padding-bottom: 0;
+}
+
+.activity-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) 0;
+}
+
+.activity-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.activity-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.activity-text {
+  color: var(--color-text);
+}
+
+.activity-date {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -146,6 +146,16 @@
 
         <button
           class="btn-attach"
+          data-testid="activity-drawer-btn"
+          title="Activity"
+          :aria-expanded="isActivityDrawerOpen"
+          @click="isActivityDrawerOpen = !isActivityDrawerOpen"
+        >
+          <span>🕐</span>
+        </button>
+
+        <button
+          class="btn-attach"
           data-testid="attach-file-btn"
           :disabled="isUploading"
           @click="triggerFileInput"
@@ -429,6 +439,30 @@
       </aside>
     </Teleport>
 
+    <!-- Activity Drawer: teleported to the same right-drawer mount point.
+         Per-card activity feed (#308) — property changes (board moves,
+         archive) and checklist changes on this note, sourced from the
+         workspace's existing append-only audit log filtered by note_id. -->
+    <Teleport to="#app-right-drawer">
+      <aside
+        v-if="isActivityDrawerOpen"
+        class="comments-drawer"
+        data-testid="activity-drawer"
+      >
+        <div class="comments-drawer-header">
+          <h3>Activity</h3>
+          <button
+            type="button"
+            class="drawer-close-btn"
+            data-testid="activity-drawer-close-btn"
+            aria-label="Close activity"
+            @click="isActivityDrawerOpen = false"
+          >&times;</button>
+        </div>
+        <ActivityPanel :entries="activityEntries" />
+      </aside>
+    </Teleport>
+
     <!-- Outline Drawer: teleported to the same right-drawer mount point as
          Comments (#262), listing the note's headings for quick navigation
          (G.1, #286). -->
@@ -520,13 +554,14 @@
 
 <script setup lang="ts">
 import { ref, reactive, watch, computed, nextTick, onUnmounted, onMounted } from 'vue'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, NoteChecklistItem, UnlinkedMention, OutgoingLink } from '../services/types'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, NoteChecklistItem, NoteActivityEntry, UnlinkedMention, OutgoingLink } from '../services/types'
 import {
   uploadAttachment,
   getNoteRevisions, getNoteRevision, restoreNoteRevision,
   setNoteProperty, deleteNoteProperty,
   getNoteComments, addNoteComment, deleteNoteComment,
   getChecklistItems, createChecklistItem, updateChecklistItem, deleteChecklistItem,
+  getNoteActivity,
   getUnlinkedMentions, getNote, updateNote,
   getOutgoingLinks
 } from '../services/api'
@@ -537,6 +572,7 @@ import UnlinkedMentionsPanel from './UnlinkedMentionsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import PropertiesPanel from './PropertiesPanel.vue'
 import ChecklistPanel from './ChecklistPanel.vue'
+import ActivityPanel from './ActivityPanel.vue'
 import CommentsPanel from './CommentsPanel.vue'
 import CoverImageModal from './CoverImageModal.vue'
 import SlashMenu from './SlashMenu.vue'
@@ -738,6 +774,8 @@ const comments = ref<NoteComment[]>([])
 const commentsError = ref<string | null>(null)
 const checklistItems = ref<NoteChecklistItem[]>([])
 const isChecklistDrawerOpen = ref(false)
+const activityEntries = ref<NoteActivityEntry[]>([])
+const isActivityDrawerOpen = ref(false)
 // Deliberately NOT reset on note switch (see the watcher below) — like a
 // sidebar, staying open while browsing between notes is the expected
 // drawer behavior, not per-note ephemeral UI state.
@@ -954,9 +992,19 @@ watch(() => props.note, (newNote) => {
   showHistory.value = false
   loadComments(newNote.id)
   loadChecklistItems(newNote.id)
+  loadActivity(newNote.id)
   loadUnlinkedMentions(newNote.id)
   loadOutgoingLinks(newNote.id)
 }, { immediate: true })
+
+async function loadActivity(noteId: number) {
+  if (!props.workspaceId) return
+  try {
+    activityEntries.value = await getNoteActivity(props.workspaceId, noteId)
+  } catch (err) {
+    console.error('Failed to load activity:', err)
+  }
+}
 
 async function loadComments(noteId: number) {
   commentsError.value = null

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem } from './types'
+import type { Workspace, Tenant, NoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem, NoteActivityEntry } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -269,6 +269,11 @@ export async function updateChecklistItem(
 
 export async function deleteChecklistItem(workspaceId: number, noteId: number, itemId: number): Promise<void> {
   await api.delete(`/workspaces/${workspaceId}/notes/${noteId}/checklist-items/${itemId}`)
+}
+
+export async function getNoteActivity(workspaceId: number, noteId: number): Promise<NoteActivityEntry[]> {
+  const response = await api.get<{ data: NoteActivityEntry[] }>(`/workspaces/${workspaceId}/notes/${noteId}/activity`)
+  return response.data.data
 }
 
 export interface ImportResult {

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -198,6 +198,14 @@ export interface BoardColumnConfig {
   auto_archive?: boolean
 }
 
+export interface NoteActivityEntry {
+  id: number
+  event: string
+  metadata: Record<string, unknown> | null
+  actor_subject_id: string | null
+  created_at: string | null
+}
+
 export interface NoteChecklistItem {
   id: number
   note_id: number

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,6 +58,7 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::post('/workspaces/{workspace}/notes/{note}/checklist-items', [\App\Http\Controllers\NoteChecklistItemController::class, 'store']);
     Route::put('/workspaces/{workspace}/notes/{note}/checklist-items/{item}', [\App\Http\Controllers\NoteChecklistItemController::class, 'update']);
     Route::delete('/workspaces/{workspace}/notes/{note}/checklist-items/{item}', [\App\Http\Controllers\NoteChecklistItemController::class, 'destroy']);
+    Route::get('/workspaces/{workspace}/notes/{note}/activity', [\App\Http\Controllers\WorkspaceNoteActivityController::class, 'index']);
 
     Route::get('/workspaces/{workspace}/notifications', [\App\Http\Controllers\WorkspaceNotificationController::class, 'index']);
     Route::post('/workspaces/{workspace}/notifications/{notification}/read', [\App\Http\Controllers\WorkspaceNotificationController::class, 'markAsRead']);

--- a/tests/Feature/WorkspaceNoteActivityControllerTest.php
+++ b/tests/Feature/WorkspaceNoteActivityControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class WorkspaceNoteActivityControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeNote(): array
+    {
+        $tenant = Tenant::create(['slug' => 'activity-test-'.uniqid(), 'name' => 'Activity Test']);
+        $vaultPath = storage_path('app/vaults/activity_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'activity-'.uniqid(),
+            'name' => 'Activity Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = app(VaultStorage::class);
+        $storage->write($workspace, 'card.md', '# Card');
+        $note = Note::where('workspace_id', $workspace->id)->where('path', 'card.md')->firstOrFail();
+
+        return [$workspace, $note];
+    }
+
+    public function test_setting_a_property_records_an_activity_entry_for_the_note(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+
+        $this->actingAs($admin)->postJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/properties",
+            ['name' => 'status', 'value' => 'done']
+        )->assertOk();
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/activity");
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.event', 'note.updated')
+            ->assertJsonPath('data.0.metadata.action', 'property_set')
+            ->assertJsonPath('data.0.metadata.name', 'status')
+            ->assertJsonPath('data.0.metadata.value', 'done');
+    }
+
+    public function test_toggling_a_checklist_item_records_an_activity_entry(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $note] = $this->makeNote();
+
+        $created = $this->actingAs($admin)->postJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items",
+            ['text' => 'Ship it']
+        )->assertCreated();
+        $itemId = $created->json('data.id');
+
+        $this->actingAs($admin)->putJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/checklist-items/{$itemId}",
+            ['done' => true]
+        )->assertOk();
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/activity");
+
+        $response->assertOk();
+        $events = collect($response->json('data'))->pluck('metadata.action');
+        $this->assertTrue($events->contains('checklist_item_created'));
+        $this->assertTrue($events->contains('checklist_item_checked'));
+    }
+
+    public function test_activity_is_scoped_to_the_note_not_the_whole_workspace(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        [$workspace, $noteA] = $this->makeNote();
+
+        /** @var VaultStorage $storage */
+        $storage = app(VaultStorage::class);
+        $storage->write($workspace, 'other.md', '# Other');
+        $noteB = Note::where('workspace_id', $workspace->id)->where('path', 'other.md')->firstOrFail();
+
+        $this->actingAs($admin)->postJson(
+            "/api/workspaces/{$workspace->id}/notes/{$noteB->id}/properties",
+            ['name' => 'status', 'value' => 'done']
+        )->assertOk();
+
+        $response = $this->actingAs($admin)->getJson("/api/workspaces/{$workspace->id}/notes/{$noteA->id}/activity");
+
+        $response->assertOk()->assertJsonCount(0, 'data');
+    }
+
+    public function test_cannot_view_activity_in_a_workspace_the_user_is_unauthorized_for(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        [$workspace, $note] = $this->makeNote();
+
+        $response = $this->actingAs($user)->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}/activity");
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- `audit_log` gains a nullable `note_id`; `AuditRecorder::record()` accepts it
- Property changes (board moves, archive toggles) and checklist item create/toggle now record note-scoped audit entries
- New `GET /workspaces/{workspace}/notes/{note}/activity` endpoint returns the last 50 entries for a note
- `ActivityPanel.vue` renders them as a timeline in a new `NoteEditor.vue` drawer, mirroring `CommentsPanel`/`ChecklistPanel`

Closes #308 — last of the #299-#308 Trello board-parity batch.

## Test plan
- [x] `WorkspaceNoteActivityControllerTest` (4/4, new)
- [x] `NoteChecklistItemControllerTest` (5/5, unaffected)
- [x] `ActivityPanel.spec.ts` (2/2, new)
- [x] `vue-tsc` build clean
- [x] Full frontend suite (429/429)
- [x] Full backend suite (188/188)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>