### PR TITLE
fix(dev): isolate tests across worktrees

### DIFF
--- a/docs/superpowers/plans/2026-08-10-worktree-test-isolation.md
+++ b/docs/superpowers/plans/2026-08-10-worktree-test-isolation.md
@@ -1,0 +1,138 @@
+# Worktree Test Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `scripts/jt.ps1 test` create Docker Compose resources unique to its worktree.
+
+**Architecture:** A small PowerShell helper derives a Docker-safe project name from the absolute worktree path and temporarily sets `COMPOSE_PROJECT_NAME`. The `test` verb wraps its current bootstrap and test sequence in that scope; all other verbs remain unchanged.
+
+**Tech Stack:** Windows PowerShell 5.1, .NET SHA-256, Docker Compose, Laravel, Vitest.
+
+## Global Constraints
+
+- Do not read, copy, log, or synchronize `.env` secrets between worktrees.
+- Keep the isolation exclusive to the `test` verb.
+- Restore a caller-provided `COMPOSE_PROJECT_NAME` after success and failure.
+- Do not change the behavior of `up`, `down`, `artisan`, `composer`, `npm`, `e2e`, or `release`.
+
+---
+
+### Task 1: Add the red regression harness
+
+**Files:**
+- Create: `scripts/tests/jt-compose-project-name.tests.ps1`
+- Test: `scripts/tests/jt-compose-project-name.tests.ps1`
+
+**Interfaces:** Consumes `Get-TestComposeProjectName -RepositoryPath <string>` and `Invoke-WithTestComposeProject -RepositoryPath <string> -Action <scriptblock>` from `scripts/jt-compose.ps1`.
+
+- [ ] **Step 1: Write the failing script**
+
+```powershell
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '..\jt-compose.ps1')
+function Assert-True([bool]$condition, [string]$message) { if (-not $condition) { throw $message } }
+$first = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-a'
+$same = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-a'
+$second = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-b'
+Assert-True ($first -eq $same) 'The same path must have a stable project name.'
+Assert-True ($first -ne $second) 'Different paths must have different project names.'
+Assert-True ($first -match '^jotter-test-[0-9a-f]{12}$') 'The project name must be Docker-safe.'
+$env:COMPOSE_PROJECT_NAME = 'caller-project'
+Invoke-WithTestComposeProject -RepositoryPath 'C:\work\jotter-a' -Action { Assert-True ($env:COMPOSE_PROJECT_NAME -eq $first) 'The action must receive its test project.' }
+Assert-True ($env:COMPOSE_PROJECT_NAME -eq 'caller-project') 'The caller project must be restored after success.'
+try { Invoke-WithTestComposeProject -RepositoryPath 'C:\work\jotter-a' -Action { throw 'expected failure' } } catch { Assert-True ($_.Exception.Message -eq 'expected failure') 'The action error must be preserved.' }
+Assert-True ($env:COMPOSE_PROJECT_NAME -eq 'caller-project') 'The caller project must be restored after failure.'
+Remove-Item Env:COMPOSE_PROJECT_NAME
+```
+
+- [ ] **Step 2: Verify red**
+
+Run: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/jt-compose-project-name.tests.ps1`
+
+Expected: failure because `scripts/jt-compose.ps1` does not exist.
+
+- [ ] **Step 3: Commit the test**
+
+Run: `git add scripts/tests/jt-compose-project-name.tests.ps1; git commit -m "test(dev): cover worktree Compose isolation"`
+
+### Task 2: Isolate the PowerShell test Compose project
+
+**Files:**
+- Create: `scripts/jt-compose.ps1`
+- Modify: `scripts/jt.ps1`
+- Test: `scripts/tests/jt-compose-project-name.tests.ps1`
+
+**Interfaces:** `Get-TestComposeProjectName` returns `jotter-test-<12 lowercase hex characters>`. `Invoke-WithTestComposeProject` runs an action under that name and restores the prior process environment.
+
+- [ ] **Step 1: Implement the helper**
+
+```powershell
+function Get-TestComposeProjectName {
+    param([Parameter(Mandatory = $true)][string]$RepositoryPath)
+    $path = [IO.Path]::GetFullPath($RepositoryPath).TrimEnd('\', '/').ToLowerInvariant()
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try { $hash = -join ($sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($path)) | ForEach-Object { $_.ToString('x2') }) } finally { $sha256.Dispose() }
+    "jotter-test-$($hash.Substring(0, 12))"
+}
+function Invoke-WithTestComposeProject {
+    param([Parameter(Mandatory = $true)][string]$RepositoryPath, [Parameter(Mandatory = $true)][scriptblock]$Action)
+    $previous = [Environment]::GetEnvironmentVariable('COMPOSE_PROJECT_NAME', 'Process')
+    [Environment]::SetEnvironmentVariable('COMPOSE_PROJECT_NAME', (Get-TestComposeProjectName -RepositoryPath $RepositoryPath), 'Process')
+    try { & $Action } finally { [Environment]::SetEnvironmentVariable('COMPOSE_PROJECT_NAME', $previous, 'Process') }
+}
+```
+
+- [ ] **Step 2: Load and use the helper in `jt.ps1`**
+
+Add `. (Join-Path $PSScriptRoot 'jt-compose.ps1')` after the strict-mode setup. Wrap the existing `test` switch branch, without changing its internal command order:
+
+```powershell
+'test' {
+    Invoke-WithTestComposeProject -RepositoryPath $RootDir -Action {
+        Invoke-Bootstrap
+        Initialize-TestDatabase
+        Invoke-Compose -Arguments @(
+            'run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app',
+            'php', 'artisan', 'migrate:fresh', '--seed', '--force'
+        )
+        Invoke-Compose -Arguments (@('run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app', 'php', 'artisan', 'test') + $VerbArgs)
+        Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test')
+    }
+}
+```
+
+- [ ] **Step 3: Verify green**
+
+Run: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/jt-compose-project-name.tests.ps1`
+
+Expected: exit code `0`.
+
+- [ ] **Step 4: Prove Compose receives the isolated project**
+
+Run: `. .\scripts\jt-compose.ps1; $env:COMPOSE_PROJECT_NAME = Get-TestComposeProjectName -RepositoryPath (Get-Location).Path; docker compose -f compose.yaml config --volumes; Remove-Item Env:COMPOSE_PROJECT_NAME`
+
+Expected: the configured volume begins with `jotter-test-`, not `jotter_`.
+
+- [ ] **Step 5: Commit the production change**
+
+Run: `git add scripts/jt.ps1 scripts/jt-compose.ps1; git commit -m "fix(dev): isolate test Compose projects by worktree"`
+
+### Task 3: Validate a complete isolated test run
+
+**Files:**
+- Modify: none
+- Test: `scripts/tests/jt-compose-project-name.tests.ps1`, Laravel suite, Vitest suite
+
+**Interfaces:** Consumes the scoped `test` verb from Task 2.
+
+- [ ] **Step 1: Run full verification**
+
+Run: `.\scripts\jt.ps1 test`
+
+Expected: it creates a `jotter-test-*` MySQL resource and completes without MySQL error 1045.
+
+- [ ] **Step 2: Inspect scope and repository state**
+
+Run: `docker compose -f compose.yaml ps; git diff main...HEAD --check; git status --short --branch`
+
+Expected: the development `jotter` project remains separate, and no `.env` or generated files are staged.

