### PR TITLE
Release for multiple instances + jotter:doctor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,55 +1,83 @@
+# Jotter environment. Copy to `.env` per installation; never commit `.env`.
+# Lines marked [PROD REQUIRED] must be set on every production installation.
+# `php artisan jotter:doctor` checks most of these.
+
+# [PROD REQUIRED] Application name shown in the UI and e-mail subjects.
 APP_NAME=Jotter
+# [PROD REQUIRED] Must be `production` on a live installation.
 APP_ENV=local
+# [PROD REQUIRED] Generate once per installation: `php artisan key:generate --force`.
 APP_KEY=
+# [PROD REQUIRED] Must be `false` in production (true leaks stack traces and config).
 APP_DEBUG=true
+# [PROD REQUIRED] Public https:// URL of this installation (its own subdomain).
 APP_URL=http://localhost:8080
+# Dev only: host port published by the Docker app service.
 APP_PORT=8080
+# [PROD REQUIRED] Unique identifier for this installation when several share a
+# host (e.g. the client slug). Stamped on every log line and shown by the doctor.
+APP_INSTANCE_SLUG=
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
 APP_MAINTENANCE_DRIVER=file
 
+# `single` is the safest channel on shared hosting (one rotating file under storage/logs).
 LOG_CHANNEL=stack
 LOG_STACK=single
+# Use `warning` or `error` in production.
 LOG_LEVEL=debug
 
+# [PROD REQUIRED] One MySQL database (or one DB_PREFIX) per installation.
 DB_CONNECTION=mysql
 DB_HOST=mysql
 DB_PORT=3306
 DB_DATABASE=jotter
 DB_USERNAME=jotter
 DB_PASSWORD=
+# Optional table prefix when installations must share one database.
 DB_PREFIX=
+# Dev only: root password for the Docker MySQL service.
 MYSQL_ROOT_PASSWORD=
 
+# [PROD REQUIRED] Sessions live in MySQL; no daemon or Redis is available.
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 SESSION_PATH=/
+# Leave empty so the cookie binds to this installation's own subdomain.
 SESSION_DOMAIN=
+# Set to `true` in production (HTTPS only).
 SESSION_SECURE_COOKIE=false
 SESSION_SAME_SITE=lax
 
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
+# [PROD REQUIRED] No queue worker runs on shared hosting; keep `sync` or `database`
+# and let the scheduler (`schedule:run`) execute deferred work.
 QUEUE_CONNECTION=database
+# [PROD REQUIRED] The scheduler heartbeat and locks live in the cache table.
 CACHE_STORE=database
 
+# Seed values for the first tenant/workspace (used by `migrate --seed`).
 JOTTER_TENANT_NAME=Jotter
 JOTTER_TENANT_SLUG=default
 
+# [PROD REQUIRED] Absolute path where vaults are stored. Must exist, be writable
+# by PHP, and sit OUTSIDE the document root (e.g. /home/<user>/vaults/<slug>).
 VAULT_BASE_PATH=
 JOTTER_WORKSPACE_NAME="Default Workspace"
 JOTTER_WORKSPACE_SLUG=default
+# Optional explicit path for the seeded default workspace vault.
 JOTTER_VAULT_PATH=
 JOTTER_TRASH_RETENTION_DAYS=30
 JOTTER_TRASH_PURGE_BATCH=100
-# Private PDF export artifacts and bounded cron processing.
+# Private PDF export artifacts and bounded cron processing (outside the document root).
 JOTTER_PDF_STORAGE_PATH=
 JOTTER_PDF_RETENTION_HOURS=24
 JOTTER_PDF_PROCESS_BATCH=10
-# Comma-separated HTTPS embed hosts; empty by default.
+# Usage analytics rollups (audit_log cursor batches).
 JOTTER_ANALYTICS_ROLLUP_BATCH=500
 JOTTER_ANALYTICS_STALE_DAYS=30
 JOTTER_ANALYTICS_RECORD_READS=false
@@ -67,6 +95,8 @@ JOTTER_OIDC_POST_LOGIN_REDIRECT_URI=${APP_URL}
 JOTTER_OIDC_ALLOW_INSECURE_HTTP=false
 JOTTER_OIDC_TRUSTED_EMAIL_CLAIM=false
 
+# [PROD REQUIRED] A real transport (e.g. `smtp`) if notification e-mails should be
+# delivered; with `log` they are recorded as skipped and never sent.
 MAIL_MAILER=log
 MAIL_HOST=
 MAIL_PORT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           name: jotter-release
           path: |
-            dist/jotter-release.zip
-            dist/jotter-release.zip.sha256
+            dist/jotter-release-*.zip
+            dist/jotter-release-*.zip.sha256
 
       - name: Stop containers
         if: always()

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,6 +23,11 @@ All roadmap/spec decisions are resolved — see `docs/decisions.md`. This sectio
 
 The roadmap's historical Phase 1 gaps are already delivered in this repository: search filters (#52), Markdown/JSON import and round-trip backup (#77/#78), templates/daily notes (#56), and version history with restore (#51). Do not create duplicate issues from the roadmap's stale gap summary; select the next new feature from a refreshed issue or audit.
 
