### PR TITLE
feat: auto-create a default board for every workspace

### DIFF
--- a/app/Console/Commands/BackfillDefaultBoardsCommand.php
+++ b/app/Console/Commands/BackfillDefaultBoardsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Board;
+use App\Models\Workspace;
+use Illuminate\Console\Command;
+
+class BackfillDefaultBoardsCommand extends Command
+{
+    protected $signature = 'boards:backfill-default';
+
+    protected $description = 'Create a default board for any workspace that has none (idempotent — for workspaces that predate the auto-create-on-workspace-creation behavior)';
+
+    public function handle(): int
+    {
+        $workspaces = Workspace::query()->whereDoesntHave('boards')->get();
+
+        foreach ($workspaces as $workspace) {
+            Board::create([
+                'workspace_id' => $workspace->id,
+                'name' => 'Board',
+                'sort_position' => 0,
+            ]);
+            $this->info("Created default board for workspace #{$workspace->id} ({$workspace->name})");
+        }
+
+        if ($workspaces->isEmpty()) {
+            $this->info('Every workspace already has a board — nothing to do.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -44,4 +44,9 @@ class Workspace extends Model
     {
         return $this->hasMany(AuditLog::class);
     }
+
+    public function boards(): HasMany
+    {
+        return $this->hasMany(Board::class);
+    }
 }

--- a/app/Observers/WorkspaceObserver.php
+++ b/app/Observers/WorkspaceObserver.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Board;
+use App\Models\Workspace;
+
+class WorkspaceObserver
+{
+    public function created(Workspace $workspace): void
+    {
+        Board::create([
+            'workspace_id' => $workspace->id,
+            'name' => 'Board',
+            'sort_position' => 0,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,6 +35,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        \App\Models\Workspace::observe(\App\Observers\WorkspaceObserver::class);
     }
 }

--- a/tests/Feature/BackfillDefaultBoardsCommandTest.php
+++ b/tests/Feature/BackfillDefaultBoardsCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Board;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class BackfillDefaultBoardsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_a_default_board_only_for_workspaces_that_have_none(): void
+    {
+        $tenant = Tenant::create(['slug' => 'backfill-test', 'name' => 'Backfill Test']);
+
+        $vaultPathA = storage_path('app/vaults/backfill_a_'.uniqid());
+        mkdir($vaultPathA, 0755, true);
+        $withoutBoard = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'no-board', 'name' => 'No Board', 'vault_path' => $vaultPathA]);
+        // The auto-create-on-workspace-creation observer already gave this
+        // one a board; delete it to simulate a workspace that predates that
+        // behavior (e.g. the existing production workspace).
+        Board::query()->where('workspace_id', $withoutBoard->id)->delete();
+
+        $vaultPathB = storage_path('app/vaults/backfill_b_'.uniqid());
+        mkdir($vaultPathB, 0755, true);
+        $withBoard = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'has-board', 'name' => 'Has Board', 'vault_path' => $vaultPathB]);
+        Board::query()->where('workspace_id', $withBoard->id)->update(['name' => 'Existing Custom Board']);
+
+        $this->artisan('boards:backfill-default')->assertSuccessful();
+
+        $this->assertSame(1, Board::query()->where('workspace_id', $withoutBoard->id)->count());
+        $this->assertSame('Board', Board::query()->where('workspace_id', $withoutBoard->id)->first()->name);
+
+        $this->assertSame(1, Board::query()->where('workspace_id', $withBoard->id)->count());
+        $this->assertSame('Existing Custom Board', Board::query()->where('workspace_id', $withBoard->id)->first()->name);
+    }
+}

--- a/tests/Feature/BoardControllerTest.php
+++ b/tests/Feature/BoardControllerTest.php
@@ -31,6 +31,9 @@ final class BoardControllerTest extends TestCase
     {
         $admin = User::factory()->create(['is_admin' => true]);
         $workspace = $this->makeWorkspace();
+        // Workspace creation auto-creates a default board; this test is
+        // about ordering, not that feature, so clear it first.
+        Board::query()->where('workspace_id', $workspace->id)->delete();
         Board::create(['workspace_id' => $workspace->id, 'name' => 'Second', 'sort_position' => 1]);
         Board::create(['workspace_id' => $workspace->id, 'name' => 'First', 'sort_position' => 0]);
 

--- a/tests/Feature/WorkspaceDefaultBoardTest.php
+++ b/tests/Feature/WorkspaceDefaultBoardTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Board;
+use App\Models\Tenant;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class WorkspaceDefaultBoardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_a_workspace_automatically_creates_a_default_board(): void
+    {
+        $tenant = Tenant::create(['slug' => 'default-board-test', 'name' => 'Default Board Test']);
+        $vaultPath = storage_path('app/vaults/default_board_test_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'default-board',
+            'name' => 'Default Board Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+
+        $boards = Board::query()->where('workspace_id', $workspace->id)->get();
+
+        $this->assertCount(1, $boards);
+        $this->assertSame('Board', $boards->first()->name);
+    }
+}


### PR DESCRIPTION
## Summary
- New workspaces automatically get a default "Board" via a `WorkspaceObserver` on the `created` event
- Boards are workspace-scoped (shared by all members), not per-user — the hook lives on workspace creation, not user creation, since user creation never creates a workspace (users join existing workspaces via Membership)
- New idempotent `boards:backfill-default` Artisan command creates a default board for any pre-existing workspace without one — will be run once in production to cover the existing workspace

## Test plan
- [x] `WorkspaceDefaultBoardTest` (1/1, new)
- [x] `BackfillDefaultBoardsCommandTest` (1/1, new)
- [x] `BoardControllerTest` (8/8, adjusted for the new auto-board)
- [x] Full backend suite (190/190)
- [x] Full frontend suite (429/429, unaffected)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>