### PR TITLE
test(frontend): remove Teleport and notification mock warnings

### DIFF
--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -1,7 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App.vue'
-import { createNote, getWorkspaces, getAuthConfig, getTenants, getNotes, getNote, deleteNote } from './services/api'
+import { createNote, getWorkspaces, getAuthConfig, getTenants, getNotes, getNote, deleteNote, getNotifications } from './services/api'
 
 vi.mock('./services/api', () => ({
   getWorkspaces: vi.fn().mockResolvedValue([
@@ -39,7 +39,14 @@ vi.mock('./services/api', () => ({
   logout: vi.fn(),
   getCsrfCookie: vi.fn().mockResolvedValue(undefined),
   setUnauthenticatedHandler: vi.fn(),
-  getAuthConfig: vi.fn().mockResolvedValue({ provider: 'local', sso_login_url: null, version: null })
+  getAuthConfig: vi.fn().mockResolvedValue({ provider: 'local', sso_login_url: null, version: null }),
+  getNoteComments: vi.fn().mockResolvedValue([]),
+  getChecklistItems: vi.fn().mockResolvedValue([]),
+  getNoteActivity: vi.fn().mockResolvedValue([]),
+  getUnlinkedMentions: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getWorkspaceProperties: vi.fn().mockResolvedValue([]),
+  getNotifications: vi.fn().mockResolvedValue([]),
 }))
 
 beforeEach(() => {
@@ -50,6 +57,19 @@ describe('App Component', () => {
   it('renders the Jotter sidebar brand title', () => {
     const wrapper = mount(App)
     expect(wrapper.find('.brand-title').text()).toBe('Jotter')
+  })
+
+  it('loads an empty notification list without reporting a mock error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(App)
+
+    await flushPromises()
+
+    expect(getNotifications).toHaveBeenCalledWith(1)
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    errorSpy.mockRestore()
   })
 })
 

--- a/frontend/src/NoteEditor.spec.ts
+++ b/frontend/src/NoteEditor.spec.ts
@@ -769,11 +769,6 @@ describe('NoteEditor comments drawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(getNoteComments as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
-    document.body.insertAdjacentHTML('beforeend', '<div id="app-right-drawer"></div>')
-  })
-
-  afterEach(() => {
-    document.getElementById('app-right-drawer')?.remove()
   })
 
   it('does not render the drawer until toggled open', async () => {
@@ -839,11 +834,6 @@ describe('NoteEditor comments drawer', () => {
 describe('NoteEditor outline drawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    document.body.insertAdjacentHTML('beforeend', '<div id="app-right-drawer"></div>')
-  })
-
-  afterEach(() => {
-    document.getElementById('app-right-drawer')?.remove()
   })
 
   it('does not render the drawer until toggled open', async () => {
@@ -1050,11 +1040,6 @@ describe('NoteEditor wikilink embeds', () => {
 describe('NoteEditor local graph', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    document.body.insertAdjacentHTML('beforeend', '<div id="app-right-drawer"></div>')
-  })
-
-  afterEach(() => {
-    document.getElementById('app-right-drawer')?.remove()
   })
 
   it('does not render the drawer until toggled open', async () => {

--- a/frontend/src/test-setup.spec.ts
+++ b/frontend/src/test-setup.spec.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest'
+
+describe('shared Vitest setup', () => {
+  it('provides the right drawer Teleport target', () => {
+    expect(document.getElementById('app-right-drawer')).not.toBeNull()
+  })
+})

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,5 @@
 import { config } from '@vue/test-utils'
+import { afterEach, beforeEach } from 'vitest'
 import i18n from './i18n'
 
 // Reuse the app's actual i18n singleton (not a separate instance) so tests that
@@ -8,3 +9,19 @@ import i18n from './i18n'
 i18n.global.locale.value = 'en'
 
 config.global.plugins.push(i18n)
+
+function removeRightDrawerTarget() {
+  document.getElementById('app-right-drawer')?.remove()
+}
+
+beforeEach(() => {
+  removeRightDrawerTarget()
+
+  const target = document.createElement('div')
+  target.id = 'app-right-drawer'
+  document.body.append(target)
+})
+
+afterEach(() => {
+  removeRightDrawerTarget()
+})


### PR DESCRIPTION
## Summary
- provides one real `#app-right-drawer` Teleport target for every Vitest test
- removes redundant local drawer fixtures from NoteEditor tests
- completes App's API mock for notification and mounted panel reads

## Why
The frontend suite passed while repeated missing-Teleport and missing-API-export warnings obscured actionable failures.

## Validation
- `./scripts/jt.ps1 npm test`
- `./scripts/jt.ps1 test`

Closes #340