--- a/docs/superpowers/specs/2026-08-10-worktree-test-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-10-worktree-test-isolation-design.md
@@ -1,0 +1,46 @@
+# Worktree Test Isolation Design
+
+## Objective
+
+Make `scripts/jt.ps1 test` safe and repeatable from multiple Jotter worktrees that share a Docker host. A test run must never reuse another worktree's MySQL volume or require its secrets.
+
+## Root Cause
+
+Docker Compose currently uses the fixed project name `jotter`. Its named `mysql_data` volume is therefore shared across every worktree. Each new worktree creates its own `.env` secrets, which do not match the root password used when the shared volume was initialized. The root-only test-database bootstrap then fails with MySQL error 1045.
+
+## Selected Design
+
+The `test` verb will set `COMPOSE_PROJECT_NAME` for the lifetime of the script process to a deterministic, Docker-safe value derived from the absolute repository path. Every Compose call issued by that test run will consequently receive isolated containers, networks, and named volumes.
+
+The other verbs retain their current project name and behavior. A repeated test run from the same worktree resolves to the same isolated project, so it can reuse caches and its own MySQL volume. Different worktrees resolve to different names.
+
+## Components
+
+### `Get-TestComposeProjectName`
+
+Returns `jotter-test-<hash>`, where `<hash>` is a stable short SHA-256 digest of the normalized absolute repository path. The function uses only lowercase ASCII, digits, and hyphens, satisfying Docker Compose project-name rules. The hash avoids collisions created by similarly named worktrees and avoids exposing path details in Docker resource names.
+
+### `Use-TestComposeProject`
+
+Sets `COMPOSE_PROJECT_NAME` just before the `test` bootstrap. It preserves the previous process environment value and restores it in `finally`, including when the test command fails. This prevents a caller's shell environment from being changed after the script exits and keeps the isolation scoped to the test verb.
+
+### Test flow
+
+The `test` switch case wraps its existing bootstrap, database setup, Laravel test, and Vitest test calls with `Use-TestComposeProject`. No database SQL, credentials, or production development project resources are shared between worktrees.
+
+## Error Handling
+
+If a Compose call fails, the existing `Invoke-Compose` error is preserved. The `finally` block restores `COMPOSE_PROJECT_NAME` before the error is returned. The failure does not trigger any deletion of containers, volumes, or user `.env` files.
+
+## Verification
+
+1. Add a PowerShell regression test that imports the helper behavior and proves two different absolute paths produce different valid project names, while the same path is stable.
+2. Verify the test wrapper restores a pre-existing `COMPOSE_PROJECT_NAME` value after both success and failure paths.
+3. Run `scripts/jt.ps1 test` from a fresh linked worktree while the existing development `jotter` MySQL volume is present. The command must create a `jotter-test-*` MySQL resource and complete without error 1045.
+4. Run the normal backend and frontend suites after the isolated bootstrap.
+
+## Non-Goals
+
+- Changing `up`, `down`, `artisan`, `composer`, `npm`, `e2e`, or `release` project names.
+- Copying, reading, or synchronizing credentials from another worktree.
+- Cleaning up test volumes automatically; retaining the worktree-scoped volume supports repeatable local runs and Docker-managed cleanup.

