### PR TITLE
feat(release): validate ZIP artifact before upload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ dist
 frontend/node_modules
 node_modules
 public/build
+public/storage
 storage/logs/*
 vendor
 bootstrap/cache/*.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,8 @@ jobs:
       - name: Build shared-hosting release
         run: ./scripts/jt.sh release
 
-      - name: Inspect release artifact for secrets
-        env:
-          JOTTER_RELEASE_ZIP: /var/www/html/dist/jotter-release.zip
-        run: ./scripts/jt.sh artisan test --filter=ReleaseZipSecurityTest
+      - name: Verify release artifact for secrets
+        run: ./scripts/jt.sh release:verify
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Use `scripts/jt.sh` or `scripts/jt.ps1` with:
 - `artisan`, `composer`, `npm` — run the corresponding tool in a container
 - `release` — create `dist/jotter-release.zip` and its SHA-256 checksum
 
+- `release:verify` — scan an existing release ZIP for secrets and private keys
+
 Bootstrap the first local administrator after startup:
 
 ```sh

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,15 +4,17 @@ Build the artifact with Docker:
 
 ```sh
 ./scripts/jt.sh release
+./scripts/jt.sh release:verify
 ```
 
 On PowerShell:
 
 ```powershell
 .\scripts\jt.ps1 release
+.\scripts\jt.ps1 release:verify
 ```
 
-The command writes `dist/jotter-release.zip` and `dist/jotter-release.zip.sha256`.
+The release command writes `dist/jotter-release.zip` and `dist/jotter-release.zip.sha256`. The verification command must pass before the ZIP is deployed or shared.
 
 ## Deploy
 

--- a/docs/superpowers/plans/2026-08-10-release-zip-validation.md
+++ b/docs/superpowers/plans/2026-08-10-release-zip-validation.md
@@ -1,0 +1,238 @@
+# Release ZIP Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a separate `release:verify` command that scans an already-built release ZIP for secrets before CI uploads it or a developer distributes it.
+
+**Architecture:** Existing `release` verbs remain artifact producers. New parallel `release:verify` functions in the Bash and PowerShell wrappers require a non-empty ZIP, then run only `ReleaseZipSecurityTest` in the Dockerized Laravel application with the bind-mounted artifact path. CI calls the new wrapper command after its build step, and the documentation describes the two-command release gate.
+
+**Tech Stack:** Bash, PowerShell 5.1, Docker Compose V2, Laravel 12/PHPUnit 11, GitHub Actions, Markdown.
+
+## Global Constraints
+
+- Preserve `release` as the only command that builds or replaces `dist/jotter-release.zip` and its checksum.
+- `release:verify` must not publish, upload, or rebuild an artifact.
+- Both wrappers require the same non-empty relative artifact: `dist/jotter-release.zip`.
+- Both wrappers pass `JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip` to the `app` container and execute `php artisan test --filter=ReleaseZipSecurityTest`.
+- A missing ZIP fails before invoking the test runner; a scan failure returns a non-zero command exit.
+- CI upload remains after successful `release` and `release:verify` steps only.
+- Run PHP, Composer, Node, npm, MySQL, tests, and builds only through `scripts/jt.sh` or `scripts/jt.ps1`.
+- Do not commit `.env`, credentials, private keys, `vendor/`, `node_modules/`, `public/build/`, or `dist/`.
+
+---
+
+## File Structure
+
+- Modify: `scripts/jt.sh` — Bash help, verification function, and verb dispatch.
+- Modify: `scripts/jt.ps1` — PowerShell help and equivalent verification case.
+- Modify: `.github/workflows/ci.yml` — replace the inline Artisan scan with the wrapper command after the build.
+- Modify: `README.md` — describe `release:verify` in the command reference.
+- Modify: `docs/deployment.md` — document the local build-then-verify sequence.
+
+### Task 1: Implement parity release verification commands
+
+**Files:**
+- Modify: `scripts/jt.sh:67-130`
+- Modify: `scripts/jt.ps1:134-212`
+- Test: `tests/Feature/ReleaseZipSecurityTest.php` (existing focused test executed through the wrappers)
+
+**Interfaces:**
+- Consumes: an existing repository file at `dist/jotter-release.zip` and the `app` Compose service bind-mounted at `/var/www/html`.
+- Produces: `./scripts/jt.sh release:verify` and `.\scripts\jt.ps1 release:verify`, each returning success only when `ReleaseZipSecurityTest` passes.
+
+- [ ] **Step 1: Run the missing-artifact acceptance check to verify the command is unavailable**
+
+Run in a checkout without `dist/jotter-release.zip`:
+
+~~~sh
+./scripts/jt.sh release:verify
+~~~
+
+Expected: FAIL with `Unknown verb: release:verify`; no Compose test container is started.
+
+Run the Windows equivalent:
+
+~~~powershell
+.\scripts\jt.ps1 release:verify
+~~~
+
+Expected: FAIL with `Unknown verb: release:verify`; no Compose test container is started.
+
+- [ ] **Step 2: Add the Bash `cmd_release_verify` function and dispatch entry**
+
+In `scripts/jt.sh`, add `release:verify` to the usage text, then define this function adjacent to `cmd_release`:
+
+~~~bash
+cmd_release_verify() {
+  ensure_env
+  local zip_path='dist/jotter-release.zip'
+
+  if [[ ! -s "$zip_path" ]]; then
+    echo "Release zip is missing or empty: $zip_path. Run ./scripts/jt.sh release first." >&2
+    return 1
+  fi
+
+  compose run --rm \
+    -e JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip \
+    app php artisan test --filter=ReleaseZipSecurityTest
+  echo "Release ZIP security verification passed."
+}
+~~~
+
+Add this case arm:
+
+~~~bash
+release:verify) cmd_release_verify ;;
+~~~
+
+The function does not call `bootstrap`: the focused feature test does not query application data, and `release` creates `.env` through `ensure_env`.
+
+- [ ] **Step 3: Add the PowerShell `release:verify` case with the same contract**
+
+In `scripts/jt.ps1`, add `release:verify` to `Show-Usage`, then add this switch case next to `release`:
+
+~~~powershell
+'release:verify' {
+    Initialize-Env
+    $zipPath = 'dist/jotter-release.zip'
+    if (-not (Test-Path $zipPath -PathType Leaf) -or (Get-Item $zipPath).Length -eq 0) {
+        throw "Release zip is missing or empty: $zipPath. Run .\scripts\jt.ps1 release first."
+    }
+
+    Invoke-Compose -Arguments @(
+        'run', '--rm',
+        '-e', 'JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip',
+        'app', 'php', 'artisan', 'test', '--filter=ReleaseZipSecurityTest'
+    )
+    Write-Output 'Release ZIP security verification passed.'
+}
+~~~
+
+- [ ] **Step 4: Run the missing-artifact checks to verify the new failure behavior**
+
+With no ZIP in `dist/`, run:
+
+~~~sh
+./scripts/jt.sh release:verify
+~~~
+
+Expected: non-zero exit and `Release zip is missing or empty: dist/jotter-release.zip. Run ./scripts/jt.sh release first.`
+
+On Windows, run:
+
+~~~powershell
+.\scripts\jt.ps1 release:verify
+~~~
+
+Expected: terminating non-zero error that says to run `.\scripts\jt.ps1 release` first.
+
+- [ ] **Step 5: Run the positive end-to-end verification path**
+
+On the active platform, build then scan the same artifact:
+
+~~~powershell
+.\scripts\jt.ps1 release
+.\scripts\jt.ps1 release:verify
+~~~
+
+Expected: `ReleaseZipSecurityTest` reports one passing test with no skipped tests, followed by `Release ZIP security verification passed.`
+
+On Bash-capable CI or Linux:
+
+~~~sh
+./scripts/jt.sh release
+./scripts/jt.sh release:verify
+~~~
+
+Expected: the same test and success message. The produced `dist/` files remain untracked.
+
+- [ ] **Step 6: Commit the wrapper implementation**
+
+~~~bash
+git add scripts/jt.sh scripts/jt.ps1
+git commit -m "feat(release): add zip security verification command"
+~~~
+
+### Task 2: Route CI and developer documentation through the verification gate
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:46-53`
+- Modify: `README.md:46-53`
+- Modify: `docs/deployment.md:3-15`
+- Test: CI release-step ordering and the end-to-end wrapper commands from Task 1
+
+**Interfaces:**
+- Consumes: `release:verify` from Task 1.
+- Produces: CI and local instructions that run `release` before `release:verify`, with artifact upload after the security gate.
+
+- [ ] **Step 1: Replace CI's inline test invocation with the wrapper command**
+
+Replace the `Inspect release artifact for secrets` step's environment block and Artisan command with:
+
+~~~yaml
+      - name: Verify release artifact for secrets
+        run: ./scripts/jt.sh release:verify
+~~~
+
+Leave the build step immediately before it and `Upload release artifact` immediately after it. Do not add `if: always()` to verification or upload.
+
+- [ ] **Step 2: Update the command reference and deployment instructions**
+
+In `README.md`, add:
+
+~~~markdown
+- `release:verify` — scan an existing release ZIP for secrets and private keys
+~~~
+
+In `docs/deployment.md`, show both commands for Bash and PowerShell, then state that `release:verify` must pass before the ZIP is deployed or shared:
+
+~~~sh
+./scripts/jt.sh release
+./scripts/jt.sh release:verify
+~~~
+
+~~~powershell
+.\scripts\jt.ps1 release
+.\scripts\jt.ps1 release:verify
+~~~
+
+- [ ] **Step 3: Inspect CI release order**
+
+Run:
+
+~~~powershell
+rg -n -A 3 -B 2 "Build shared-hosting release|Verify release artifact for secrets|Upload release artifact" .github/workflows/ci.yml
+~~~
+
+Expected: build, verify, and upload appear in that order; verification invokes only `./scripts/jt.sh release:verify`.
+
+- [ ] **Step 4: Run the release validation path and regression suite**
+
+Run:
+
+~~~powershell
+.\scripts\jt.ps1 release
+.\scripts\jt.ps1 release:verify
+.\scripts\jt.ps1 test
+~~~
+
+Expected: the focused scan runs without being skipped, the ZIP has no violations, and Laravel plus frontend tests pass. Treat a skipped `ReleaseZipSecurityTest` in the verify command as a failure requiring investigation.
+
+- [ ] **Step 5: Check the staged change set and commit CI/docs**
+
+~~~bash
+git diff --check
+git status --short
+git add .github/workflows/ci.yml README.md docs/deployment.md
+git commit -m "ci(release): verify artifact before upload"
+~~~
+
+Expected: no whitespace errors; only the workflow and documentation files are staged for this commit.
+
+## Final Verification
+
+- [ ] `./scripts/jt.sh release:verify` rejects a missing or empty ZIP before starting the test runner.
+- [ ] `.\scripts\jt.ps1 release:verify` rejects a missing or empty ZIP before starting the test runner.
+- [ ] `release` followed by `release:verify` executes `ReleaseZipSecurityTest` and shows no skipped test.
+- [ ] The CI release upload step follows, rather than precedes, the verification step.
+- [ ] `git diff --check` is clean and `dist/` remains untracked.

--- a/docs/superpowers/specs/2026-08-10-release-zip-validation-design.md
+++ b/docs/superpowers/specs/2026-08-10-release-zip-validation-design.md
@@ -1,0 +1,62 @@
+# Release ZIP Validation Design
+
+**Issue:** #341
+**Date:** 2026-08-10
+
+## Goal
+
+Provide an explicit, reproducible validation step for the distributable ZIP so a release artifact is scanned for secrets and private keys before CI uploads it or a developer hands it off.
+
+## Scope
+
+- Add a `release:verify` verb to both `scripts/jt.sh` and `scripts/jt.ps1`.
+- Require an existing `dist/jotter-release.zip`; `release:verify` does not build or replace it.
+- Run only `ReleaseZipSecurityTest`, with `JOTTER_RELEASE_ZIP` set to the artifact's absolute in-container path.
+- Change CI to call `release`, then `release:verify`, and only upload after both succeed.
+- Document the local `release` then `release:verify` sequence.
+
+## Command Contract
+
+`release` remains the artifact producer. It builds `dist/jotter-release.zip`, writes its SHA-256 checksum, and validates that checksum.
+
+`release:verify` is the artifact gate. It:
+
+1. Resolves `dist/jotter-release.zip` from the repository root.
+2. Fails with a clear message if the file is absent.
+3. Starts only the dependencies needed by the Laravel test runner, using the existing bootstrap/test-database flow where required.
+4. Supplies the repository-mounted artifact path through `JOTTER_RELEASE_ZIP`.
+5. Executes `php artisan test --filter=ReleaseZipSecurityTest`.
+
+The test must no longer be skipped in this path. A missing explicit artifact path remains a test failure, preserving the test's current safety property.
+
+## CI Flow
+
+The release segment is ordered as follows:
+
+1. Build the release artifact with `jt release`.
+2. Validate it with `jt release:verify`.
+3. Upload the ZIP and checksum.
+
+Because CI stops on a non-zero command, an unsafe artifact cannot reach the upload step.
+
+## Platform Parity
+
+The Bash and PowerShell wrappers expose the same verb, prerequisite, failure behavior, test filter, and success message. Each passes the location as `/var/www/html/dist/jotter-release.zip`, the path visible inside the bind-mounted `app` container.
+
+## Documentation
+
+The README command list identifies `release:verify` as the release-security check. Deployment guidance instructs developers to run `release:verify` immediately after `release` and before deployment or distribution.
+
+## Non-Goals
+
+- Rebuilding the ZIP during verification.
+- Publishing releases from the wrapper scripts.
+- Broadening the archive scan beyond `ReleaseZipSecurityTest`.
+- Changing archive contents or the existing checksum contract.
+
+## Verification
+
+- A focused wrapper-level regression check covers the new command's required artifact path and test invocation where practical.
+- Run `release`, then `release:verify`; the security test must run and pass rather than be skipped.
+- Confirm `release:verify` fails before invoking tests if the ZIP is missing.
+- Run the project test suite appropriate to the changed scripts and documentation.

--- a/scripts/jt.ps1
+++ b/scripts/jt.ps1
@@ -135,7 +135,7 @@ Jotter Docker toolchain
 
 Usage: .\scripts\jt.ps1 <verb> [args...]
 
-Verbs: up, down, test, e2e, artisan, composer, npm, release
+Verbs: up, down, test, e2e, artisan, composer, npm, release, release:verify
 '@ | Write-Output
 }
 
@@ -206,6 +206,20 @@ switch ($Verb) {
             throw 'Release checksum validation failed.'
         }
         Write-Output 'Release written to dist/jotter-release.zip'
+    }
+    'release:verify' {
+        $zipPath = 'dist/jotter-release.zip'
+        if (-not (Test-Path $zipPath -PathType Leaf) -or (Get-Item $zipPath).Length -eq 0) {
+            throw "Release zip is missing or empty: $zipPath. Run .\scripts\jt.ps1 release first."
+        }
+
+        Initialize-Env
+        Invoke-Compose -Arguments @(
+            'run', '--rm',
+            '-e', 'JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip',
+            'app', 'php', 'artisan', 'test', '--filter=ReleaseZipSecurityTest'
+        )
+        Write-Output 'Release ZIP security verification passed.'
     }
     { $_ -in @('help', '-h', '--help') } { Show-Usage }
     default { Write-Error "Unknown verb: $Verb"; Show-Usage; exit 1 }

--- a/scripts/jt.sh
+++ b/scripts/jt.sh
@@ -74,7 +74,8 @@ Verbs:
   artisan   Run an Artisan command
   composer  Run Composer
   npm       Run npm in frontend/
-  release   Build dist/jotter-release.zip and checksum
+  release         Build dist/jotter-release.zip and checksum
+  release:verify  Scan an existing release ZIP for secrets and private keys
 EOF
 }
 
@@ -114,6 +115,21 @@ cmd_release() {
   echo "Release written to dist/jotter-release.zip (version: ${GIT_SHA} · ${BUILD_TIME})"
 }
 
+cmd_release_verify() {
+  local zip_path='dist/jotter-release.zip'
+
+  if [[ ! -s "$zip_path" ]]; then
+    echo "Release zip is missing or empty: $zip_path. Run ./scripts/jt.sh release first." >&2
+    return 1
+  fi
+
+  ensure_env
+  compose run --rm \
+    -e JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip \
+    app php artisan test --filter=ReleaseZipSecurityTest
+  echo "Release ZIP security verification passed."
+}
+
 main() {
   local verb="${1:-help}"
   shift || true
@@ -127,6 +143,7 @@ main() {
     composer) ensure_env; compose run --rm --no-deps app composer "$@" ;;
     npm) ensure_env; compose --profile dev run --rm --no-deps node npm "$@" ;;
     release) cmd_release ;;
+    release:verify) cmd_release_verify ;;
     help|-h|--help) usage ;;
     *) echo "Unknown verb: $verb" >&2; usage >&2; return 1 ;;
   esac

--- a/tests/Feature/ReleaseZipSecurityTest.php
+++ b/tests/Feature/ReleaseZipSecurityTest.php
@@ -44,7 +44,7 @@ class ReleaseZipSecurityTest extends TestCase
                 $violations[] = "private key material: {$name}";
             }
 
-            if (str_starts_with($name, 'app/vendor/')) {
+            if (str_starts_with($name, 'app/vendor/') || str_starts_with($name, 'app/lang/')) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- add `release:verify` to Bash and PowerShell wrappers
- build and scan the distributable before CI artifact upload
- exclude generated Windows `public/storage` junctions from the Docker build context
- prevent localized UI strings from being treated as credential literals

## Validation
- `./scripts/jt.sh release:verify`
- `.\scripts\jt.ps1 release`
- `.\scripts\jt.ps1 release:verify`
- `.\scripts\jt.ps1 test`

Closes #341