+## Operations follow-ups (from the 2026-08-31 multi-instance release)
+
+- **Trial expiry job.** There is no trial concept today; when one is introduced, register its expiry command in `routes/console.php` and add it to the scheduled-jobs table in `docs/deployment.md` (the doctor and scheduler test will need the new command name).
+- **Doctor thresholds.** Disk-space (100 MiB critical / 1 GiB warning) and scheduler age (5 minutes) are constants on `InstanceDoctor`; make them configurable only if a host proves them wrong.
+
 ## Completed follow-up
 
 - ~~**Revision comparison (#388).**~~ **Delivered.** Added the ACL-protected revision comparison endpoint for revision-to-revision and revision-to-current comparisons, a bounded in-memory line diff, workspace/note isolation and 401/403/404/422 coverage, plus HistoryPanel selectors and semantic diff rendering. The restore workflow remains independent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Jotter will be documented here. Decision records live in `docs/decisions.md`; security-audit findings live in `docs/security-audit-2026.md`; visual-identity rollout tracking lives in `docs/visual-identity.md`. Split from a single overloaded `BACKLOG.md` in #208.
 
+## v1 (post-v0) — 2026-08-31: Multi-instance release and installation doctor
+
+Shared-hosting production means one installation per client on its own subdomain, no daemon, and a single cron per installation. This entry makes the release ZIP install predictably N times on one host and lets each installation diagnose itself (`feat/multi-instance-release`).
+
+- **Versioned artifact.** `jt release` resolves the version from the exact git tag or `0.0.0-<short sha>`, writes it to `VERSION` inside the ZIP, and names the artifact `dist/jotter-release-<version>.zip` with a matching `.sha256`. `GET /api/auth/config` exposes it as `data.version`; `jt release:verify` accepts the newest ZIP or an explicit path; CI uploads the glob.
+- **`php artisan jotter:doctor`** (`--json` for machines, exit code 1 on any critical failure). Checks PHP version and required/recommended extensions, `APP_KEY`, `APP_ENV`, `APP_DEBUG`, `APP_URL` HTTPS, `storage/` and `bootstrap/cache` writability, `VAULT_BASE_PATH` existence/writability/location outside the document root, vault free disk space, database connectivity, pending migrations, `MAIL_MAILER`, `APP_INSTANCE_SLUG`, and the scheduler heartbeat (last `schedule:run` within 5 minutes). Logic lives in `App\Domain\Health\InstanceDoctor`.
+- **`GET /api/health`** — unauthenticated `{status, version, scheduler_last_run_at}`, 503 when MySQL does not answer, registered outside the `api` middleware group so session/cache/throttle failures cannot turn a 503 into a 500. Exposes no slug, path, hostname, or configuration.
+- **Scheduler is the only executor.** `routes/console.php` registers every periodic job (`notifications:send-digest`, new `notifications:process-deliveries`, `pdf:process-exports`, `analytics:rollup`, `vault:reindex --all`, `vault:purge-trash`, `vault:prune-revisions`, `audit:prune`, plus a heartbeat) for the one-line `schedule:run` cron, with cache-lock overlap protection and no `runInBackground()`. `notifications:process-deliveries` closes a real gap: `LocalJobDispatcher` only logged `SendNotificationEmail`, so pending deliveries were never sent without a queue worker. `vault:reindex` gained `--all`.
+- **`APP_INSTANCE_SLUG`** identifies an installation; it is shared into every log line's context and printed by the doctor. `.env.example` now documents every production-required variable.
+- **Rehearsal verb.** `jt release:doctor` extracts the newest ZIP into `dist/install-test/`, writes an isolated `.env`, runs `schedule:run` once, and runs the doctor inside the extracted copy (both `jt.sh` and `jt.ps1`).
+- **Docs and tests.** `docs/deployment.md` gains "Multiple instances on one shared host", the health endpoint contract, and the scheduled-jobs table; feature tests cover the doctor (ok, failure, severities, JSON), `/api/health` (200/503/no leaks), scheduler registration and heartbeat, and the deliveries command.
+
 ## v1 (post-v0) — 2026-07-29: UI audit follow-through
 
 `BACKLOG.md`'s Milestone checkmarks tracked backend/API delivery, not UI delivery — a 2026-07-29 audit of the SPA against the roadmap found 14 backend-complete features with no frontend surface. All 14 gaps (#156–#169) plus a follow-up (#197) are closed:

--- a/STATUS.md
+++ b/STATUS.md
@@ -100,6 +100,16 @@ This file previously ended at the 2026-08-05 formatting toolbar while 65 commits
 
 ---
 
+## 1.2 Delivered 2026-08-31 — multi-instance release + doctor
+
+- **Versioned release ZIP.** `jt release` writes `dist/jotter-release-<version>.zip` (+ `.sha256`) with `<version>` from the exact git tag or `0.0.0-<sha>`, and stores the same string in `VERSION` (exposed by `/api/auth/config` and `/api/health`). `jt release:verify` resolves the newest ZIP or a path argument.
+- **`jotter:doctor`.** Installation self-diagnosis (human and `--json`), exit 1 on critical failures. `jt release:doctor` rehearses an install from the ZIP inside the dev container.
+- **`GET /api/health`.** Public liveness probe: `{status, version, scheduler_last_run_at}`, 503 without MySQL, no sensitive data.
+- **Scheduler completeness.** All periodic jobs registered in `routes/console.php` for one `schedule:run` cron per installation; new `notifications:process-deliveries` executes deliveries the `JobDispatcher` only recorded; `vault:reindex --all`.
+- **`APP_INSTANCE_SLUG`** in `.env.example`, log context, and the doctor. `docs/deployment.md` documents the per-client folder layout on a shared host.
+
+---
+
 ## 2. Position against the product roadmap
 
 `docs/20260727-jotter-roadmap-ai-agent.md` ranks twelve near-term priorities. **Five of its top six already ship here** — search, nested folders, tags, backlinks, and attachments. Its gap analysis says otherwise because its baseline describes a different product (offline-first, Material You, realtime collaboration); spec §14.1 records this and §14.3 carries the authoritative delivered-state table.

--- a/app/Console/Commands/JotterDoctorCommand.php
+++ b/app/Console/Commands/JotterDoctorCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Health\DoctorCheck;
+use App\Domain\Health\InstanceDoctor;
+use Illuminate\Console\Command;
+
+final class JotterDoctorCommand extends Command
+{
+    protected $signature = 'jotter:doctor {--json : Emit a machine-readable JSON report}';
+
+    protected $description = 'Diagnose this installation: runtime, configuration, storage, database, and scheduler.';
+
+    public function handle(InstanceDoctor $doctor): int
+    {
+        $report = $doctor->run();
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($report->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return $report->hasCriticalFailures() ? self::FAILURE : self::SUCCESS;
+        }
+
+        $this->line(sprintf(
+            'Jotter doctor — instance: %s · version: %s · env: %s',
+            $report->instance ?? '(unset)',
+            $report->version ?? '(dev)',
+            $report->environment,
+        ));
+        $this->newLine();
+
+        foreach ($report->checks as $check) {
+            $this->renderCheck($check);
+        }
+
+        $summary = $report->summary();
+        $this->newLine();
+        $this->line(sprintf(
+            '%d passed, %d warning(s), %d failure(s) — status: %s',
+            $summary['passed'],
+            $summary['warnings'],
+            $summary['failures'],
+            strtoupper($report->status()),
+        ));
+
+        return $report->hasCriticalFailures() ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function renderCheck(DoctorCheck $check): void
+    {
+        $line = sprintf('%-28s %s', $check->label, $check->message);
+
+        match ($check->status()) {
+            'pass' => $this->line("<info>[PASS]</info> {$line}"),
+            'warn' => $this->line("<comment>[WARN]</comment> {$line}"),
+            default => $this->line("<error>[FAIL]</error> {$line}"),
+        };
+    }
+}

--- a/app/Console/Commands/ProcessNotificationDeliveriesCommand.php
+++ b/app/Console/Commands/ProcessNotificationDeliveriesCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Notifications\NotificationEmailService;
+use App\Models\NotificationDelivery;
+use Illuminate\Console\Command;
+
+/**
+ * Sends notification deliveries that were handed to the JobDispatcher. On shared
+ * hosting the local dispatcher only records the job, so this bounded command is
+ * the scheduler-driven executor for `SendNotificationEmail`.
+ */
+final class ProcessNotificationDeliveriesCommand extends Command
+{
+    protected $signature = 'notifications:process-deliveries {--limit=50 : Maximum deliveries to send in this run}';
+
+    protected $description = 'Send pending notification email deliveries (bounded, cron-safe).';
+
+    public function handle(NotificationEmailService $service): int
+    {
+        $limit = max(1, (int) $this->option('limit'));
+
+        $deliveries = NotificationDelivery::query()
+            ->where('channel', 'email')
+            ->where('status', 'pending')
+            ->orderBy('dispatched_at')
+            ->orderBy('id')
+            ->limit($limit)
+            ->get();
+
+        $sent = 0;
+        $failed = 0;
+        foreach ($deliveries as $delivery) {
+            $service->sendDelivery($delivery);
+            $delivery->refresh()->status === 'sent' ? $sent++ : $failed++;
+        }
+
+        $this->info("Processed {$deliveries->count()} delivery(ies): {$sent} sent, {$failed} failed.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/VaultReindexCommand.php
+++ b/app/Console/Commands/VaultReindexCommand.php
@@ -10,6 +10,7 @@ class VaultReindexCommand extends Command
 {
     protected $signature = 'vault:reindex
                             {--workspace= : Workspace id to reconcile}
+                            {--all : Reconcile every workspace (scheduler mode)}
                             {--batch= : Optional batch size override for shared-hosting limits}';
 
     protected $description = 'Rebuild the notes projection for a workspace from on-disk Markdown (bounded/batched)';
@@ -17,8 +18,12 @@ class VaultReindexCommand extends Command
     public function handle(VaultReindexer $reindexer): int
     {
         $workspaceId = $this->option('workspace');
+        if ($this->option('all')) {
+            return $this->reindexAll($reindexer);
+        }
+
         if ($workspaceId === null || $workspaceId === '') {
-            $this->error('The --workspace option is required.');
+            $this->error('The --workspace option is required (or pass --all).');
 
             return self::FAILURE;
         }
@@ -57,6 +62,28 @@ class VaultReindexCommand extends Command
             $result['upserted'],
             $result['removed'],
         ));
+
+        return self::SUCCESS;
+    }
+
+    private function reindexAll(VaultReindexer $reindexer): int
+    {
+        $count = 0;
+        Workspace::query()->orderBy('id')->each(function (Workspace $workspace) use ($reindexer, &$count): void {
+            $result = $reindexer->reindex($workspace, null);
+            $count++;
+
+            $this->line(sprintf(
+                'Reindexed workspace %d (%s): scanned %d, upserted %d, removed %d.',
+                $workspace->id,
+                $workspace->slug,
+                $result['scanned'],
+                $result['upserted'],
+                $result['removed'],
+            ));
+        });
+
+        $this->info("Reindexed {$count} workspace(s).");
 
         return self::SUCCESS;
     }

--- a/app/Domain/Health/DoctorCheck.php
+++ b/app/Domain/Health/DoctorCheck.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Domain\Health;
+
+final class DoctorCheck
+{
+    /**
+     * @param  array<string, mixed>  $details
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+        public readonly bool $critical,
+        public readonly bool $passed,
+        public readonly string $message,
+        public readonly array $details = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $details
+     */
+    public static function pass(string $id, string $label, bool $critical, string $message, array $details = []): self
+    {
+        return new self($id, $label, $critical, true, $message, $details);
+    }
+
+    /**
+     * @param  array<string, mixed>  $details
+     */
+    public static function fail(string $id, string $label, bool $critical, string $message, array $details = []): self
+    {
+        return new self($id, $label, $critical, false, $message, $details);
+    }
+
+    /**
+     * pass | warn | fail — a failed non-critical check is a warning.
+     */
+    public function status(): string
+    {
+        if ($this->passed) {
+            return 'pass';
+        }
+
+        return $this->critical ? 'fail' : 'warn';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'label' => $this->label,
+            'severity' => $this->critical ? 'critical' : 'warning',
+            'status' => $this->status(),
+            'message' => $this->message,
+            'details' => $this->details,
+        ];
+    }
+}

--- a/app/Domain/Health/DoctorReport.php
+++ b/app/Domain/Health/DoctorReport.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Domain\Health;
+
+final class DoctorReport
+{
+    /**
+     * @param  list<DoctorCheck>  $checks
+     */
+    public function __construct(
+        public readonly ?string $instance,
+        public readonly ?string $version,
+        public readonly string $environment,
+        public readonly array $checks,
+    ) {}
+
+    public function hasCriticalFailures(): bool
+    {
+        foreach ($this->checks as $check) {
+            if ($check->status() === 'fail') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * ok | warn | fail
+     */
+    public function status(): string
+    {
+        if ($this->hasCriticalFailures()) {
+            return 'fail';
+        }
+
+        foreach ($this->checks as $check) {
+            if ($check->status() === 'warn') {
+                return 'warn';
+            }
+        }
+
+        return 'ok';
+    }
+
+    /**
+     * @return array{passed: int, warnings: int, failures: int}
+     */
+    public function summary(): array
+    {
+        $summary = ['passed' => 0, 'warnings' => 0, 'failures' => 0];
+        foreach ($this->checks as $check) {
+            match ($check->status()) {
+                'pass' => $summary['passed']++,
+                'warn' => $summary['warnings']++,
+                default => $summary['failures']++,
+            };
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'instance' => $this->instance,
+            'version' => $this->version,
+            'environment' => $this->environment,
+            'status' => $this->status(),
+            'summary' => $this->summary(),
+            'checks' => array_map(static fn (DoctorCheck $check): array => $check->toArray(), $this->checks),
+        ];
+    }
+}

--- a/app/Domain/Health/InstanceDoctor.php
+++ b/app/Domain/Health/InstanceDoctor.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace App\Domain\Health;
+
+use App\Support\ReleaseVersion;
+use App\Support\SchedulerHeartbeat;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Self-diagnosis for one shared-hosting installation. Every check is pure PHP:
+ * no shelling out, no network calls beyond the configured database connection.
+ */
+final class InstanceDoctor
+{
+    public const MINIMUM_PHP_VERSION = '8.2.0';
+
+    public const SCHEDULER_MAX_AGE_MINUTES = 5;
+
+    public const DISK_CRITICAL_BYTES = 100 * 1024 * 1024;
+
+    public const DISK_WARNING_BYTES = 1024 * 1024 * 1024;
+
+    /**
+     * Extensions the runtime actually requires (composer.lock `ext-*` requirements
+     * plus the drivers this application uses directly).
+     *
+     * @var list<string>
+     */
+    public const REQUIRED_EXTENSIONS = [
+        'pdo_mysql',
+        'mbstring',
+        'openssl',
+        'tokenizer',
+        'ctype',
+        'json',
+        'fileinfo',
+        'filter',
+        'dom',
+        'libxml',
+        'iconv',
+        'session',
+        'curl',
+        'zip',
+    ];
+
+    /**
+     * Extensions that only degrade optional features when missing.
+     *
+     * @var list<string>
+     */
+    public const RECOMMENDED_EXTENSIONS = ['intl', 'bcmath', 'gd'];
+
+    public function __construct(
+        private readonly Migrator $migrator,
+    ) {}
+
+    public function run(): DoctorReport
+    {
+        $isProduction = $this->isProduction();
+        $databaseCheck = $this->checkDatabase();
+
+        $checks = [
+            $this->checkPhpVersion(),
+            $this->checkRequiredExtensions(),
+            $this->checkRecommendedExtensions(),
+            $this->checkInstanceSlug(),
+            $this->checkAppEnvironment(),
+            $this->checkAppKey(),
+            $this->checkAppDebug($isProduction),
+            $this->checkAppUrl($isProduction),
+            $this->checkWritable('storage_writable', 'storage/ writable', $this->storageDirectories()),
+            $this->checkWritable('bootstrap_cache_writable', 'bootstrap/cache writable', [base_path('bootstrap/cache')]),
+            $this->checkVaultPath(),
+            $this->checkVaultOutsideDocumentRoot(),
+            $this->checkVaultDiskSpace(),
+            $databaseCheck,
+            $this->checkPendingMigrations($databaseCheck->passed),
+            $this->checkMailer(),
+            $this->checkScheduler(),
+        ];
+
+        return new DoctorReport(
+            instance: $this->instanceSlug(),
+            version: ReleaseVersion::current(),
+            environment: (string) config('app.env'),
+            checks: $checks,
+        );
+    }
+
+    private function isProduction(): bool
+    {
+        return config('app.env') === 'production';
+    }
+
+    private function instanceSlug(): ?string
+    {
+        $slug = config('jotter.instance_slug');
+
+        return is_string($slug) && trim($slug) !== '' ? trim($slug) : null;
+    }
+
+    private function checkPhpVersion(): DoctorCheck
+    {
+        $ok = version_compare(PHP_VERSION, self::MINIMUM_PHP_VERSION, '>=');
+
+        return $ok
+            ? DoctorCheck::pass('php_version', 'PHP version', true, 'PHP '.PHP_VERSION, ['version' => PHP_VERSION])
+            : DoctorCheck::fail('php_version', 'PHP version', true, sprintf('PHP %s is below the required %s.', PHP_VERSION, self::MINIMUM_PHP_VERSION), ['version' => PHP_VERSION]);
+    }
+
+    private function checkRequiredExtensions(): DoctorCheck
+    {
+        $missing = array_values(array_filter(self::REQUIRED_EXTENSIONS, static fn (string $extension): bool => ! extension_loaded($extension)));
+
+        return $missing === []
+            ? DoctorCheck::pass('php_extensions', 'Required PHP extensions', true, 'All required extensions are loaded.', ['required' => self::REQUIRED_EXTENSIONS])
+            : DoctorCheck::fail('php_extensions', 'Required PHP extensions', true, 'Missing: '.implode(', ', $missing), ['missing' => $missing]);
+    }
+
+    private function checkRecommendedExtensions(): DoctorCheck
+    {
+        $missing = array_values(array_filter(self::RECOMMENDED_EXTENSIONS, static fn (string $extension): bool => ! extension_loaded($extension)));
+
+        return $missing === []
+            ? DoctorCheck::pass('php_recommended_extensions', 'Recommended PHP extensions', false, 'All recommended extensions are loaded.', ['recommended' => self::RECOMMENDED_EXTENSIONS])
+            : DoctorCheck::fail('php_recommended_extensions', 'Recommended PHP extensions', false, 'Missing (optional features degrade): '.implode(', ', $missing), ['missing' => $missing]);
+    }
+
+    private function checkInstanceSlug(): DoctorCheck
+    {
+        $slug = $this->instanceSlug();
+
+        return $slug !== null
+            ? DoctorCheck::pass('instance_slug', 'APP_INSTANCE_SLUG', false, $slug, ['slug' => $slug])
+            : DoctorCheck::fail('instance_slug', 'APP_INSTANCE_SLUG', false, 'Not set. Give each installation a unique slug so logs and diagnostics can be told apart.');
+    }
+
+    private function checkAppEnvironment(): DoctorCheck
+    {
+        $environment = (string) config('app.env');
+
+        return $environment === 'production'
+            ? DoctorCheck::pass('app_env', 'APP_ENV', false, 'production', ['environment' => $environment])
+            : DoctorCheck::fail('app_env', 'APP_ENV', false, sprintf("APP_ENV is '%s'; production installations must set APP_ENV=production.", $environment), ['environment' => $environment]);
+    }
+
+    private function checkAppKey(): DoctorCheck
+    {
+        $key = (string) config('app.key');
+
+        return trim($key) !== ''
+            ? DoctorCheck::pass('app_key', 'APP_KEY', true, 'Set.')
+            : DoctorCheck::fail('app_key', 'APP_KEY', true, 'APP_KEY is empty. Run `php artisan key:generate --force` once per installation.');
+    }
+
+    private function checkAppDebug(bool $isProduction): DoctorCheck
+    {
+        $debug = (bool) config('app.debug');
+
+        if (! $debug) {
+            return DoctorCheck::pass('app_debug', 'APP_DEBUG', $isProduction, 'false');
+        }
+
+        return DoctorCheck::fail('app_debug', 'APP_DEBUG', $isProduction, 'APP_DEBUG=true leaks stack traces and configuration; set APP_DEBUG=false in production.');
+    }
+
+    private function checkAppUrl(bool $isProduction): DoctorCheck
+    {
+        $url = (string) config('app.url');
+
+        return str_starts_with(strtolower($url), 'https://')
+            ? DoctorCheck::pass('app_url_https', 'APP_URL uses HTTPS', $isProduction, $url, ['url' => $url])
+            : DoctorCheck::fail('app_url_https', 'APP_URL uses HTTPS', $isProduction, sprintf("APP_URL is '%s'; production installations must use an https:// URL.", $url), ['url' => $url]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storageDirectories(): array
+    {
+        return [
+            storage_path(),
+            storage_path('app'),
+            storage_path('framework/cache'),
+            storage_path('framework/sessions'),
+            storage_path('framework/views'),
+            storage_path('logs'),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $directories
+     */
+    private function checkWritable(string $id, string $label, array $directories): DoctorCheck
+    {
+        $problems = [];
+        foreach ($directories as $directory) {
+            if (! is_dir($directory)) {
+                $problems[] = $directory.' (missing)';
+            } elseif (! is_writable($directory)) {
+                $problems[] = $directory.' (not writable)';
+            }
+        }
+
+        return $problems === []
+            ? DoctorCheck::pass($id, $label, true, 'Writable.', ['directories' => $directories])
+            : DoctorCheck::fail($id, $label, true, implode('; ', $problems), ['problems' => $problems]);
+    }
+
+    private function vaultBasePath(): string
+    {
+        return (string) config('vault.base_path');
+    }
+
+    private function checkVaultPath(): DoctorCheck
+    {
+        $path = $this->vaultBasePath();
+        $details = ['path' => $path, 'explicit' => $path !== storage_path('app/vaults')];
+
+        if (trim($path) === '') {
+            return DoctorCheck::fail('vault_path', 'VAULT_BASE_PATH', true, 'VAULT_BASE_PATH resolves to an empty path.', $details);
+        }
+
+        if (! is_dir($path)) {
+            return DoctorCheck::fail('vault_path', 'VAULT_BASE_PATH', true, sprintf('%s does not exist or is not a directory.', $path), $details);
+        }
+
+        if (! is_writable($path)) {
+            return DoctorCheck::fail('vault_path', 'VAULT_BASE_PATH', true, sprintf('%s is not writable by PHP.', $path), $details);
+        }
+
+        return DoctorCheck::pass('vault_path', 'VAULT_BASE_PATH', true, $path, $details);
+    }
+
+    private function checkVaultOutsideDocumentRoot(): DoctorCheck
+    {
+        // realpath('') resolves to the working directory; never let an empty path pass.
+        $vault = trim($this->vaultBasePath()) === '' ? false : realpath($this->vaultBasePath());
+        $documentRoot = realpath(public_path());
+        $details = ['vault' => $vault ?: $this->vaultBasePath(), 'document_root' => $documentRoot ?: public_path()];
+
+        if ($vault === false || $documentRoot === false) {
+            return DoctorCheck::fail('vault_outside_docroot', 'Vault outside document root', true, 'Cannot resolve the vault or document root path.', $details);
+        }
+
+        $inside = $vault === $documentRoot || str_starts_with($vault.DIRECTORY_SEPARATOR, $documentRoot.DIRECTORY_SEPARATOR);
+
+        return $inside
+            ? DoctorCheck::fail('vault_outside_docroot', 'Vault outside document root', true, sprintf('%s is inside the document root %s; notes would be served as static files.', $vault, $documentRoot), $details)
+            : DoctorCheck::pass('vault_outside_docroot', 'Vault outside document root', true, 'Vault is not under public/.', $details);
+    }
+
+    private function checkVaultDiskSpace(): DoctorCheck
+    {
+        $path = $this->vaultBasePath();
+        $free = is_dir($path) ? @disk_free_space($path) : false;
+
+        if ($free === false) {
+            return DoctorCheck::fail('vault_disk_space', 'Vault free disk space', false, 'Could not determine free disk space for the vault path.', ['path' => $path]);
+        }
+
+        $details = ['path' => $path, 'free_bytes' => (int) $free, 'free_human' => $this->humanBytes((int) $free)];
+
+        if ($free < self::DISK_CRITICAL_BYTES) {
+            return DoctorCheck::fail('vault_disk_space', 'Vault free disk space', true, sprintf('Only %s free; writes will start failing.', $details['free_human']), $details);
+        }
+
+        if ($free < self::DISK_WARNING_BYTES) {
+            return DoctorCheck::fail('vault_disk_space', 'Vault free disk space', false, sprintf('%s free; below the 1 GiB comfort margin.', $details['free_human']), $details);
+        }
+
+        return DoctorCheck::pass('vault_disk_space', 'Vault free disk space', true, $details['free_human'].' free', $details);
+    }
+
+    private function checkDatabase(): DoctorCheck
+    {
+        $connection = (string) config('database.default');
+
+        try {
+            DB::connection()->select('select 1');
+
+            return DoctorCheck::pass('database', 'Database connection', true, sprintf('Connected (%s).', $connection), ['connection' => $connection]);
+        } catch (\Throwable $exception) {
+            return DoctorCheck::fail('database', 'Database connection', true, 'Cannot connect: '.$this->sanitize($exception->getMessage()), ['connection' => $connection]);
+        }
+    }
+
+    private function checkPendingMigrations(bool $databaseReachable): DoctorCheck
+    {
+        if (! $databaseReachable) {
+            return DoctorCheck::fail('migrations', 'Pending migrations', true, 'Skipped: database unavailable.');
+        }
+
+        try {
+            if (! $this->migrator->repositoryExists()) {
+                $pending = array_keys($this->migrator->getMigrationFiles($this->migrationPaths()));
+            } else {
+                $ran = $this->migrator->getRepository()->getRan();
+                $pending = array_values(array_diff(array_keys($this->migrator->getMigrationFiles($this->migrationPaths())), $ran));
+            }
+        } catch (\Throwable $exception) {
+            return DoctorCheck::fail('migrations', 'Pending migrations', true, 'Could not read migration state: '.$this->sanitize($exception->getMessage()));
+        }
+
+        return $pending === []
+            ? DoctorCheck::pass('migrations', 'Pending migrations', true, 'None.')
+            : DoctorCheck::fail('migrations', 'Pending migrations', true, sprintf('%d pending; run `php artisan migrate --force`.', count($pending)), ['pending' => $pending]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function migrationPaths(): array
+    {
+        return array_values(array_unique(array_merge($this->migrator->paths(), [database_path('migrations')])));
+    }
+
+    private function checkMailer(): DoctorCheck
+    {
+        $mailer = (string) config('mail.default');
+
+        return $mailer !== 'log'
+            ? DoctorCheck::pass('mail_mailer', 'MAIL_MAILER', false, $mailer, ['mailer' => $mailer])
+            : DoctorCheck::fail('mail_mailer', 'MAIL_MAILER', false, 'MAIL_MAILER=log: notification emails are recorded as skipped and never delivered.', ['mailer' => $mailer]);
+    }
+
+    private function checkScheduler(): DoctorCheck
+    {
+        $lastRun = SchedulerHeartbeat::lastRunAt();
+        $details = ['last_run_at' => $lastRun?->toIso8601String(), 'max_age_minutes' => self::SCHEDULER_MAX_AGE_MINUTES];
+
+        if ($lastRun === null) {
+            return DoctorCheck::fail('scheduler', 'Scheduler heartbeat', true, 'No `schedule:run` recorded yet. Add the per-minute cron entry for this installation.', $details);
+        }
+
+        $ageMinutes = $lastRun->diffInMinutes(CarbonImmutable::now());
+        $details['age_minutes'] = (int) floor($ageMinutes);
+
+        return $ageMinutes <= self::SCHEDULER_MAX_AGE_MINUTES
+            ? DoctorCheck::pass('scheduler', 'Scheduler heartbeat', true, sprintf('Last run %s.', $lastRun->diffForHumans()), $details)
+            : DoctorCheck::fail('scheduler', 'Scheduler heartbeat', true, sprintf('Last run %s; the cron entry is missing or stalled.', $lastRun->diffForHumans()), $details);
+    }
+
+    private function humanBytes(int $bytes): string
+    {
+        $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+        $value = (float) $bytes;
+        $unit = 0;
+        while ($value >= 1024 && $unit < count($units) - 1) {
+            $value /= 1024;
+            $unit++;
+        }
+
+        return sprintf($unit === 0 ? '%d %s' : '%.1f %s', $value, $units[$unit]);
+    }
+
+    /**
+     * Keep credentials out of diagnostics: PDO messages can echo the DSN.
+     */
+    private function sanitize(string $message): string
+    {
+        $message = preg_replace('/password=[^;\s]*/i', 'password=***', $message) ?? $message;
+
+        return mb_substr(trim($message), 0, 200);
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Domain\Vault\ExternalEmbedPolicy;
+use App\Support\ReleaseVersion;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -68,14 +69,11 @@ final class AuthController extends Controller
             $ssoLoginUrl = url('/api/auth/oidc/redirect');
         }
 
-        $versionFile = base_path('VERSION');
-        $version = file_exists($versionFile) ? trim(file_get_contents($versionFile)) : null;
-
         return response()->json([
             'data' => [
                 'provider' => $provider,
                 'sso_login_url' => $ssoLoginUrl,
-                'version' => $version,
+                'version' => ReleaseVersion::current(),
                 'external_embed_domains' => ExternalEmbedPolicy::configured()->allowedHosts(),
             ],
         ]);

--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Support\ReleaseVersion;
+use App\Support\SchedulerHeartbeat;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Unauthenticated liveness probe for one installation. It intentionally exposes
+ * only the release version and the scheduler heartbeat: no hostnames, paths,
+ * database names, instance slug, or configuration values.
+ */
+final class HealthController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $databaseReachable = $this->databaseReachable();
+
+        return response()
+            ->json([
+                'status' => $databaseReachable ? 'ok' : 'unavailable',
+                'version' => ReleaseVersion::current(),
+                'scheduler_last_run_at' => SchedulerHeartbeat::lastRunAt()?->toIso8601String(),
+            ], $databaseReachable ? 200 : 503)
+            ->header('Cache-Control', 'no-store');
+    }
+
+    private function databaseReachable(): bool
+    {
+        try {
+            DB::connection()->select('select 1');
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -43,5 +44,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         \App\Models\Workspace::observe(\App\Observers\WorkspaceObserver::class);
+
+        // Several installations may share one host; stamp every log line with the
+        // installation slug so they can be told apart when logs are aggregated.
+        $instance = config('jotter.instance_slug');
+        if (is_string($instance) && trim($instance) !== '') {
+            Log::shareContext(['instance' => trim($instance)]);
+        }
     }
 }

--- a/app/Support/ReleaseVersion.php
+++ b/app/Support/ReleaseVersion.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Resolves the release version written by `jt release` into `VERSION` at the
+ * application root. Development checkouts have no VERSION file and report null.
+ */
+final class ReleaseVersion
+{
+    public static function current(): ?string
+    {
+        $path = base_path('VERSION');
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            return null;
+        }
+
+        $version = trim($contents);
+
+        return $version === '' ? null : $version;
+    }
+}

--- a/app/Support/SchedulerHeartbeat.php
+++ b/app/Support/SchedulerHeartbeat.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Records when `php artisan schedule:run` last executed so the doctor command
+ * and the health endpoint can tell whether the per-installation cron is alive.
+ */
+final class SchedulerHeartbeat
+{
+    public const CACHE_KEY = 'jotter:scheduler:last_run_at';
+
+    public static function record(): void
+    {
+        Cache::forever(self::CACHE_KEY, CarbonImmutable::now()->toIso8601String());
+    }
+
+    public static function lastRunAt(): ?CarbonImmutable
+    {
+        try {
+            $value = Cache::get(self::CACHE_KEY);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,8 +1,18 @@
 <?php
 
+use App\Http\Controllers\HealthController;
+use App\Http\Middleware\AuthorizeWorkspaceAccess;
+use App\Http\Middleware\AuthorizeWorkspaceWrite;
+use App\Http\Middleware\SetLocaleFromSubject;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -10,29 +20,35 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            // Unauthenticated liveness probe registered outside the `api` group on
+            // purpose: the session, cookie, and throttle middleware all touch the
+            // database, and this route must answer 503 (not 500) when MySQL is down.
+            Route::get('/api/health', HealthController::class)->name('health');
+        },
     )
     ->withCommands([
         __DIR__.'/../app/Console/Commands',
     ])
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->api(append: [
-            \Illuminate\Cookie\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\SetLocaleFromSubject::class,
+            EncryptCookies::class,
+            AddQueuedCookiesToResponse::class,
+            StartSession::class,
+            ShareErrorsFromSession::class,
+            SetLocaleFromSubject::class,
         ]);
 
         // Markdown is canonical file content: preserve intentional whitespace and empty notes.
         $middleware->trimStrings(except: ['content']);
         $middleware->convertEmptyStringsToNull(except: [
-            fn (\Illuminate\Http\Request $request): bool => $request->is('api/workspaces/*/notes*')
+            fn (Request $request): bool => $request->is('api/workspaces/*/notes*')
                 && $request->has('content'),
         ]);
 
         $middleware->alias([
-            'workspace.authorization' => \App\Http\Middleware\AuthorizeWorkspaceAccess::class,
-            'workspace.write' => \App\Http\Middleware\AuthorizeWorkspaceWrite::class,
+            'workspace.authorization' => AuthorizeWorkspaceAccess::class,
+            'workspace.write' => AuthorizeWorkspaceWrite::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/compose.yaml
+++ b/compose.yaml
@@ -76,14 +76,13 @@ services:
       dockerfile: docker/release/Dockerfile
       target: release
       args:
-        GIT_SHA: ${GIT_SHA:-dev}
-        BUILD_TIME: ${BUILD_TIME:-unknown}
+        RELEASE_VERSION: ${RELEASE_VERSION:-0.0.0-dev}
     volumes:
       - ./dist:/dist
     command:
       - sh
       - -c
-      - cp /jotter-release.zip /jotter-release.zip.sha256 /dist/
+      - cp /jotter-release-*.zip /jotter-release-*.zip.sha256 /dist/
 
 volumes:
   mysql_data:

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    // Identifies one installation when several share a host (logs, doctor, support).
+    'instance_slug' => env('APP_INSTANCE_SLUG'),
+
     'seed' => [
         'tenant_name' => env('JOTTER_TENANT_NAME', 'Jotter'),
         'tenant_slug' => env('JOTTER_TENANT_SLUG', 'default'),

--- a/config/vault.php
+++ b/config/vault.php
@@ -1,5 +1,7 @@
 <?php
 
 return [
-    'base_path' => env('VAULT_BASE_PATH', storage_path('app/vaults')),
+    // An empty VAULT_BASE_PATH (as shipped in .env.example) falls back to the
+    // default, matching VaultRootGuard, instead of resolving to ''.
+    'base_path' => env('VAULT_BASE_PATH') ?: storage_path('app/vaults'),
 ];

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -18,8 +18,7 @@ RUN composer dump-autoload --optimize --no-dev --no-scripts
 
 FROM node:22-bookworm-slim AS frontend
 
-ARG GIT_SHA=dev
-ARG BUILD_TIME=unknown
+ARG RELEASE_VERSION=0.0.0-dev
 
 WORKDIR /app/frontend
 
@@ -27,13 +26,14 @@ COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
 COPY frontend/ ./
-ENV VITE_APP_VERSION="${GIT_SHA} · ${BUILD_TIME}"
+ENV VITE_APP_VERSION="${RELEASE_VERSION}"
 RUN npm run build
 
 FROM alpine:3.21 AS release
 
-ARG GIT_SHA=dev
-ARG BUILD_TIME=unknown
+# Git tag when HEAD is tagged, otherwise 0.0.0-<short sha>. Written to VERSION
+# inside the artifact and exposed by GET /api/auth/config and GET /api/health.
+ARG RELEASE_VERSION=0.0.0-dev
 
 RUN apk add --no-cache zip
 
@@ -45,7 +45,7 @@ COPY --from=frontend /app/public/manifest.webmanifest /release/app/public/manife
 COPY --from=frontend /app/public/offline.html /release/app/public/offline.html
 COPY --from=frontend /app/public/service-worker.js /release/app/public/service-worker.js
 
-RUN echo "${GIT_SHA} · ${BUILD_TIME}" > /release/app/VERSION
+RUN printf '%s\n' "${RELEASE_VERSION}" > /release/app/VERSION
 
 RUN cd /release/app \
     && rm -rf \
@@ -84,12 +84,12 @@ RUN cd /release/app \
     && find storage bootstrap/cache -type d -exec chmod 775 {} \;
 
 RUN cd /release \
-    && zip -q -r /jotter-release.zip app \
+    && zip -q -r "/jotter-release-${RELEASE_VERSION}.zip" app \
     && cd / \
-    && sha256sum jotter-release.zip > jotter-release.zip.sha256
+    && sha256sum "jotter-release-${RELEASE_VERSION}.zip" > "jotter-release-${RELEASE_VERSION}.zip.sha256"
 
 FROM scratch AS export
 
 COPY --from=release /release/app /app
-COPY --from=release /jotter-release.zip /jotter-release.zip
-COPY --from=release /jotter-release.zip.sha256 /jotter-release.zip.sha256
+COPY --from=release /jotter-release-*.zip /
+COPY --from=release /jotter-release-*.zip.sha256 /

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,22 @@ On PowerShell:
 .\scripts\jt.ps1 release:verify
 ```
 
-The release command writes `dist/jotter-release.zip` and `dist/jotter-release.zip.sha256`. The verification command must pass before the ZIP is deployed or shared.
+The release command writes `dist/jotter-release-<version>.zip` and
+`dist/jotter-release-<version>.zip.sha256`, where `<version>` is the git tag when
+`HEAD` is exactly tagged (for example `v1.4.0`) and `0.0.0-<short sha>` otherwise.
+The same string is written to `VERSION` inside the artifact and reported by
+`GET /api/auth/config` (`data.version`), `GET /api/health` (`version`), and
+`php artisan jotter:doctor`. The verification command scans the newest ZIP in
+`dist/` (or an explicit path: `./scripts/jt.sh release:verify dist/jotter-release-v1.4.0.zip`)
+and must pass before the ZIP is deployed or shared.
+
+To rehearse an installation before touching a host, extract the newest ZIP into
+`dist/install-test/` and run the doctor inside that copy against the dev database:
+
+```sh
+./scripts/jt.sh release:doctor          # human-readable
+./scripts/jt.sh release:doctor --json   # machine-readable
+```
 
 ## Deploy
 
@@ -25,6 +40,105 @@ The release command writes `dist/jotter-release.zip` and `dist/jotter-release.zi
 5. Ensure `storage/` and `bootstrap/cache/` are writable by PHP.
 6. Run `php artisan migrate --force` using the host's PHP 8.2+ CLI facility.
 7. Keep debug mode off and use HTTPS.
+8. Add the single cron entry described under [Scheduled jobs](#scheduled-jobs-one-cron-entry-per-installation).
+9. Run `php artisan jotter:doctor` and fix every `[FAIL]` before handing the installation over.
+
+## Multiple instances on one shared host
+
+One release ZIP installs any number of times on the same Hostinger account: one
+directory per client, one subdomain per client, one database (or one `DB_PREFIX`)
+per client, one vault directory per client, and one cron entry per client. Nothing
+is shared between installations except the PHP runtime.
+
+Recommended layout for a client with slug `acme` served at `acme.example.com`:
+
+```text
+domains/acme.example.com/public_html/acme/   ← extracted `app/` contents (this is the Laravel root)
+    .env                                     ← this installation's values only
+    artisan
+    public/                                  ← the subdomain's document root points HERE
+    storage/, bootstrap/cache/               ← writable by PHP
+    VERSION                                  ← written by `jt release`
+~/vaults/acme/                               ← VAULT_BASE_PATH (outside every document root)
+~/pdf-exports/acme/                          ← JOTTER_PDF_STORAGE_PATH (optional, outside every document root)
+```
+
+Rules that keep installations predictable:
+
+- The document root of the subdomain must be `.../<slug>/public/`, never the
+  Laravel root and never a parent folder shared with another installation.
+- `VAULT_BASE_PATH` must be outside every document root and unique per slug. The
+  doctor fails the installation when the vault resolves inside `public/`.
+- `APP_INSTANCE_SLUG=<slug>` names the installation. It is added to every log line
+  (`context.instance`) and printed by the doctor; it is never exposed by
+  `GET /api/health`.
+- `APP_URL=https://<slug>.example.com`, `APP_ENV=production`, `APP_DEBUG=false`,
+  `SESSION_SECURE_COOKIE=true`, `CACHE_STORE=database`, `SESSION_DRIVER=database`.
+  `.env.example` marks every value a production installation must set.
+- Each installation gets its own `APP_KEY` (`php artisan key:generate --force`);
+  never copy a key between clients.
+
+Per-installation cron entry (adjust the PHP binary to the host's 8.2+ CLI):
+
+```cron
+* * * * * cd /home/<user>/domains/acme.example.com/public_html/acme && /usr/bin/php artisan schedule:run >> storage/logs/scheduler.log 2>&1
+```
+
+After extracting, migrating, and adding the cron entry, run the doctor:
+
+```sh
+cd /home/<user>/domains/acme.example.com/public_html/acme
+php artisan jotter:doctor           # exit code 1 while any critical check fails
+php artisan jotter:doctor --json    # for scripts and support tickets
+```
+
+The doctor verifies: PHP version and required extensions, `APP_KEY`, `APP_ENV`,
+`APP_DEBUG=false`, `APP_URL` on HTTPS, `storage/` and `bootstrap/cache` writable,
+`VAULT_BASE_PATH` existing, writable, and outside the document root, free disk
+space for the vault, database connectivity, pending migrations, `MAIL_MAILER`
+different from `log`, `APP_INSTANCE_SLUG`, and the scheduler heartbeat (a
+`schedule:run` within the last 5 minutes). `APP_DEBUG` and the HTTPS check are
+critical when `APP_ENV=production` and warnings otherwise; the mailer, recommended
+extensions, and instance slug are always warnings.
+
+## Health endpoint
+
+`GET /api/health` is unauthenticated and answers with exactly three fields:
+
+```json
+{"status": "ok", "version": "v1.4.0", "scheduler_last_run_at": "2026-08-31T10:00:00+00:00"}
+```
+
+It returns HTTP 503 with `status: "unavailable"` when the database does not answer.
+It deliberately exposes nothing sensitive: no instance slug, hostnames, paths,
+database names, PHP version, or configuration values. The route is registered
+outside the `api` middleware group so it can still answer 503 (instead of 500)
+when the session, cache, or throttle stores backed by MySQL are down. Point the
+host's uptime monitor at it and alert when `scheduler_last_run_at` is older than
+a few minutes.
+
+## Scheduled jobs (one cron entry per installation)
+
+All periodic work is registered in `routes/console.php` and executed by the single
+`php artisan schedule:run` cron entry above. No job needs a queue worker, daemon,
+or background process; every command is bounded and idempotent, and overlapping
+runs are prevented with cache locks (`CACHE_STORE=database`).
+
+| Job | Schedule | Purpose |
+| --- | --- | --- |
+| `jotter:scheduler-heartbeat` | every minute | Records the last `schedule:run` time read by the doctor and `/api/health`. |
+| `notifications:send-digest --limit=100` | every minute | Builds digest deliveries from unsent notifications. |
+| `notifications:process-deliveries --limit=50` | every minute | Sends pending notification e-mails. `JobDispatcher` only records `SendNotificationEmail` on shared hosting; this command is its executor. |
+| `pdf:process-exports` | every minute | Renders queued PDF exports (`GeneratePdfExport`) and removes expired artifacts. |
+| `analytics:rollup` | every 5 minutes | Advances the usage-analytics cursor over new audit rows. |
+| `vault:reindex --all` | hourly | Reconciles every workspace vault from disk into the MySQL projection. |
+| `vault:purge-trash` | daily 02:00 | Permanently deletes notes past the trash retention period. |
+| `vault:prune-revisions --days=30` | daily 02:15 | Prunes derived revision snapshots (Markdown files are never touched). |
+| `audit:prune --days=90` | daily 02:30 | Enforces audit-log retention. |
+
+Trial expiry is not scheduled because the product has no trial concept; add it to
+this table and to `routes/console.php` if one is introduced. The individual
+commands below remain available for one-off runs with different options.
 
 ## External content embeds
 
@@ -78,48 +192,40 @@ and does not require a queue worker, daemon, websocket, or long-running process.
 
 The artifact includes production `vendor/` dependencies and compiled `public/build/` assets. It excludes tests, frontend sources, container files, development tooling, and secrets.
 
-Schedule a bounded reconcile for each workspace vault (adjust the id and frequency to the host):
+One-off reconcile of a single workspace vault (the scheduler runs `--all` hourly):
 
 ```sh
 php artisan vault:reindex --workspace=1
 ```
 
-Schedule a bounded daily purge for notes that have exceeded the trash retention
-period (the default is 30 days; override it with `JOTTER_TRASH_RETENTION_DAYS`):
+Trash purge (scheduled daily; the default retention is 30 days via
+`JOTTER_TRASH_RETENTION_DAYS`). Use `--days=N` or `--batch=N` for a one-off
+retention or batch-size override:
 
 ```sh
 php artisan vault:purge-trash
 ```
 
-Use `--days=N` or `--batch=N` for a one-off retention or batch-size override.
-
-Schedule a daily audit log prune to enforce retention limits (adjust days as needed):
+Audit log prune (scheduled daily with `--days=90`):
 
 ```sh
 php artisan audit:prune --days=90
 ```
 
-Schedule a bounded daily prune for derived note revision snapshots. Revision
-history is stored in MySQL; the Markdown files in the vault are never removed
-by this command. The default retention window is 30 days and can be overridden
-per run with `--days=N`:
-
-```cron
-15 2 * * * cd /var/www/jotter && php artisan vault:prune-revisions --days=30 >> storage/logs/revision-prune.log 2>&1
-```
-
-Run it manually with a different window when needed:
+Revision snapshot prune (scheduled daily with `--days=30`). Revision history is
+stored in MySQL; the Markdown files in the vault are never removed by this
+command:
 
 ```sh
 php artisan vault:prune-revisions --days=90
 ```
 
-Schedule the bounded usage-analytics rollup after audit events are written. It
-advances an `audit_log` cursor in batches, is safe to rerun, and keeps the
-workspace rollups when `audit:prune` removes the source rows:
+Usage-analytics rollup (scheduled every 5 minutes). It advances an `audit_log`
+cursor in batches, is safe to rerun, and keeps the workspace rollups when
+`audit:prune` removes the source rows:
 
-```cron
-*/5 * * * * cd /var/www/jotter && php artisan analytics:rollup --batch=500 >> storage/logs/analytics-rollup.log 2>&1
+```sh
+php artisan analytics:rollup --batch=500
 ```
 
 The analytics API and dashboard read only the durable rollups; they do not
@@ -137,13 +243,15 @@ recorded activity such as edits and other audit events; it should not be read
 as “most viewed” unless read tracking has explicitly been enabled and the
 rollup command has processed those events.
 
-Schedule the notification digest every minute. The command is bounded by the
-per-recipient `--limit`, uses an idempotent delivery ledger, and is safe to run
-repeatedly. It dispatches mail work through `JobDispatcher`; it does not send
-SMTP mail inline in the cron process.
+The notification digest runs every minute from the scheduler. The command is
+bounded by the per-recipient `--limit`, uses an idempotent delivery ledger, and is
+safe to run repeatedly. It hands mail work to `JobDispatcher`; the scheduled
+`notifications:process-deliveries` command then sends the pending deliveries, so
+no SMTP mail is sent inline in a web request.
 
-```cron
-* * * * * cd /var/www/jotter && php artisan notifications:send-digest --limit=100 >> storage/logs/notification-digest.log 2>&1
+```sh
+php artisan notifications:send-digest --limit=100
+php artisan notifications:process-deliveries --limit=50
 ```
 
 Configure a Laravel mail transport for external delivery. With the default
@@ -181,11 +289,12 @@ JOTTER_PDF_RETENTION_HOURS=24
 JOTTER_PDF_PROCESS_BATCH=10
 ```
 
-Ensure PHP can create and remove files in that directory. Run the bounded worker
-from cron (or invoke the same command from the configured `JobDispatcher` worker):
+Ensure PHP can create and remove files in that directory. The scheduler runs the
+bounded worker every minute; invoke it manually with a different batch size when
+needed:
 
-```cron
-* * * * * cd /var/www/jotter && php artisan pdf:process-exports --limit=10 >> storage/logs/pdf-exports.log 2>&1
+```sh
+php artisan pdf:process-exports --limit=10
 ```
 
 `POST /api/workspaces/{workspace}/pdf-exports` snapshots only notes visible to

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::post('/auth/login', [AuthController::class, 'login']);
 Route::post('/auth/logout', [AuthController::class, 'logout']);
 Route::get('/auth/me', [AuthController::class, 'me']);
 Route::get('/auth/config', [AuthController::class, 'config']);
+// GET /api/health lives in bootstrap/app.php (no session/throttle middleware).
 Route::get('/auth/oidc/redirect', [\App\Http\Controllers\OidcController::class, 'redirect']);
 Route::get('/auth/oidc/callback', [\App\Http\Controllers\OidcController::class, 'callback']);
 Route::post('/auth/change-password', [\App\Http\Controllers\AdminUserController::class, 'changePassword']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,44 @@
 <?php
 
+use App\Support\SchedulerHeartbeat;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+/*
+|--------------------------------------------------------------------------
+| Periodic work (shared hosting: one cron entry per installation)
+|--------------------------------------------------------------------------
+|
+| Every recurring job Jotter needs is registered here and driven by a single
+| `php artisan schedule:run` cron entry executing every minute. Nothing below
+| depends on a queue worker, daemon, or `runInBackground()` (which would fork
+| a process). `withoutOverlapping()` uses the cache lock table, so a slow run
+| never stacks up behind itself. Keep docs/deployment.md's job table in sync.
+|
+*/
+
+// Heartbeat read by `jotter:doctor` and GET /api/health.
+Schedule::call(static fn () => SchedulerHeartbeat::record())
+    ->name('jotter:scheduler-heartbeat')
+    ->everyMinute();
+
+// Every minute: bounded, idempotent executors for dispatched work.
+Schedule::command('notifications:send-digest', ['--limit=100'])->everyMinute()->withoutOverlapping(10);
+Schedule::command('notifications:process-deliveries', ['--limit=50'])->everyMinute()->withoutOverlapping(10);
+Schedule::command('pdf:process-exports')->everyMinute()->withoutOverlapping(10);
+
+// Every five minutes: analytics rollups over new audit rows.
+Schedule::command('analytics:rollup')->everyFiveMinutes()->withoutOverlapping(10);
+
+// Hourly: reconcile the on-disk vaults into the MySQL projection.
+Schedule::command('vault:reindex', ['--all'])->hourly()->withoutOverlapping(55);
+
+// Nightly retention (spread out so they never share a minute).
+Schedule::command('vault:purge-trash')->dailyAt('02:00')->withoutOverlapping(60);
+Schedule::command('vault:prune-revisions', ['--days=30'])->dailyAt('02:15')->withoutOverlapping(60);
+Schedule::command('audit:prune', ['--days=90'])->dailyAt('02:30')->withoutOverlapping(60);

--- a/scripts/jt.ps1
+++ b/scripts/jt.ps1
@@ -135,7 +135,7 @@ Jotter Docker toolchain
 
 Usage: .\scripts\jt.ps1 <verb> [args...]
 
-Verbs: up, down, test, e2e, artisan, composer, npm, release, release:verify
+Verbs: up, down, test, e2e, artisan, composer, npm, release, release:verify, release:doctor
 '@ | Write-Output
 }
 
@@ -192,10 +192,18 @@ switch ($Verb) {
     'release' {
         Initialize-Env
         New-Item -ItemType Directory -Force -Path 'dist' | Out-Null
+
+        # Git tag when HEAD is exactly tagged, otherwise 0.0.0-<short sha>.
+        $version = (& git describe --tags --exact-match 2>$null)
+        if (-not $version) { $version = "0.0.0-$(& git rev-parse --short HEAD)" }
+        $version = ($version -replace '[^A-Za-z0-9._-]', '-')
+        $env:RELEASE_VERSION = $version
+
+        $zipPath = "dist/jotter-release-$version.zip"
+        $checksumPath = "$zipPath.sha256"
+        Remove-Item -Force -ErrorAction SilentlyContinue $zipPath, $checksumPath
         Invoke-Compose -Arguments @('--profile', 'tools', 'run', '--rm', '--build', 'release')
 
-        $zipPath = 'dist/jotter-release.zip'
-        $checksumPath = 'dist/jotter-release.zip.sha256'
         if (-not (Test-Path $zipPath) -or -not (Test-Path $checksumPath)) {
             throw 'Release zip or checksum was not produced.'
         }
@@ -205,10 +213,14 @@ switch ($Verb) {
         if ($actual -ne $expected.ToLowerInvariant()) {
             throw 'Release checksum validation failed.'
         }
-        Write-Output 'Release written to dist/jotter-release.zip'
+        Write-Output "Release written to $zipPath (version: $version)"
     }
     'release:verify' {
-        $zipPath = 'dist/jotter-release.zip'
+        $zipPath = if ($VerbArgs.Count -gt 0) { $VerbArgs[0] } else {
+            $newest = Get-ChildItem -Path 'dist' -Filter 'jotter-release-*.zip' -File -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if ($newest) { "dist/$($newest.Name)" } else { 'dist/jotter-release-<version>.zip' }
+        }
         if (-not (Test-Path $zipPath -PathType Leaf) -or (Get-Item $zipPath).Length -eq 0) {
             throw "Release zip is missing or empty: $zipPath. Run .\scripts\jt.ps1 release first."
         }
@@ -216,10 +228,66 @@ switch ($Verb) {
         Initialize-Env
         Invoke-Compose -Arguments @(
             'run', '--rm',
-            '-e', 'JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip',
+            '-e', "JOTTER_RELEASE_ZIP=/var/www/html/$($zipPath -replace '\\', '/')",
             'app', 'php', 'artisan', 'test', '--filter=ReleaseZipSecurityTest'
         )
-        Write-Output 'Release ZIP security verification passed.'
+        Write-Output "Release ZIP security verification passed: $zipPath"
+    }
+    'release:doctor' {
+        # Extract the newest (or given) release ZIP into dist/install-test and run
+        # jotter:doctor inside that copy against the dev database. Mirrors jt.sh.
+        $doctorArgs = @($VerbArgs)
+        $zipPath = $null
+        if ($doctorArgs.Count -gt 0 -and $doctorArgs[0] -like '*.zip') {
+            $zipPath = $doctorArgs[0]
+            $doctorArgs = if ($doctorArgs.Count -gt 1) { $doctorArgs[1..($doctorArgs.Count - 1)] } else { @() }
+        }
+        if (-not $zipPath) {
+            $newest = Get-ChildItem -Path 'dist' -Filter 'jotter-release-*.zip' -File -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if (-not $newest) { throw 'Release zip is missing. Run .\scripts\jt.ps1 release first.' }
+            $zipPath = "dist/$($newest.Name)"
+        }
+
+        Initialize-Env
+        $installDir = 'dist/install-test'
+
+        $overrides = @(
+            'APP_ENV=production',
+            'APP_DEBUG=false',
+            'APP_URL=https://install-test.example.invalid',
+            'APP_INSTANCE_SLUG=install-test',
+            'LOG_CHANNEL=single',
+            'CACHE_STORE=database',
+            'SESSION_DRIVER=database',
+            'QUEUE_CONNECTION=sync',
+            'MAIL_MAILER=log',
+            "VAULT_BASE_PATH=/var/www/html/$installDir/vault"
+        )
+        $envLines = @(Get-Content '.env' | Where-Object { $_ -match '^(APP_KEY|DB_DATABASE|DB_USERNAME|DB_PASSWORD)=' })
+        $envLines += @('DB_CONNECTION=mysql', 'DB_HOST=mysql', 'DB_PORT=3306') + $overrides
+        Set-Content -Path "$installDir.env" -Value $envLines -NoNewline:$false
+
+        # Extraction, .env placement, and cleanup happen inside the container so
+        # file ownership never blocks a rerun from the host.
+        $script = @'
+set -e
+rm -rf "$JOTTER_INSTALL_DIR"
+mkdir -p "$JOTTER_INSTALL_DIR/vault"
+unzip -q "$JOTTER_INSTALL_ZIP" -d "$JOTTER_INSTALL_DIR"
+cp "$JOTTER_INSTALL_DIR.env" "$JOTTER_INSTALL_DIR/app/.env"
+cd "$JOTTER_INSTALL_DIR/app"
+php artisan schedule:run --no-ansi >/dev/null
+php artisan jotter:doctor "$@"
+'@
+        $composeArgs = @('run', '--rm')
+        foreach ($override in $overrides) { $composeArgs += @('-e', $override) }
+        $composeArgs += @(
+            '-e', "JOTTER_INSTALL_DIR=/var/www/html/$installDir",
+            '-e', "JOTTER_INSTALL_ZIP=/var/www/html/$($zipPath -replace '\\', '/')",
+            'app', 'sh', '-c', $script, 'sh'
+        ) + $doctorArgs
+        Invoke-Compose -Arguments $composeArgs
     }
     { $_ -in @('help', '-h', '--help') } { Show-Usage }
     default { Write-Error "Unknown verb: $Verb"; Show-Usage; exit 1 }

--- a/scripts/jt.sh
+++ b/scripts/jt.sh
@@ -74,8 +74,9 @@ Verbs:
   artisan   Run an Artisan command
   composer  Run Composer
   npm       Run npm in frontend/
-  release         Build dist/jotter-release.zip and checksum
-  release:verify  Scan an existing release ZIP for secrets and private keys
+  release         Build dist/jotter-release-<version>.zip and checksum
+  release:verify  Scan a release ZIP for secrets and private keys (newest, or path arg)
+  release:doctor  Extract a release ZIP into dist/install-test and run jotter:doctor there
 EOF
 }
 
@@ -103,31 +104,129 @@ cmd_e2e() {
   compose --profile dev run --rm node npm run e2e -- "$@"
 }
 
+# Git tag when HEAD is exactly tagged, otherwise 0.0.0-<short sha>. Sanitized so
+# it is safe inside a file name.
+release_version() {
+  local version
+  version="$(git describe --tags --exact-match 2>/dev/null || true)"
+  if [[ -z "$version" ]]; then
+    version="0.0.0-$(git rev-parse --short HEAD)"
+  fi
+  printf '%s' "$version" | tr -c 'A-Za-z0-9._-' '-'
+}
+
+# Newest release ZIP in dist/, or the explicit path given as first argument.
+latest_release_zip() {
+  local explicit="${1:-}"
+  if [[ -n "$explicit" ]]; then
+    printf '%s' "$explicit"
+    return
+  fi
+  ls -t dist/jotter-release-*.zip 2>/dev/null | head -n 1 || true
+}
+
 cmd_release() {
   ensure_env
   mkdir -p dist
-  export GIT_SHA="$(git rev-parse --short HEAD)"
-  export BUILD_TIME="$(date -u +'%Y-%m-%d %H:%M')"
+  export RELEASE_VERSION="$(release_version)"
+  local zip_name="jotter-release-${RELEASE_VERSION}.zip"
+  rm -f "dist/${zip_name}" "dist/${zip_name}.sha256"
   compose --profile tools run --rm --build release
-  test -s dist/jotter-release.zip
-  test -s dist/jotter-release.zip.sha256
-  (cd dist && sha256sum -c jotter-release.zip.sha256)
-  echo "Release written to dist/jotter-release.zip (version: ${GIT_SHA} · ${BUILD_TIME})"
+  test -s "dist/${zip_name}"
+  test -s "dist/${zip_name}.sha256"
+  (cd dist && sha256sum -c "${zip_name}.sha256")
+  echo "Release written to dist/${zip_name} (version: ${RELEASE_VERSION}, commit: $(git rev-parse --short HEAD))"
 }
 
 cmd_release_verify() {
-  local zip_path='dist/jotter-release.zip'
+  local zip_path
+  zip_path="$(latest_release_zip "${1:-}")"
 
-  if [[ ! -s "$zip_path" ]]; then
-    echo "Release zip is missing or empty: $zip_path. Run ./scripts/jt.sh release first." >&2
+  if [[ -z "$zip_path" || ! -s "$zip_path" ]]; then
+    echo "Release zip is missing or empty: ${zip_path:-dist/jotter-release-<version>.zip}. Run ./scripts/jt.sh release first." >&2
+    return 1
+  fi
+
+  case "$zip_path" in
+    dist/*) ;;
+    *) echo "Release zip must live under dist/ so the container can read it: $zip_path" >&2; return 1 ;;
+  esac
+
+  ensure_env
+  compose run --rm \
+    -e "JOTTER_RELEASE_ZIP=/var/www/html/${zip_path}" \
+    app php artisan test --filter=ReleaseZipSecurityTest
+  echo "Release ZIP security verification passed: ${zip_path}"
+}
+
+# Installs the ZIP the way a shared host would (fresh directory, its own .env,
+# its own vault outside public/) and runs the doctor inside that copy. Reuses the
+# dev MySQL database (schema state is only read); `schedule:run` is executed once
+# so the heartbeat check has something to report. Usage:
+#   ./scripts/jt.sh release:doctor [dist/jotter-release-<version>.zip] [--json]
+cmd_release_doctor() {
+  local zip_arg=''
+  if [[ "${1:-}" == *.zip ]]; then
+    zip_arg="$1"
+    shift
+  fi
+
+  local zip_path
+  zip_path="$(latest_release_zip "$zip_arg")"
+
+  if [[ -z "$zip_path" || ! -s "$zip_path" ]]; then
+    echo "Release zip is missing or empty. Run ./scripts/jt.sh release first." >&2
     return 1
   fi
 
   ensure_env
-  compose run --rm \
-    -e JOTTER_RELEASE_ZIP=/var/www/html/dist/jotter-release.zip \
-    app php artisan test --filter=ReleaseZipSecurityTest
-  echo "Release ZIP security verification passed."
+  local install_dir='dist/install-test'
+
+  # The dev compose service injects the repository .env into the container, and
+  # real environment variables win over a .env file. Override the values that
+  # must differ for the installation under test.
+  local -a overrides=(
+    APP_ENV=production
+    APP_DEBUG=false
+    APP_URL=https://install-test.example.invalid
+    APP_INSTANCE_SLUG=install-test
+    LOG_CHANNEL=single
+    CACHE_STORE=database
+    SESSION_DRIVER=database
+    QUEUE_CONNECTION=sync
+    MAIL_MAILER=log
+    "VAULT_BASE_PATH=/var/www/html/${install_dir}/vault"
+  )
+
+  # Staged on the host (dist/ is host-owned); copied into the extracted app by
+  # the container, which owns everything under install_dir.
+  {
+    grep -E '^(APP_KEY|DB_DATABASE|DB_USERNAME|DB_PASSWORD)=' .env
+    printf 'DB_CONNECTION=mysql\nDB_HOST=mysql\nDB_PORT=3306\n'
+    printf '%s\n' "${overrides[@]}"
+  } > "${install_dir}.env"
+
+  local -a env_flags=()
+  local override
+  for override in "${overrides[@]}"; do
+    env_flags+=(-e "$override")
+  done
+
+  # Extraction, .env placement, and cleanup all happen inside the container so
+  # file ownership never blocks a rerun from the host.
+  compose run --rm "${env_flags[@]}" \
+    -e "JOTTER_INSTALL_DIR=/var/www/html/${install_dir}" \
+    -e "JOTTER_INSTALL_ZIP=/var/www/html/${zip_path}" \
+    app sh -c '
+      set -e
+      rm -rf "$JOTTER_INSTALL_DIR"
+      mkdir -p "$JOTTER_INSTALL_DIR/vault"
+      unzip -q "$JOTTER_INSTALL_ZIP" -d "$JOTTER_INSTALL_DIR"
+      cp "$JOTTER_INSTALL_DIR.env" "$JOTTER_INSTALL_DIR/app/.env"
+      cd "$JOTTER_INSTALL_DIR/app"
+      php artisan schedule:run --no-ansi >/dev/null
+      php artisan jotter:doctor "$@"
+    ' sh "$@"
 }
 
 main() {
@@ -143,7 +242,8 @@ main() {
     composer) ensure_env; compose run --rm --no-deps app composer "$@" ;;
     npm) ensure_env; compose --profile dev run --rm --no-deps node npm "$@" ;;
     release) cmd_release ;;
-    release:verify) cmd_release_verify ;;
+    release:verify) cmd_release_verify "$@" ;;
+    release:doctor) cmd_release_doctor "$@" ;;
     help|-h|--help) usage ;;
     *) echo "Unknown verb: $verb" >&2; usage >&2; return 1 ;;
   esac

--- a/tests/Feature/HealthEndpointTest.php
+++ b/tests/Feature/HealthEndpointTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\SchedulerHeartbeat;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+final class HealthEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_health_is_public_and_reports_version_and_scheduler_heartbeat(): void
+    {
+        Cache::forever(SchedulerHeartbeat::CACHE_KEY, '2026-08-31T10:00:00+00:00');
+
+        $response = $this->getJson('/api/health');
+
+        $response->assertOk()
+            ->assertHeader('Cache-Control', 'no-store, private')
+            ->assertExactJson([
+                'status' => 'ok',
+                'version' => null,
+                'scheduler_last_run_at' => '2026-08-31T10:00:00+00:00',
+            ]);
+    }
+
+    public function test_health_omits_sensitive_details(): void
+    {
+        config(['jotter.instance_slug' => 'acme']);
+
+        $payload = $this->getJson('/api/health')->assertOk()->json();
+
+        $this->assertSame(['status', 'version', 'scheduler_last_run_at'], array_keys($payload));
+        $this->assertStringNotContainsString('acme', json_encode($payload));
+    }
+}

--- a/tests/Feature/HealthEndpointUnavailableTest.php
+++ b/tests/Feature/HealthEndpointUnavailableTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Deliberately without RefreshDatabase: the test swaps the default connection to
+ * an unreachable host, and the trait would try to roll back on that connection.
+ */
+final class HealthEndpointUnavailableTest extends TestCase
+{
+    public function test_health_returns_503_when_the_database_is_unreachable(): void
+    {
+        config([
+            'database.connections.unreachable' => array_merge(
+                config('database.connections.mysql'),
+                ['host' => '127.0.0.1', 'port' => 1, 'database' => 'unreachable'],
+            ),
+            'database.default' => 'unreachable',
+        ]);
+        DB::purge('unreachable');
+
+        $response = $this->getJson('/api/health');
+
+        $response->assertStatus(503)
+            ->assertJsonPath('status', 'unavailable')
+            ->assertJsonStructure(['status', 'version', 'scheduler_last_run_at']);
+    }
+}

--- a/tests/Feature/JotterDoctorCommandTest.php
+++ b/tests/Feature/JotterDoctorCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Health\InstanceDoctor;
+use App\Support\SchedulerHeartbeat;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class JotterDoctorCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $vault;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vault = storage_path('framework/testing/doctor-vault-'.uniqid());
+        File::ensureDirectoryExists($this->vault);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->vault);
+
+        parent::tearDown();
+    }
+
+    private function healthyProductionConfig(): void
+    {
+        config([
+            'app.env' => 'production',
+            'app.debug' => false,
+            'app.key' => 'base64:'.base64_encode(random_bytes(32)),
+            'app.url' => 'https://client-a.example.com',
+            'mail.default' => 'smtp',
+            'vault.base_path' => $this->vault,
+            'jotter.instance_slug' => 'client-a',
+        ]);
+        SchedulerHeartbeat::record();
+    }
+
+    public function test_doctor_passes_on_a_healthy_production_installation(): void
+    {
+        $this->healthyProductionConfig();
+
+        $this->artisan('jotter:doctor')
+            ->expectsOutputToContain('instance: client-a')
+            ->expectsOutputToContain('[PASS] Scheduler heartbeat')
+            ->expectsOutputToContain('[PASS] Vault outside document root')
+            ->expectsOutputToContain('[PASS] Pending migrations')
+            ->expectsOutputToContain('0 failure(s)')
+            ->assertSuccessful();
+    }
+
+    public function test_doctor_json_report_is_machine_readable(): void
+    {
+        $this->healthyProductionConfig();
+
+        $this->artisan('jotter:doctor --json')->assertSuccessful();
+
+        // Re-run through the doctor directly to inspect the structure without console buffering.
+        $report = app(InstanceDoctor::class)->run()->toArray();
+
+        // Optional extensions (e.g. gd) may be missing in the dev image: warnings are allowed, failures are not.
+        $this->assertContains($report['status'], ['ok', 'warn']);
+        $this->assertSame('client-a', $report['instance']);
+        $this->assertSame('production', $report['environment']);
+        $this->assertSame(0, $report['summary']['failures']);
+        $ids = array_column($report['checks'], 'id');
+        foreach ([
+            'php_version', 'php_extensions', 'app_key', 'app_debug', 'app_url_https',
+            'storage_writable', 'bootstrap_cache_writable', 'vault_path', 'vault_outside_docroot',
+            'vault_disk_space', 'database', 'migrations', 'mail_mailer', 'scheduler', 'instance_slug',
+        ] as $expected) {
+            $this->assertContains($expected, $ids);
+        }
+    }
+
+    public function test_doctor_fails_when_critical_checks_fail(): void
+    {
+        $this->healthyProductionConfig();
+        config([
+            'app.key' => '',
+            'app.debug' => true,
+            'app.url' => 'http://client-a.example.com',
+            'vault.base_path' => public_path('vault-inside-docroot'),
+        ]);
+        File::ensureDirectoryExists(public_path('vault-inside-docroot'));
+        Cache::forget(SchedulerHeartbeat::CACHE_KEY);
+
+        try {
+            $this->artisan('jotter:doctor')
+                ->expectsOutputToContain('[FAIL] APP_KEY')
+                ->expectsOutputToContain('[FAIL] APP_DEBUG')
+                ->expectsOutputToContain('[FAIL] APP_URL uses HTTPS')
+                ->expectsOutputToContain('[FAIL] Vault outside document root')
+                ->expectsOutputToContain('[FAIL] Scheduler heartbeat')
+                ->expectsOutputToContain('status: FAIL')
+                ->assertFailed();
+        } finally {
+            File::deleteDirectory(public_path('vault-inside-docroot'));
+        }
+    }
+
+    public function test_doctor_treats_stale_scheduler_and_log_mailer_as_configured_severities(): void
+    {
+        $this->healthyProductionConfig();
+        config(['mail.default' => 'log']);
+        Cache::forever(SchedulerHeartbeat::CACHE_KEY, now()->subMinutes(30)->toIso8601String());
+
+        $report = app(InstanceDoctor::class)->run()->toArray();
+        $byId = array_column($report['checks'], null, 'id');
+
+        $this->assertSame('warn', $byId['mail_mailer']['status']);
+        $this->assertSame('fail', $byId['scheduler']['status']);
+        $this->assertSame('fail', $report['status']);
+    }
+
+    public function test_doctor_only_warns_outside_production_for_debug_and_http(): void
+    {
+        $this->healthyProductionConfig();
+        config(['app.env' => 'local', 'app.debug' => true, 'app.url' => 'http://localhost:8080']);
+
+        $report = app(InstanceDoctor::class)->run()->toArray();
+        $byId = array_column($report['checks'], null, 'id');
+
+        $this->assertSame('warn', $byId['app_env']['status']);
+        $this->assertSame('warn', $byId['app_debug']['status']);
+        $this->assertSame('warn', $byId['app_url_https']['status']);
+        $this->assertSame('warn', $report['status']);
+    }
+
+    public function test_doctor_reports_missing_vault_directory_as_critical(): void
+    {
+        $this->healthyProductionConfig();
+        config(['vault.base_path' => $this->vault.'/does-not-exist']);
+
+        $this->artisan('jotter:doctor')
+            ->expectsOutputToContain('[FAIL] VAULT_BASE_PATH')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/ProcessNotificationDeliveriesCommandTest.php
+++ b/tests/Feature/ProcessNotificationDeliveriesCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Notifications\NotificationType;
+use App\Mail\NotificationEmail;
+use App\Models\Notification;
+use App\Models\NotificationDelivery;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+final class ProcessNotificationDeliveriesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pending_deliveries_are_sent_up_to_the_limit(): void
+    {
+        Mail::fake();
+        config(['mail.default' => 'array']);
+        $recipient = User::factory()->create();
+        $first = $this->pendingDelivery($recipient, now()->subMinutes(2));
+        $second = $this->pendingDelivery($recipient, now()->subMinute());
+
+        $this->artisan('notifications:process-deliveries', ['--limit' => 1])
+            ->expectsOutputToContain('Processed 1 delivery(ies): 1 sent, 0 failed.')
+            ->assertSuccessful();
+
+        $this->assertSame('sent', $first->fresh()->status);
+        $this->assertSame('pending', $second->fresh()->status);
+        Mail::assertSent(NotificationEmail::class, 1);
+    }
+
+    public function test_sent_deliveries_are_not_processed_again(): void
+    {
+        Mail::fake();
+        config(['mail.default' => 'array']);
+        $recipient = User::factory()->create();
+        $delivery = $this->pendingDelivery($recipient, now());
+        $delivery->update(['status' => 'sent', 'sent_at' => now()]);
+
+        $this->artisan('notifications:process-deliveries')
+            ->expectsOutputToContain('Processed 0 delivery(ies)')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+    }
+
+    private function pendingDelivery(User $recipient, \DateTimeInterface $dispatchedAt): NotificationDelivery
+    {
+        $tenant = Tenant::create(['slug' => 'deliveries-'.uniqid(), 'name' => 'Deliveries']);
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'deliveries-'.uniqid(),
+            'name' => 'Deliveries workspace',
+            'vault_path' => storage_path('app/vaults/deliveries-'.uniqid()),
+        ]);
+        $notification = Notification::create([
+            'workspace_id' => $workspace->id,
+            'user_id' => $recipient->id,
+            'type' => NotificationType::MENTION->value,
+            'title' => 'Notification title',
+            'data' => ['note_title' => 'Watched note', 'note_path' => 'watched.md', 'target_kind' => 'note'],
+        ]);
+
+        return NotificationDelivery::create([
+            'user_id' => $recipient->id,
+            'notification_id' => $notification->id,
+            'channel' => 'email',
+            'kind' => 'immediate',
+            'dedupe_key' => 'notification:'.$notification->id.':email',
+            'status' => 'pending',
+            'payload' => ['notification_id' => $notification->id],
+            'dispatched_at' => $dispatchedAt,
+        ]);
+    }
+}

--- a/tests/Feature/ReleaseZipSecurityTest.php
+++ b/tests/Feature/ReleaseZipSecurityTest.php
@@ -12,7 +12,7 @@ class ReleaseZipSecurityTest extends TestCase
     public function test_release_zip_contains_no_secrets_or_private_keys(): void
     {
         $configuredPath = getenv('JOTTER_RELEASE_ZIP');
-        $path = $configuredPath ?: base_path('dist/jotter-release.zip');
+        $path = $configuredPath ?: $this->newestReleaseZip();
 
         if (! is_file($path)) {
             if (is_string($configuredPath) && $configuredPath !== '') {
@@ -58,6 +58,17 @@ class ReleaseZipSecurityTest extends TestCase
         $zip->close();
 
         $this->assertSame([], $violations, implode(PHP_EOL, $violations));
+    }
+
+    /**
+     * `jt release` writes dist/jotter-release-<version>.zip; pick the newest.
+     */
+    private function newestReleaseZip(): string
+    {
+        $candidates = glob(base_path('dist/jotter-release-*.zip')) ?: [];
+        usort($candidates, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        return $candidates[0] ?? base_path('dist/jotter-release.zip');
     }
 
     private function isForbiddenPath(string $name): bool

--- a/tests/Feature/SchedulerRegistrationTest.php
+++ b/tests/Feature/SchedulerRegistrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\SchedulerHeartbeat;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Shared hosting runs one cron entry per installation: `schedule:run` every
+ * minute. Every periodic job must therefore be registered with the scheduler
+ * and none may rely on a queue worker or a background process.
+ */
+final class SchedulerRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return list<string>
+     */
+    private function scheduledCommands(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (Event $event): string => (string) ($event->command ?? $event->description ?? ''),
+            app(Schedule::class)->events(),
+        )));
+    }
+
+    public function test_every_periodic_job_is_registered_with_the_scheduler(): void
+    {
+        $commands = implode("\n", $this->scheduledCommands());
+
+        foreach ([
+            'notifications:send-digest',
+            'notifications:process-deliveries',
+            'pdf:process-exports',
+            'analytics:rollup',
+            'vault:reindex',
+            'vault:purge-trash',
+            'vault:prune-revisions',
+            'audit:prune',
+            'jotter:scheduler-heartbeat',
+        ] as $expected) {
+            $this->assertStringContainsString($expected, $commands, "{$expected} is not scheduled");
+        }
+    }
+
+    public function test_no_scheduled_job_runs_in_background(): void
+    {
+        foreach (app(Schedule::class)->events() as $event) {
+            $this->assertFalse($event->runInBackground, 'Scheduled jobs must not fork background processes on shared hosting.');
+        }
+    }
+
+    public function test_schedule_run_records_the_heartbeat(): void
+    {
+        Cache::forget(SchedulerHeartbeat::CACHE_KEY);
+
+        $this->artisan('schedule:run')->assertSuccessful();
+
+        $this->assertNotNull(SchedulerHeartbeat::lastRunAt());
+        $this->assertTrue(SchedulerHeartbeat::lastRunAt()->greaterThan(now()->subMinute()));
+    }
+}


### PR DESCRIPTION
## Summary

Production is shared PHP hosting (Hostinger): one installation per client on its own subdomain, no daemon, one cron entry per installation. This PR makes the release ZIP install predictably N times on one host and gives each installation a self-diagnosis command.

1. **Versioned artifact** — `jt release` resolves the version from the exact git tag or `0.0.0-<short sha>`, writes it to `VERSION` inside the ZIP, and names the artifact `dist/jotter-release-<version>.zip` (+ `.sha256`). `GET /api/auth/config` exposes it as `data.version`. `jt release:verify` picks the newest ZIP or an explicit path; CI uploads the glob. Both `jt.sh` and `jt.ps1` updated.
2. **`php artisan jotter:doctor`** (human-readable and `--json`, exit code 1 on any critical failure). Checks PHP version and required/recommended extensions, `APP_KEY`, `APP_ENV`, `APP_DEBUG=false`, `APP_URL` on HTTPS, `storage/` and `bootstrap/cache` writable, `VAULT_BASE_PATH` existing/writable/outside the document root, vault free disk space, database connectivity, pending migrations, `MAIL_MAILER != log`, `APP_INSTANCE_SLUG`, and the scheduler heartbeat (last `schedule:run` within 5 minutes; recorded in cache on every scheduler run). Logic lives in `App\Domain\Health\InstanceDoctor`.
3. **`GET /api/health`** — unauthenticated `{status, version, scheduler_last_run_at}`, HTTP 503 when MySQL does not answer. Registered outside the `api` middleware group so session/cache/throttle stores backed by MySQL cannot turn the 503 into a 500. Exposes no slug, path, hostname, or configuration (documented).
4. **Scheduler is the only executor** — `routes/console.php` registers every periodic job for the one-line `schedule:run` cron: `notifications:send-digest`, new `notifications:process-deliveries`, `pdf:process-exports`, `analytics:rollup`, `vault:reindex --all` (new flag), `vault:purge-trash`, `vault:prune-revisions`, `audit:prune`, plus a heartbeat. No job uses `runInBackground()`; overlaps are guarded with cache locks. **Gap closed:** `LocalJobDispatcher` only logged `SendNotificationEmail`, so pending deliveries were never sent without a queue worker — the new command is their executor. Trial expiry: no trial concept exists; noted in docs/BACKLOG. Job table in `docs/deployment.md`.
5. **`.env.example`** — every production-required variable is commented; `APP_INSTANCE_SLUG` added (config `jotter.instance_slug`, shared into log context via `Log::shareContext`, shown by the doctor). An empty `VAULT_BASE_PATH` now falls back to the default (matching `VaultRootGuard`) instead of resolving to `''`.
6. **Docs** — `docs/deployment.md`: "Multiple instances on one shared host" (folder layout, cron line, doctor usage), health endpoint contract, scheduled-jobs table. `CHANGELOG.md`, `STATUS.md`, `BACKLOG.md` updated. No new dependency, so `docs/decisions.md` is unchanged.
7. **Tests** — `JotterDoctorCommandTest` (healthy, critical failures, severities, JSON, missing vault), `HealthEndpointTest` + `HealthEndpointUnavailableTest` (200 shape, no leaks, 503), `SchedulerRegistrationTest` (all jobs registered, none in background, heartbeat recorded by `schedule:run`), `ProcessNotificationDeliveriesCommandTest`.

New verb: `jt release:doctor [zip] [--json]` extracts the newest ZIP into `dist/install-test/` inside the dev container, writes an isolated `.env`, runs `schedule:run` once, and runs the doctor in the extracted copy.

## Verification

- `./scripts/jt.sh test` — 378 PHP tests passed (1588 assertions), 616 frontend tests passed.
- `./scripts/jt.sh release` → `dist/jotter-release-0.0.0-fa4afe4.zip` (checksum OK, `VERSION` = `0.0.0-fa4afe4`).
- `./scripts/jt.sh release:verify` → `ReleaseZipSecurityTest` passed.
- `./scripts/jt.sh release:doctor` on the extracted install (dev container, separate directory and vault, dev MySQL):

```text
Jotter doctor — instance: install-test · version: 0.0.0-fa4afe4 · env: production
[PASS] PHP version                  PHP 8.2.33
[PASS] Required PHP extensions      All required extensions are loaded.
[WARN] Recommended PHP extensions   Missing (optional features degrade): gd
[PASS] APP_INSTANCE_SLUG            install-test
[PASS] APP_ENV                      production
[PASS] APP_KEY                      Set.
[PASS] APP_DEBUG                    false
[PASS] APP_URL uses HTTPS           https://install-test.example.invalid
[PASS] storage/ writable            Writable.
[PASS] bootstrap/cache writable     Writable.
[PASS] VAULT_BASE_PATH              /var/www/html/dist/install-test/vault
[PASS] Vault outside document root  Vault is not under public/.
[PASS] Vault free disk space        25.6 GiB free
[PASS] Database connection          Connected (mysql).
[PASS] Pending migrations           None.
[WARN] MAIL_MAILER                  MAIL_MAILER=log: notification emails are recorded as skipped and never delivered.
[PASS] Scheduler heartbeat          Last run 2 seconds ago.
15 passed, 2 warning(s), 0 failure(s) — status: WARN
```

The two warnings are expected in this environment: the dev PHP image has no `gd` (optional, PDF images) and `MAIL_MAILER=log`. Exit code 0; with `--json` the report has `"status": "warn"` and `"failures": 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