--- a/scripts/jt-compose.ps1
+++ b/scripts/jt-compose.ps1
@@ -1,0 +1,38 @@
+function Get-TestComposeProjectName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryPath
+    )
+
+    $normalizedPath = [IO.Path]::GetFullPath($RepositoryPath).TrimEnd('\', '/').ToLowerInvariant()
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = -join ($sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedPath)) | ForEach-Object {
+            $_.ToString('x2')
+        })
+    } finally {
+        $sha256.Dispose()
+    }
+
+    return "jotter-test-$($hash.Substring(0, 12))"
+}
+
+function Invoke-WithTestComposeProject {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryPath,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action
+    )
+
+    $previousProjectName = [Environment]::GetEnvironmentVariable('COMPOSE_PROJECT_NAME', 'Process')
+    $testProjectName = Get-TestComposeProjectName -RepositoryPath $RepositoryPath
+    [Environment]::SetEnvironmentVariable('COMPOSE_PROJECT_NAME', $testProjectName, 'Process')
+
+    try {
+        & $Action
+    } finally {
+        [Environment]::SetEnvironmentVariable('COMPOSE_PROJECT_NAME', $previousProjectName, 'Process')
+    }
+}

--- a/scripts/jt.ps1
+++ b/scripts/jt.ps1
@@ -2,6 +2,8 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'jt-compose.ps1')
+
 $RootDir = Split-Path -Parent $PSScriptRoot
 Set-Location $RootDir
 
