### PR TITLE
Add side-by-side note revision comparison

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,7 +11,7 @@ This file previously also carried the shipped-item changelog, decision records, 
 - **Security/correctness audit findings** → `docs/security-audit-2026.md`
 - **Visual-identity design-system tracking** (#96–#110) → `docs/visual-identity.md`
 
-As of 2026-08-19, every previously-tracked Milestone and Confluence-parity issue (#347–#360) is delivered or resolved. #51 (version history) is also delivered and verified; #355 shipped in PR #375, #356 shipped in PR #377, #357 shipped in PR #380, #358 shipped in PR #382, and #359 shipped in PR #384; #360 was resolved as a documentation decision.
+As of 2026-08-20, every previously-tracked Milestone and Confluence-parity issue (#347–#360) is delivered or resolved. #51 (version history) and its comparison follow-up #388 are delivered and verified; #355 shipped in PR #375, #356 shipped in PR #377, #357 shipped in PR #380, #358 shipped in PR #382, and #359 shipped in PR #384; #360 was resolved as a documentation decision.
 
 ---
 
@@ -22,6 +22,10 @@ All roadmap/spec decisions are resolved — see `docs/decisions.md`. This sectio
 ## Current implementation queue
 
 The roadmap's historical Phase 1 gaps are already delivered in this repository: search filters (#52), Markdown/JSON import and round-trip backup (#77/#78), templates/daily notes (#56), and version history with restore (#51). Do not create duplicate issues from the roadmap's stale gap summary; select the next new feature from a refreshed issue or audit.
+
+## Completed follow-up
+
+- ~~**Revision comparison (#388).**~~ **Delivered.** Added the ACL-protected revision comparison endpoint for revision-to-revision and revision-to-current comparisons, a bounded in-memory line diff, workspace/note isolation and 401/403/404/422 coverage, plus HistoryPanel selectors and semantic diff rendering. The restore workflow remains independent.
 
 ## WYSIWYG editor epic (decision resolved 2026-08-05 — option (b))
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,10 @@
 # Jotter — Project Status
 
 - **Current Version:** v0.9.0 (v0 spec contracts complete; v1 work in progress)
-- **Last Updated:** 2026-08-19 (#359 shipped in PR #384; #360 resolved in documentation; #51 version history verified; no open Confluence-parity issues remain)
+- **Last Updated:** 2026-08-20 (#388 revision comparison delivered; #51 version history remains complete; no open Confluence-parity issues remain)
 - **Repo:** https://github.com/suporterfid/jotter
 - **Production Site:** https://hub.taskconnect.com.br/
+- **#388 — Revision comparison:** delivered an ACL-protected revision/current line-diff endpoint, bounded in-memory diffing, HistoryPanel source/target selectors, semantic added/removed/context rows, and regression coverage. Restore remains an independent write action.
 - **CI Status:** 🟢 Green on `main`. #140 and #142 fixed via PR #144, merged and confirmed on two green GitHub Actions runs, both issues closed. **`main` is now branch-protected** (#148): the `test` CI job is a required status check, `enforce_admins` is on, force-pushes and deletions are disabled — direct pushes and merges without green CI are rejected by GitHub. Verified live: an empty direct-push commit was rejected with `Required status check "test" is expected`. This is the mechanism that was missing when #140 regressed silently after #49.
 - **Planning authority:** `docs/jotter-initial-spec-and-build-plan.md` §14 sequences post-v0 work from `docs/20260727-jotter-roadmap-ai-agent.md`
 

--- a/app/Domain/Vault/NoteRevisionDiff.php
+++ b/app/Domain/Vault/NoteRevisionDiff.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Domain\Vault;
+
+use InvalidArgumentException;
+
+/**
+ * Produces a bounded line-level diff without persisting derived data.
+ */
+final class NoteRevisionDiff
+{
+    private const DEFAULT_MAX_LINES = 5000;
+
+    /**
+     * @return array{changed: bool, lines: list<array{type: string, from_line: int|null, to_line: int|null, text: string}>}
+     */
+    public function compare(string $from, string $to, int $maxLines = self::DEFAULT_MAX_LINES): array
+    {
+        if ($maxLines < 1) {
+            throw new InvalidArgumentException('The line limit must be positive.');
+        }
+
+        $fromLines = $this->splitLines($from);
+        $toLines = $this->splitLines($to);
+
+        if (count($fromLines) > $maxLines || count($toLines) > $maxLines) {
+            throw new InvalidArgumentException('Revision comparison exceeds the line limit.');
+        }
+
+        if ($fromLines === $toLines) {
+            return ['changed' => false, 'lines' => []];
+        }
+
+        return [
+            'changed' => true,
+            'lines' => $this->formatOperations($this->operations($fromLines, $toLines)),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitLines(string $contents): array
+    {
+        $normalized = str_replace(["\r\n", "\r"], "\n", $contents);
+        $normalized = rtrim($normalized, "\n");
+
+        return $normalized === '' ? [] : explode("\n", $normalized);
+    }
+
+    /**
+     * Myers' shortest edit script keeps memory bounded by the number of lines.
+     *
+     * @param  list<string>  $from
+     * @param  list<string>  $to
+     * @return list<array{type: string, text: string}>
+     */
+    private function operations(array $from, array $to): array
+    {
+        $fromCount = count($from);
+        $toCount = count($to);
+        $max = $fromCount + $toCount;
+        $frontier = [1 => 0];
+        $trace = [];
+
+        for ($distance = 0; $distance <= $max; $distance++) {
+            $trace[] = $frontier;
+
+            for ($diagonal = -$distance; $diagonal <= $distance; $diagonal += 2) {
+                if (
+                    $diagonal === -$distance
+                    || ($diagonal !== $distance && ($frontier[$diagonal - 1] ?? 0) < ($frontier[$diagonal + 1] ?? 0))
+                ) {
+                    $fromIndex = $frontier[$diagonal + 1] ?? 0;
+                } else {
+                    $fromIndex = ($frontier[$diagonal - 1] ?? 0) + 1;
+                }
+
+                $toIndex = $fromIndex - $diagonal;
+                while (
+                    $fromIndex < $fromCount
+                    && $toIndex < $toCount
+                    && $from[$fromIndex] === $to[$toIndex]
+                ) {
+                    $fromIndex++;
+                    $toIndex++;
+                }
+
+                $frontier[$diagonal] = $fromIndex;
+
+                if ($fromIndex >= $fromCount && $toIndex >= $toCount) {
+                    return $this->backtrack($trace, $from, $to, $distance);
+                }
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  list<array<int, int>>  $trace
+     * @param  list<string>  $from
+     * @param  list<string>  $to
+     * @return list<array{type: string, text: string}>
+     */
+    private function backtrack(array $trace, array $from, array $to, int $distance): array
+    {
+        $fromIndex = count($from);
+        $toIndex = count($to);
+        $operations = [];
+
+        for ($currentDistance = $distance; $currentDistance > 0; $currentDistance--) {
+            // The trace is captured at the start of each iteration, so the
+            // entry at this distance contains the previous edit frontier.
+            $previousFrontier = $trace[$currentDistance];
+            $diagonal = $fromIndex - $toIndex;
+
+            if (
+                $diagonal === -$currentDistance
+                || ($diagonal !== $currentDistance && ($previousFrontier[$diagonal - 1] ?? 0) < ($previousFrontier[$diagonal + 1] ?? 0))
+            ) {
+                $previousDiagonal = $diagonal + 1;
+            } else {
+                $previousDiagonal = $diagonal - 1;
+            }
+
+            $previousFromIndex = $previousFrontier[$previousDiagonal] ?? 0;
+            $previousToIndex = $previousFromIndex - $previousDiagonal;
+
+            while ($fromIndex > $previousFromIndex && $toIndex > $previousToIndex) {
+                array_unshift($operations, ['type' => 'context', 'text' => $from[$fromIndex - 1]]);
+                $fromIndex--;
+                $toIndex--;
+            }
+
+            if ($fromIndex === $previousFromIndex) {
+                array_unshift($operations, ['type' => 'added', 'text' => $to[$toIndex - 1]]);
+                $toIndex--;
+            } else {
+                array_unshift($operations, ['type' => 'removed', 'text' => $from[$fromIndex - 1]]);
+                $fromIndex--;
+            }
+        }
+
+        while ($fromIndex > 0 && $toIndex > 0) {
+            array_unshift($operations, ['type' => 'context', 'text' => $from[$fromIndex - 1]]);
+            $fromIndex--;
+            $toIndex--;
+        }
+        while ($fromIndex > 0) {
+            array_unshift($operations, ['type' => 'removed', 'text' => $from[$fromIndex - 1]]);
+            $fromIndex--;
+        }
+        while ($toIndex > 0) {
+            array_unshift($operations, ['type' => 'added', 'text' => $to[$toIndex - 1]]);
+            $toIndex--;
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @param  list<array{type: string, text: string}>  $operations
+     * @return list<array{type: string, from_line: int|null, to_line: int|null, text: string}>
+     */
+    private function formatOperations(array $operations): array
+    {
+        $fromLine = 0;
+        $toLine = 0;
+        $formatted = [];
+
+        foreach ($operations as $operation) {
+            if ($operation['type'] === 'context') {
+                $fromLine++;
+                $toLine++;
+                $formatted[] = [
+                    'type' => 'context',
+                    'from_line' => $fromLine,
+                    'to_line' => $toLine,
+                    'text' => $operation['text'],
+                ];
+                continue;
+            }
+
+            if ($operation['type'] === 'removed') {
+                $fromLine++;
+                $formatted[] = [
+                    'type' => 'removed',
+                    'from_line' => $fromLine,
+                    'to_line' => null,
+                    'text' => $operation['text'],
+                ];
+                continue;
+            }
+
+            $toLine++;
+            $formatted[] = [
+                'type' => 'added',
+                'from_line' => null,
+                'to_line' => $toLine,
+                'text' => $operation['text'],
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/app/Http/Controllers/WorkspaceNoteRevisionController.php
+++ b/app/Http/Controllers/WorkspaceNoteRevisionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Domain\Auth\NoteAccess;
+use App\Domain\Vault\NoteRevisionDiff;
 use App\Domain\Vault\NoteRevisions;
 use App\Domain\Vault\VaultStorage;
 use App\Models\Note;
@@ -17,6 +18,7 @@ final class WorkspaceNoteRevisionController extends Controller
     public function __construct(
         private readonly IdentityProvider $identityProvider,
         private readonly NoteRevisions $noteRevisions,
+        private readonly NoteRevisionDiff $revisionDiff,
         private readonly VaultStorage $vaultStorage,
         private readonly NoteAccess $noteAccess,
     ) {}
@@ -49,6 +51,81 @@ final class WorkspaceNoteRevisionController extends Controller
             ->get(['id', 'note_id', 'content_hash', 'actor_id', 'created_at']);
 
         return response()->json(['data' => $revisions]);
+    }
+
+    public function compare(Request $request, int $workspaceId, int $noteId): JsonResponse
+    {
+        $validated = $request->validate([
+            'from' => ['required', 'integer', 'min:1'],
+            'to' => ['required', 'regex:/^(current|[1-9][0-9]*)$/'],
+        ]);
+
+        $subject = $this->identityProvider->resolveIdentity($request);
+        if (! $subject) {
+            return response()->json(['message' => __('messages.unauthenticated')], 401);
+        }
+
+        if (! $this->identityProvider->isAuthorizedForWorkspace($subject, $workspaceId)) {
+            return response()->json(['message' => __('messages.forbidden')], 403);
+        }
+
+        $workspace = Workspace::query()->find($workspaceId);
+        $note = Note::query()->where('workspace_id', $workspaceId)->whereKey($noteId)->first();
+        if (! $workspace || ! $note) {
+            return response()->json(['message' => __('messages.note_not_found')], 404);
+        }
+        $this->noteAccess->assertView($subject, $note);
+
+        $fromRevision = NoteRevision::query()
+            ->where('workspace_id', $workspaceId)
+            ->where('note_id', $noteId)
+            ->whereKey((int) $validated['from'])
+            ->first();
+        if (! $fromRevision) {
+            return response()->json(['message' => __('messages.revision_not_found')], 404);
+        }
+
+        $toValue = (string) $validated['to'];
+        $toRevision = $toValue === 'current'
+            ? null
+            : NoteRevision::query()
+                ->where('workspace_id', $workspaceId)
+                ->where('note_id', $noteId)
+                ->whereKey((int) $toValue)
+                ->first();
+        if ($toValue !== 'current' && ! $toRevision) {
+            return response()->json(['message' => __('messages.revision_not_found')], 404);
+        }
+
+        $fromContent = (string) $fromRevision->content;
+        $toContent = $toRevision?->content;
+        if ($toRevision === null) {
+            $toContent = $this->vaultStorage->readContents($workspace, (string) $note->path);
+        }
+
+        try {
+            $diff = $this->revisionDiff->compare($fromContent, (string) $toContent);
+        } catch (\InvalidArgumentException $exception) {
+            return response()->json(['message' => $exception->getMessage()], 422);
+        }
+
+        $toMeta = $toRevision
+            ? $toRevision->only(['id', 'note_id', 'content_hash', 'actor_id', 'created_at'])
+            : [
+                'id' => null,
+                'note_id' => $note->id,
+                'content_hash' => hash('sha256', (string) $toContent),
+                'actor_id' => null,
+                'created_at' => null,
+            ];
+
+        return response()->json([
+            'data' => [
+                'from' => $fromRevision->only(['id', 'note_id', 'content_hash', 'actor_id', 'created_at']),
+                'to' => $toMeta,
+                ...$diff,
+            ],
+        ]);
     }
 
     public function show(Request $request, int $workspaceId, int $noteId, int $revisionId): JsonResponse

--- a/frontend/src/HistoryPanel.spec.ts
+++ b/frontend/src/HistoryPanel.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import HistoryPanel from './components/HistoryPanel.vue'
+import type { NoteRevisionComparison } from './services/types'
 
 const source = readFileSync('src/components/HistoryPanel.vue', 'utf8')
 
@@ -16,6 +17,17 @@ const revisions = [
   { id: 2, note_id: 1, content_hash: 'abc123def456', actor_id: null, created_at: '2026-07-02T00:00:00Z' },
   { id: 1, note_id: 1, content_hash: '789xyz000111', actor_id: null, created_at: '2026-07-01T00:00:00Z' }
 ]
+
+const comparison: NoteRevisionComparison = {
+  from: revisions[1],
+  to: { ...revisions[0], id: null, created_at: null },
+  changed: true,
+  lines: [
+    { type: 'context', from_line: 1, to_line: 1, text: 'same' },
+    { type: 'removed', from_line: 2, to_line: null, text: 'old' },
+    { type: 'added', from_line: null, to_line: 2, text: 'new' }
+  ]
+}
 
 describe('HistoryPanel', () => {
   it('shows the empty state when there are no revisions', () => {
@@ -64,5 +76,23 @@ describe('HistoryPanel', () => {
     await wrapper.get('.modal-overlay').trigger('click')
     expect(wrapper.emitted('close')).toBeTruthy()
     wrapper.unmount()
+  })
+
+  it('emits a comparison request for the selected source and target', async () => {
+    const wrapper = mount(HistoryPanel, {
+      props: { revisions, selectedRevisionId: 2, previewContent: null }
+    })
+    await wrapper.get('[data-testid="revision-compare-btn"]').trigger('click')
+    expect(wrapper.emitted('compare-revisions')![0]).toEqual([2, 'current'])
+  })
+
+  it('renders a line comparison with semantic change markers', () => {
+    const wrapper = mount(HistoryPanel, {
+      props: { revisions, selectedRevisionId: 2, previewContent: null, comparison }
+    })
+    expect(wrapper.get('[data-testid="revision-diff"]').text()).toContain('old')
+    expect(wrapper.get('[data-testid="revision-diff"]').text()).toContain('new')
+    expect(wrapper.findAll('[data-diff-type="removed"]')).toHaveLength(1)
+    expect(wrapper.findAll('[data-diff-type="added"]')).toHaveLength(1)
   })
 })

--- a/frontend/src/NoteEditor.spec.ts
+++ b/frontend/src/NoteEditor.spec.ts
@@ -41,6 +41,13 @@ vi.mock('./services/api', () => ({
   }),
   getNote: vi.fn(),
   getNoteRevisions: vi.fn().mockResolvedValue([]),
+  getNoteRevision: vi.fn().mockResolvedValue({ id: 1, note_id: 1, content_hash: 'hash', actor_id: null, created_at: '2026-08-01T00:00:00Z', workspace_id: 1, content: 'content' }),
+  compareNoteRevisions: vi.fn().mockResolvedValue({
+    from: { id: 1, note_id: 1, content_hash: 'hash', actor_id: null, created_at: '2026-08-01T00:00:00Z' },
+    to: { id: null, note_id: 1, content_hash: 'current', actor_id: null, created_at: null },
+    changed: false,
+    lines: [],
+  }),
   getNoteActivity: vi.fn().mockResolvedValue([]),
   getChecklistItems: vi.fn().mockResolvedValue([]),
   getWorkspaceProperties: vi.fn().mockResolvedValue([]),
@@ -59,7 +66,7 @@ vi.mock('./services/api', () => ({
   requestNoteChanges: vi.fn(),
 }))
 
-import { getNoteComments, setNoteProperty, deleteNoteProperty, addNoteComment, getNote, getOutgoingLinks, restoreNoteRevision, setNoteWatching, getNoteShare, createNoteShare } from './services/api'
+import { getNoteComments, setNoteProperty, deleteNoteProperty, addNoteComment, getNote, getOutgoingLinks, getNoteRevisions, compareNoteRevisions, restoreNoteRevision, setNoteWatching, getNoteShare, createNoteShare } from './services/api'
 
 function makeNote(overrides: Partial<NoteDetail> = {}): NoteDetail {
   return {
@@ -1449,6 +1456,25 @@ describe('NoteEditor selection-driven features on the Live surface (WY.4, #324)'
     expect(wrapper.find('h1').text()).toBe('Restored')
 
     confirmSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('compares the selected revision with the current content', async () => {
+    vi.mocked(getNoteRevisions).mockResolvedValueOnce([
+      { id: 2, note_id: 1, content_hash: 'hash-2', actor_id: null, created_at: '2026-08-02T00:00:00Z' },
+      { id: 1, note_id: 1, content_hash: 'hash-1', actor_id: null, created_at: '2026-08-01T00:00:00Z' },
+    ])
+    const wrapper = mount(NoteEditor, {
+      props: { note: makeNote(), allNotes: [], workspaceId: 1 },
+    })
+    await wrapper.find('[data-testid="history-btn"]').trigger('click')
+    await flushPromises()
+    const panel = wrapper.findComponent({ name: 'HistoryPanel' })
+    await panel.get('[data-testid="revision-compare-from"]').setValue('1')
+    await panel.get('[data-testid="revision-compare-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(compareNoteRevisions).toHaveBeenCalledWith(1, 1, 1, 'current')
     wrapper.unmount()
   })
 })

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -44,32 +44,98 @@
             </div>
           </template>
         </div>
+
+        <div v-if="revisions.length > 0" class="revision-comparison-pane">
+          <div class="revision-compare-controls">
+            <label>
+              {{ t('historyPanel.compareFrom') }}
+              <select v-model="compareFromValue" data-testid="revision-compare-from">
+                <option v-for="revision in revisions" :key="revision.id" :value="String(revision.id)">
+                  {{ formatDate(revision.created_at) }}
+                </option>
+              </select>
+            </label>
+            <label>
+              {{ t('historyPanel.compareTo') }}
+              <select v-model="compareToValue" data-testid="revision-compare-to">
+                <option value="current">{{ t('historyPanel.current') }}</option>
+                <option v-for="revision in revisions" :key="revision.id" :value="String(revision.id)">
+                  {{ formatDate(revision.created_at) }}
+                </option>
+              </select>
+            </label>
+            <button
+              type="button"
+              class="btn-primary"
+              data-testid="revision-compare-btn"
+              :disabled="comparisonLoading || !compareFromValue"
+              @click="requestComparison"
+            >
+              {{ t('historyPanel.compare') }}
+            </button>
+          </div>
+
+          <div v-if="comparisonLoading" class="pane-empty">{{ t('historyPanel.loadingComparison') }}</div>
+          <div v-else-if="comparison" class="revision-diff" data-testid="revision-diff">
+            <p v-if="!comparison.changed" class="pane-empty">{{ t('historyPanel.noDifferences') }}</p>
+            <div
+              v-for="(line, index) in comparison.lines"
+              :key="index + '-' + line.type"
+              class="revision-diff-line"
+              :class="'revision-diff-line-' + line.type"
+              :data-diff-type="line.type"
+            >
+              <span class="revision-diff-line-number">{{ line.from_line ?? '·' }}</span>
+              <span class="revision-diff-line-number">{{ line.to_line ?? '·' }}</span>
+              <code>{{ line.text || ' ' }}</code>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { NoteRevisionMeta } from '../services/types'
+import type { NoteRevisionMeta, NoteRevisionComparison } from '../services/types'
 
 const { t, locale } = useI18n()
 
-defineProps<{
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'select-revision', revisionId: number): void
+  (e: 'restore-revision', revisionId: number): void
+  (e: 'compare-revisions', fromRevisionId: number, toRevisionId: number | 'current'): void
+}>()
+
+const props = defineProps<{
   revisions: NoteRevisionMeta[]
   loading?: boolean
   selectedRevisionId: number | null
   previewContent: string | null
   previewLoading?: boolean
+  comparison?: NoteRevisionComparison | null
+  comparisonLoading?: boolean
 }>()
 
-defineEmits<{
-  (e: 'close'): void
-  (e: 'select-revision', revisionId: number): void
-  (e: 'restore-revision', revisionId: number): void
-}>()
+const compareFromValue = ref(String(props.selectedRevisionId ?? props.revisions[0]?.id ?? ''))
+const compareToValue = ref<number | 'current'>('current')
 
-function formatDate(iso: string): string {
+watch(() => props.selectedRevisionId, (revisionId) => {
+  if (revisionId !== null) compareFromValue.value = String(revisionId)
+})
+
+function requestComparison(): void {
+  const fromRevisionId = Number(compareFromValue.value)
+  if (!Number.isInteger(fromRevisionId) || fromRevisionId < 1) return
+  const toRevisionId = compareToValue.value === 'current' ? 'current' : Number(compareToValue.value)
+  emit('compare-revisions', fromRevisionId, toRevisionId)
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return t('historyPanel.current')
   try {
     return new Intl.DateTimeFormat(locale.value, {
       year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
@@ -209,6 +275,68 @@ function formatDate(iso: string): string {
 .revision-actions {
   display: flex;
   justify-content: flex-end;
+}
+
+.revision-comparison-pane {
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-3) var(--space-4);
+  max-height: 42%;
+  overflow-y: auto;
+}
+
+.revision-compare-controls {
+  display: flex;
+  align-items: end;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.revision-compare-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.revision-compare-controls select {
+  min-height: 32px;
+  max-width: 150px;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.revision-diff {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.revision-diff-line {
+  display: grid;
+  grid-template-columns: 2.5rem 2.5rem minmax(0, 1fr);
+  gap: var(--space-2);
+  padding: 0.2rem var(--space-2);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.revision-diff-line-added {
+  background: color-mix(in srgb, var(--color-success, #2f9e44) 18%, transparent);
+}
+
+.revision-diff-line-removed {
+  background: color-mix(in srgb, var(--color-danger, #c92a2a) 18%, transparent);
+}
+
+.revision-diff-line-number {
+  color: var(--color-text-muted);
+  text-align: right;
+  user-select: none;
 }
 
 .btn-primary {

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -681,9 +681,12 @@
       :selected-revision-id="selectedRevisionId"
       :preview-content="revisionPreviewContent"
       :preview-loading="revisionPreviewLoading"
+      :comparison="revisionComparison"
+      :comparison-loading="revisionComparisonLoading"
       @close="showHistory = false"
       @select-revision="handleSelectRevision"
       @restore-revision="handleRestoreRevision"
+      @compare-revisions="handleCompareRevisions"
     />
   </div>
 </template>
@@ -691,12 +694,12 @@
 <script setup lang="ts">
 import { ref, reactive, watch, computed, nextTick, onUnmounted, onMounted, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteComment, NoteChecklistItem, NoteActivityEntry, UnlinkedMention, OutgoingLink, NoteShareState } from '../services/types'
+import type { NoteDetail, NoteMeta, NoteRevisionMeta, NoteRevisionComparison, NoteComment, NoteChecklistItem, NoteActivityEntry, UnlinkedMention, OutgoingLink, NoteShareState } from '../services/types'
 
 const { t } = useI18n()
 import {
   uploadAttachment,
-  getNoteRevisions, getNoteRevision, restoreNoteRevision,
+  getNoteRevisions, getNoteRevision, compareNoteRevisions, restoreNoteRevision,
   setNoteProperty, deleteNoteProperty,
   getNoteComments, addNoteComment, deleteNoteComment,
   getChecklistItems, createChecklistItem, updateChecklistItem, deleteChecklistItem,
@@ -998,6 +1001,8 @@ const revisionsLoading = ref(false)
 const selectedRevisionId = ref<number | null>(null)
 const revisionPreviewContent = ref<string | null>(null)
 const revisionPreviewLoading = ref(false)
+const revisionComparison = ref<NoteRevisionComparison | null>(null)
+const revisionComparisonLoading = ref(false)
 
 const comments = ref<NoteComment[]>([])
 const commentsError = ref<string | null>(null)
@@ -1628,6 +1633,7 @@ async function openHistory() {
   showHistory.value = true
   selectedRevisionId.value = null
   revisionPreviewContent.value = null
+  revisionComparison.value = null
   if (!props.workspaceId) return
   revisionsLoading.value = true
   try {
@@ -1651,6 +1657,24 @@ async function handleSelectRevision(revisionId: number) {
     console.error('Failed to load revision:', err)
   } finally {
     revisionPreviewLoading.value = false
+  }
+}
+
+async function handleCompareRevisions(fromRevisionId: number, toRevisionId: number | 'current') {
+  if (!props.workspaceId) return
+  revisionComparisonLoading.value = true
+  try {
+    revisionComparison.value = await compareNoteRevisions(
+      props.workspaceId,
+      props.note.id,
+      fromRevisionId,
+      toRevisionId
+    )
+  } catch (err) {
+    console.error('Failed to compare revisions:', err)
+    revisionComparison.value = null
+  } finally {
+    revisionComparisonLoading.value = false
   }
 }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -562,6 +562,12 @@ export default {
     selectToPreview: 'Select a revision to preview its content.',
     loadingPreview: 'Loading…',
     restore: 'Restore this version',
+    compareFrom: 'Compare from',
+    compareTo: 'Compare to',
+    current: 'Current content',
+    compare: 'Compare',
+    loadingComparison: 'Comparing revisions…',
+    noDifferences: 'These versions have no differences.',
   },
   markdownPreview: {
     copy: 'Copy',

--- a/frontend/src/i18n/locales/pt-BR.ts
+++ b/frontend/src/i18n/locales/pt-BR.ts
@@ -562,6 +562,12 @@ export default {
     selectToPreview: 'Selecione uma revisão para pré-visualizar o conteúdo.',
     loadingPreview: 'Carregando…',
     restore: 'Restaurar esta versão',
+    compareFrom: 'Comparar de',
+    compareTo: 'Comparar com',
+    current: 'Conteúdo atual',
+    compare: 'Comparar',
+    loadingComparison: 'Comparando revisões…',
+    noDifferences: 'Estas versões não têm diferenças.',
   },
   markdownPreview: {
     copy: 'Copiar',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Workspace, Tenant, NoteMeta, TrashNoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem, NoteActivityEntry, NoteAccessPayload, NoteAclEntry, WorkspaceGroup, NoteShareState, WorkspaceAnalytics, NoteReviewSummary } from './types'
+import type { Workspace, Tenant, NoteMeta, TrashNoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteRevisionComparison, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem, NoteActivityEntry, NoteAccessPayload, NoteAclEntry, WorkspaceGroup, NoteShareState, WorkspaceAnalytics, NoteReviewSummary } from './types'
 
 axios.defaults.withCredentials = true
 
@@ -269,6 +269,22 @@ export async function getNoteRevisions(workspaceId: number, noteId: number): Pro
 
 export async function getNoteRevision(workspaceId: number, noteId: number, revisionId: number): Promise<NoteRevisionDetail> {
   const response = await api.get<{ data: NoteRevisionDetail }>(`/workspaces/${workspaceId}/notes/${noteId}/revisions/${revisionId}`)
+  return response.data.data
+}
+
+export async function compareNoteRevisions(
+  workspaceId: number,
+  noteId: number,
+  fromRevisionId: number,
+  toRevisionId: number | 'current'
+): Promise<NoteRevisionComparison> {
+  const params = new URLSearchParams({
+    from: String(fromRevisionId),
+    to: String(toRevisionId)
+  })
+  const response = await api.get<{ data: NoteRevisionComparison }>(
+    `/workspaces/${workspaceId}/notes/${noteId}/revisions/compare?${params.toString()}`
+  )
   return response.data.data
 }
 

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -161,12 +161,32 @@ export interface NoteRevisionMeta {
   note_id: number
   content_hash: string
   actor_id: string | null
-  created_at: string
+  created_at: string | null
 }
 
 export interface NoteRevisionDetail extends NoteRevisionMeta {
   workspace_id: number
   content: string
+}
+
+export interface NoteRevisionComparisonMeta extends Omit<NoteRevisionMeta, 'id'> {
+  id: number | null
+}
+
+export type NoteRevisionDiffLineType = 'context' | 'added' | 'removed'
+
+export interface NoteRevisionDiffLine {
+  type: NoteRevisionDiffLineType
+  from_line: number | null
+  to_line: number | null
+  text: string
+}
+
+export interface NoteRevisionComparison {
+  from: NoteRevisionComparisonMeta
+  to: NoteRevisionComparisonMeta
+  changed: boolean
+  lines: NoteRevisionDiffLine[]
 }
 
 export interface NoteComment {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,4 @@
-import { config } from '@vue/test-utils'
+import { config, enableAutoUnmount } from '@vue/test-utils'
 import { afterEach, beforeEach } from 'vitest'
 import i18n from './i18n'
 
@@ -9,6 +9,7 @@ import i18n from './i18n'
 i18n.global.locale.value = 'en'
 
 config.global.plugins.push(i18n)
+enableAutoUnmount(afterEach)
 
 function removeRightDrawerTarget() {
   document.getElementById('app-right-drawer')?.remove()

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,7 @@ Route::middleware('workspace.authorization')->group(function (): void {
     Route::delete('/workspaces/{workspace}/trash/{note}', [WorkspaceTrashController::class, 'destroy'])->middleware('workspace.write');
 
     Route::get('/workspaces/{workspace}/notes/{note}/revisions', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'index']);
+    Route::get('/workspaces/{workspace}/notes/{note}/revisions/compare', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'compare']);
     Route::get('/workspaces/{workspace}/notes/{note}/revisions/{revision}', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'show']);
     Route::post('/workspaces/{workspace}/notes/{note}/revisions/{revision}/restore', [\App\Http\Controllers\WorkspaceNoteRevisionController::class, 'restore'])->middleware('workspace.write');
 

--- a/tests/Feature/NoteRevisionTest.php
+++ b/tests/Feature/NoteRevisionTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature;
 
 use App\Domain\Vault\VaultReindexer;
 use App\Domain\Vault\VaultStorage;
+use App\Models\NoteAclEntry;
 use App\Models\NoteRevision;
+use App\Models\Membership;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Models\Workspace;
@@ -89,5 +91,108 @@ final class NoteRevisionTest extends TestCase
 
         $this->assertDatabaseMissing('note_revisions', ['id' => $rev1->id]);
         $this->assertDatabaseCount('note_revisions', 3);
+    }
+
+    public function test_revisions_can_be_compared_with_current_content_and_acl_isolation(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $reader = User::factory()->create();
+        $tenant = Tenant::create(['slug' => 'compare-'.uniqid(), 'name' => 'Compare']);
+
+        $vaultPath = storage_path('app/vaults/rev_compare_'.uniqid());
+        mkdir($vaultPath, 0755, true);
+
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'compare',
+            'name' => 'Compare Workspace',
+            'vault_path' => $vaultPath,
+        ]);
+        Membership::create([
+            'subject_id' => (string) $reader->id,
+            'tenant_id' => $tenant->id,
+            'workspace_id' => $workspace->id,
+            'role' => 'viewer',
+        ]);
+
+        /** @var VaultStorage $storage */
+        $storage = $this->app->make(VaultStorage::class);
+        $note = $storage->write($workspace, 'compare.md', "same\nold");
+        $first = NoteRevision::query()->where('note_id', $note->id)->firstOrFail();
+        $storage->write($workspace, 'compare.md', "same\nnew");
+        $second = NoteRevision::query()->where('note_id', $note->id)->latest('id')->firstOrFail();
+
+        $response = $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to={$second->id}"
+        );
+
+        $response->assertOk()
+            ->assertJsonPath('data.from.id', $first->id)
+            ->assertJsonPath('data.to.id', $second->id)
+            ->assertJsonPath('data.changed', true)
+            ->assertJsonFragment(['type' => 'removed', 'text' => 'old'])
+            ->assertJsonFragment(['type' => 'added', 'text' => 'new']);
+
+        $storage->write($workspace, 'compare.md', "same\ncurrent");
+        $currentResponse = $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$second->id}&to=current"
+        );
+        $currentResponse->assertOk()
+            ->assertJsonPath('data.to.id', null)
+            ->assertJsonPath('data.to.content_hash', hash('sha256', "same\ncurrent"))
+            ->assertJsonFragment(['type' => 'removed', 'text' => 'new'])
+            ->assertJsonFragment(['type' => 'added', 'text' => 'current']);
+
+        $sameResponse = $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$second->id}&to={$second->id}"
+        );
+        $sameResponse->assertOk()->assertJsonPath('data.changed', false)->assertJsonPath('data.lines', []);
+
+        NoteAclEntry::create([
+            'note_id' => $note->id,
+            'principal_type' => 'user',
+            'principal_id' => $admin->id,
+            'permission' => 'view',
+        ]);
+        $this->actingAs($reader)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to={$second->id}"
+        )->assertNotFound();
+
+        $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to=999999"
+        )->assertNotFound();
+
+        $otherVaultPath = storage_path('app/vaults/rev_compare_other_'.uniqid());
+        mkdir($otherVaultPath, 0755, true);
+        $otherWorkspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'compare-other',
+            'name' => 'Other Compare Workspace',
+            'vault_path' => $otherVaultPath,
+        ]);
+        $otherNote = $storage->write($otherWorkspace, 'other.md', 'other');
+        $otherRevision = NoteRevision::query()->where('note_id', $otherNote->id)->firstOrFail();
+
+        $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$otherRevision->id}&to={$second->id}"
+        )->assertNotFound();
+        $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to={$otherRevision->id}"
+        )->assertNotFound();
+
+        $stranger = User::factory()->create();
+        $this->actingAs($stranger)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to={$second->id}"
+        )->assertForbidden();
+        $this->app['auth']->forgetGuards();
+        $this->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to={$second->id}"
+        )->assertUnauthorized();
+        $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?to={$second->id}"
+        )->assertStatus(422);
+        $this->actingAs($admin)->getJson(
+            "/api/workspaces/{$workspace->id}/notes/{$note->id}/revisions/compare?from={$first->id}&to=invalid"
+        )->assertStatus(422);
     }
 }

--- a/tests/Unit/NoteRevisionDiffTest.php
+++ b/tests/Unit/NoteRevisionDiffTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Vault\NoteRevisionDiff;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class NoteRevisionDiffTest extends TestCase
+{
+    public function test_it_emits_context_removed_and_added_lines_with_line_numbers(): void
+    {
+        $diff = (new NoteRevisionDiff())->compare("same\nold", "same\nnew");
+
+        $this->assertTrue($diff['changed']);
+        $this->assertSame([
+            ['type' => 'context', 'from_line' => 1, 'to_line' => 1, 'text' => 'same'],
+            ['type' => 'removed', 'from_line' => 2, 'to_line' => null, 'text' => 'old'],
+            ['type' => 'added', 'from_line' => null, 'to_line' => 2, 'text' => 'new'],
+        ], $diff['lines']);
+    }
+
+    public function test_identical_contents_have_no_lines_and_trailing_newlines_are_ignored(): void
+    {
+        $diff = (new NoteRevisionDiff())->compare("same\n", "same\r\n");
+
+        $this->assertFalse($diff['changed']);
+        $this->assertSame([], $diff['lines']);
+    }
+
+    public function test_it_handles_insertions_and_deletions_without_reordering_context(): void
+    {
+        $service = new NoteRevisionDiff();
+
+        $insertion = $service->compare("a\nc", "a\nb\nc");
+        $this->assertSame(['type' => 'added', 'from_line' => null, 'to_line' => 2, 'text' => 'b'], $insertion['lines'][1]);
+
+        $deletion = $service->compare("a\nb\nc", "a\nc");
+        $this->assertSame(['type' => 'removed', 'from_line' => 2, 'to_line' => null, 'text' => 'b'], $deletion['lines'][1]);
+    }
+
+    public function test_it_rejects_inputs_above_the_line_limit(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new NoteRevisionDiff())->compare("one\ntwo", "one\ntwo", maxLines: 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add an ACL-protected API to compare two note revisions or a revision against current content
- compute bounded in-memory line diffs with semantic context, added, and removed rows
- add HistoryPanel selectors, comparison display, localization, and regression coverage
- update STATUS.md and BACKLOG.md for issue #388

## Verification
- Backend: 363 passed, 1 skipped (1503 assertions)
- Frontend: 75 test files, 616 tests passed
- git diff --check

Closes #388