@@ -151,17 +153,19 @@ switch ($Verb) {
         Invoke-Compose -Arguments (@('down') + $VerbArgs)
     }
     'test' {
-        Invoke-Bootstrap
-        Initialize-TestDatabase
-        Invoke-Compose -Arguments @(
-            'run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app',
-            'php', 'artisan', 'migrate:fresh', '--seed', '--force'
-        )
-        Invoke-Compose -Arguments (@('run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app', 'php', 'artisan', 'test') + $VerbArgs)
-        # Test arguments target Laravel's test runner. Frontend tests use their
-        # own Vitest invocation through the `npm` verb and must not receive
-        # PHPUnit-only flags such as `--filter`.
-        Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test')
+        Invoke-WithTestComposeProject -RepositoryPath $RootDir -Action {
+            Invoke-Bootstrap
+            Initialize-TestDatabase
+            Invoke-Compose -Arguments @(
+                'run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app',
+                'php', 'artisan', 'migrate:fresh', '--seed', '--force'
+            )
+            Invoke-Compose -Arguments (@('run', '--rm', '-e', 'DB_DATABASE=jotter_testing', 'app', 'php', 'artisan', 'test') + $VerbArgs)
+            # Test arguments target Laravel's test runner. Frontend tests use their
+            # own Vitest invocation through the `npm` verb and must not receive
+            # PHPUnit-only flags such as `--filter`.
+            Invoke-Compose -Arguments @('--profile', 'dev', 'run', '--rm', '--no-deps', 'node', 'npm', 'test')
+        }
     }
     'e2e' {
         Invoke-Bootstrap

--- a/scripts/tests/jt-compose-project-name.tests.ps1
+++ b/scripts/tests/jt-compose-project-name.tests.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\jt-compose.ps1')
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$first = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-a'
+$same = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-a'
+$second = Get-TestComposeProjectName -RepositoryPath 'C:\work\jotter-b'
+
+Assert-True ($first -eq $same) 'The same path must have a stable project name.'
+Assert-True ($first -ne $second) 'Different paths must have different project names.'
+Assert-True ($first -match '^jotter-test-[0-9a-f]{12}$') 'The project name must be Docker-safe.'
+
+$env:COMPOSE_PROJECT_NAME = 'caller-project'
+Invoke-WithTestComposeProject -RepositoryPath 'C:\work\jotter-a' -Action {
+    Assert-True ($env:COMPOSE_PROJECT_NAME -eq $first) 'The action must receive its test project.'
+}
+Assert-True ($env:COMPOSE_PROJECT_NAME -eq 'caller-project') 'The caller project must be restored after success.'
+
+try {
+    Invoke-WithTestComposeProject -RepositoryPath 'C:\work\jotter-a' -Action { throw 'expected failure' }
+} catch {
+    Assert-True ($_.Exception.Message -eq 'expected failure') 'The action error must be preserved.'
+}
+Assert-True ($env:COMPOSE_PROJECT_NAME -eq 'caller-project') 'The caller project must be restored after failure.'
+
+Remove-Item Env:COMPOSE_PROJECT_NAME


### PR DESCRIPTION
## Summary
- scopes `jt.ps1 test` Docker Compose resources to a deterministic per-worktree project
- adds regression coverage for naming and environment restoration
- documents the design and implementation plan

## Root cause
All worktrees shared Compose project `jotter`, so the `mysql_data` volume could preserve a root password different from a fresh worktree’s `.env`.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/jt-compose-project-name.tests.ps1`
- `.\scripts\jt.ps1 test`

Closes #339