### PR TITLE
Branding by environment + hosted-mode plan/trial

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,16 @@ QUEUE_CONNECTION=database
 # [PROD REQUIRED] The scheduler heartbeat and locks live in the cache table.
 CACHE_STORE=database
 
+# Branding (hosted mode). All optional; defaults keep the stock Jotter identity.
+# JOTTER_BRAND_NAME defaults to APP_NAME; an empty logo URL uses the bundled mark.
+JOTTER_BRAND_NAME=
+JOTTER_BRAND_LOGO_URL=
+JOTTER_BRAND_SUPPORT_URL=
+JOTTER_BRAND_TERMS_URL=
+JOTTER_BRAND_PRIVACY_URL=
+# Show "Powered by Jotter" with a link to the repository (true by default).
+JOTTER_BRAND_POWERED_BY=true
+
 # Seed values for the first tenant/workspace (used by `migrate --seed`).
 JOTTER_TENANT_NAME=Jotter
 JOTTER_TENANT_SLUG=default

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -25,8 +25,15 @@ The roadmap's historical Phase 1 gaps are already delivered in this repository: 
 
 ## Operations follow-ups (from the 2026-08-31 multi-instance release)
 
-- **Trial expiry job.** There is no trial concept today; when one is introduced, register its expiry command in `routes/console.php` and add it to the scheduled-jobs table in `docs/deployment.md` (the doctor and scheduler test will need the new command name).
+- ~~**Trial expiry job.**~~ Delivered as `tenant:expire-trials` in `feat/brand-and-plan`.
 - **Doctor thresholds.** Disk-space (100 MiB critical / 1 GiB warning) and scheduler age (5 minutes) are constants on `InstanceDoctor`; make them configurable only if a host proves them wrong.
+
+## Hosted-mode follow-ups (from `feat/brand-and-plan`, 2026-08-31)
+
+- **Plan gate coverage.** The 402 gate covers `workspace.write` routes, WebDAV `PUT`/`MKCOL`/`DELETE`, and import, per the issue's scope. Group, ACL, review-workflow, watch, and notification-state writes are metadata and remain allowed for read-only tenants; extend the gate if operators need a stricter freeze.
+- **Trial expiry job.** Delivered as `tenant:expire-trials` (daily). Remove the placeholder from the 2026-08-31 operations follow-ups above.
+- **Hosted-mode UX.** The SPA surfaces 402 responses through the existing error paths (message text from the API). A dedicated upgrade/contact call-to-action would need the operator's `JOTTER_BRAND_SUPPORT_URL` and is not built.
+- **Design-token guard debt.** `scripts/check-design-tokens.sh` fails on `main` for pre-existing raw color fallbacks in `NoteReviewPanel.vue:243` and `NotificationPreferences.vue:117`; new components in this branch are token-only.
 
 ## Completed follow-up
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Jotter will be documented here. Decision records live in `docs/decisions.md`; security-audit findings live in `docs/security-audit-2026.md`; visual-identity rollout tracking lives in `docs/visual-identity.md`. Split from a single overloaded `BACKLOG.md` in #208.
 
+## v1 (post-v0) — 2026-08-31: Branding by environment and hosted-mode plan/trial
+
+Jotter (MIT) is also offered as the hosted service "Cadernia". Both are the same engine: branding and plan state are configuration with self-hosting-neutral defaults (`docs/decisions.md`, "Single engine; hosting is configuration"). Zero change with defaults; no payment code (`feat/brand-and-plan`).
+
+- **Branding.** `JOTTER_BRAND_NAME` (default `APP_NAME`), `JOTTER_BRAND_LOGO_URL`, `JOTTER_BRAND_SUPPORT_URL`, `JOTTER_BRAND_TERMS_URL`, `JOTTER_BRAND_PRIVACY_URL`, `JOTTER_BRAND_POWERED_BY` (default `true`) in `config/jotter.php`/`.env.example`, exposed as `data.brand` on `GET /api/auth/config`. The SPA uses them for the tab title, sidebar header (`BrandMark`), login heading, footer links and "Powered by Jotter" (`BrandFooter`); `app.blade.php` for `<title>`/OG; published pages get a footer with the links and the powered-by credit.
+- **Plan and trial.** `tenants.plan_status` (`self_hosted` default, `trial`, `active`, `past_due`, `read_only`), `trial_ends_at`, `plan_name`, `plan_seats`. `GET /api/tenants` returns a `plan` payload; the SPA shows "Trial ends in N days" (en/pt-BR) and a read-only notice. Expired trial, `past_due`, and `read_only` block writes behind `workspace.write`, WebDAV `PUT`/`MKCOL`/`DELETE`, and import with 402 + localized message while reading, search, ZIP/JSON/PDF export, and login keep working. `plan_seats` refuses a membership for a new subject beyond the limit (402). Audited as `plan.write_blocked` / `plan.seat_limit_reached`.
+- **Operator commands.** `tenant:plan {slug} --status= --trial-days= --seats= --name= [--json]` (audited as `tenant.plan_changed`) and `tenant:show {slug} [--json]`. Scheduled `tenant:expire-trials` (daily 03:00 via `schedule:run`) moves overdue trials to `read_only` and records `tenant.trial_expired`.
+- **Tests.** `BrandingTest`, `TenantPlanEnforcementTest`, `TenantPlanCommandsTest`, scheduler registration; Vitest `Brand.spec.ts`, `PlanBanner.spec.ts`.
+
 ## v1 (post-v0) — 2026-08-31: Multi-instance release and installation doctor
 
 Shared-hosting production means one installation per client on its own subdomain, no daemon, and a single cron per installation. This entry makes the release ZIP install predictably N times on one host and lets each installation diagnose itself (`feat/multi-instance-release`).

--- a/STATUS.md
+++ b/STATUS.md
@@ -110,6 +110,13 @@ This file previously ended at the 2026-08-05 formatting toolbar while 65 commits
 
 ---
 
+## 1.3 Delivered 2026-08-31 — branding by environment + hosted-mode plan/trial
+
+- **Branding.** `JOTTER_BRAND_*` env → `config('jotter.brand')` → `GET /api/auth/config` `data.brand` → SPA (title, header mark, login, footer links, "Powered by Jotter"), Laravel shell OG tags, published-page footer. Defaults = stock Jotter.
+- **Plan/trial.** `tenants.plan_status` (+ `trial_ends_at`, `plan_name`, `plan_seats`), `TenantPlan` gate returning 402 on writes for expired trial / `past_due` / `read_only`, seat limit on membership grants, trial banner in the SPA, `tenant:plan` / `tenant:show` / scheduled `tenant:expire-trials`. `self_hosted` default changes nothing; no billing code (decision recorded in `docs/decisions.md`).
+
+---
+
 ## 2. Position against the product roadmap
 
 `docs/20260727-jotter-roadmap-ai-agent.md` ranks twelve near-term priorities. **Five of its top six already ship here** — search, nested folders, tags, backlinks, and attachments. Its gap analysis says otherwise because its baseline describes a different product (offline-first, Material You, realtime collaboration); spec §14.1 records this and §14.3 carries the authoritative delivered-state table.

--- a/app/Console/Commands/TenantExpireTrialsCommand.php
+++ b/app/Console/Commands/TenantExpireTrialsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Plan\TenantPlan;
+use Illuminate\Console\Command;
+
+/**
+ * Scheduled daily. Moves trials past their deadline to read_only and writes one
+ * audit row per tenant. Idempotent: already read-only tenants are not touched.
+ */
+final class TenantExpireTrialsCommand extends Command
+{
+    protected $signature = 'tenant:expire-trials';
+
+    protected $description = 'Move expired hosted-mode trials to read_only (scheduler task).';
+
+    public function handle(TenantPlan $tenantPlan): int
+    {
+        $expired = $tenantPlan->expireTrials();
+
+        $this->info(sprintf('Expired %d trial(s)%s.', count($expired), $expired === [] ? '' : ': '.implode(', ', $expired)));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/TenantPlanCommand.php
+++ b/app/Console/Commands/TenantPlanCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Domain\Plan\PlanStatus;
+use App\Domain\Plan\TenantPlan;
+use App\Models\Tenant;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+/**
+ * Operator entry point for hosted-mode plan state. Billing is external; this
+ * command is how a paid, lapsed, or trial account is reflected in the engine.
+ */
+final class TenantPlanCommand extends Command
+{
+    protected $signature = 'tenant:plan {slug : Tenant slug}
+                            {--status= : self_hosted|trial|active|past_due|read_only}
+                            {--trial-days= : Trial length in days from now (implies --status=trial when omitted)}
+                            {--seats= : Seat limit; pass 0 or an empty value to remove it}
+                            {--name= : Plan label shown to operators}
+                            {--json : Emit the resulting tenant as JSON}';
+
+    protected $description = 'Set the hosted-mode plan status, trial deadline, seat limit, and plan name of a tenant.';
+
+    public function handle(TenantPlan $tenantPlan, AuditRecorder $auditRecorder): int
+    {
+        $tenant = Tenant::query()->where('slug', $this->argument('slug'))->first();
+        if ($tenant === null) {
+            $this->error(sprintf('Tenant [%s] was not found.', $this->argument('slug')));
+
+            return self::FAILURE;
+        }
+
+        $before = $tenantPlan->payload($tenant);
+        $changes = [];
+
+        $status = $this->option('status');
+        if ($status !== null && $status !== '') {
+            $parsed = PlanStatus::tryFrom((string) $status);
+            if ($parsed === null) {
+                $this->error(sprintf('Invalid --status [%s]. Allowed: %s.', $status, implode(', ', PlanStatus::values())));
+
+                return self::FAILURE;
+            }
+            $changes['plan_status'] = $parsed->value;
+        }
+
+        $trialDays = $this->option('trial-days');
+        if ($trialDays !== null && $trialDays !== '') {
+            if (! ctype_digit((string) $trialDays) || (int) $trialDays < 1) {
+                $this->error('--trial-days must be a positive integer.');
+
+                return self::FAILURE;
+            }
+            $changes['trial_ends_at'] = CarbonImmutable::now()->addDays((int) $trialDays);
+            if (! isset($changes['plan_status'])) {
+                $changes['plan_status'] = PlanStatus::TRIAL->value;
+            }
+        }
+
+        // Omitted options are null; `--seats=` (empty) and `--seats=0` clear the limit.
+        if ($this->option('seats') !== null) {
+            $seats = (string) $this->option('seats');
+            if ($seats === '' || $seats === '0') {
+                $changes['plan_seats'] = null;
+            } elseif (! ctype_digit($seats)) {
+                $this->error('--seats must be a non-negative integer.');
+
+                return self::FAILURE;
+            } else {
+                $changes['plan_seats'] = (int) $seats;
+            }
+        }
+
+        if ($this->option('name') !== null) {
+            $name = trim((string) $this->option('name'));
+            $changes['plan_name'] = $name === '' ? null : $name;
+        }
+
+        if ($changes === []) {
+            $this->error('Nothing to change. Pass at least one of --status, --trial-days, --seats, --name.');
+
+            return self::FAILURE;
+        }
+
+        // Leaving trial for a non-trial state clears a stale deadline.
+        if (isset($changes['plan_status'])
+            && $changes['plan_status'] !== PlanStatus::TRIAL->value
+            && ! isset($changes['trial_ends_at'])) {
+            $changes['trial_ends_at'] = null;
+        }
+
+        $tenant->forceFill($changes)->save();
+        $tenant->refresh();
+        $after = $tenantPlan->payload($tenant);
+
+        $auditRecorder->record(
+            event: AuditEvent::TENANT_PLAN_CHANGED,
+            tenantId: $tenant->id,
+            actorId: 'cli:tenant:plan',
+            metadata: [
+                'tenant_slug' => $tenant->slug,
+                'before' => $before,
+                'after' => $after,
+            ],
+        );
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($this->describe($tenant, $tenantPlan), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Tenant %s (%s) updated.', $tenant->slug, $tenant->name));
+        foreach ($this->describe($tenant, $tenantPlan)['plan'] as $key => $value) {
+            $this->line(sprintf('  %-16s %s', $key, is_bool($value) ? ($value ? 'true' : 'false') : ($value ?? '—')));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function describe(Tenant $tenant, TenantPlan $tenantPlan): array
+    {
+        return [
+            'id' => $tenant->id,
+            'slug' => $tenant->slug,
+            'name' => $tenant->name,
+            'plan' => $tenantPlan->payload($tenant) + ['seats_used' => $tenantPlan->seatsUsed($tenant)],
+        ];
+    }
+}

--- a/app/Console/Commands/TenantShowCommand.php
+++ b/app/Console/Commands/TenantShowCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Plan\TenantPlan;
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+
+final class TenantShowCommand extends Command
+{
+    protected $signature = 'tenant:show {slug : Tenant slug} {--json : Emit JSON}';
+
+    protected $description = 'Show a tenant with its hosted-mode plan state, seats, and workspaces.';
+
+    public function handle(TenantPlan $tenantPlan): int
+    {
+        $tenant = Tenant::query()->where('slug', $this->argument('slug'))->first();
+        if ($tenant === null) {
+            $this->error(sprintf('Tenant [%s] was not found.', $this->argument('slug')));
+
+            return self::FAILURE;
+        }
+
+        $report = [
+            'id' => $tenant->id,
+            'slug' => $tenant->slug,
+            'name' => $tenant->name,
+            'created_at' => $tenant->created_at?->toIso8601String(),
+            'plan' => $tenantPlan->payload($tenant) + ['seats_used' => $tenantPlan->seatsUsed($tenant)],
+            'workspaces' => $tenant->workspaces()->orderBy('id')->get(['id', 'slug', 'name'])
+                ->map(static fn ($workspace): array => ['id' => $workspace->id, 'slug' => $workspace->slug, 'name' => $workspace->name])
+                ->all(),
+        ];
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->line(sprintf('Tenant %s — %s (id %d)', $tenant->slug, $tenant->name, $tenant->id));
+        foreach ($report['plan'] as $key => $value) {
+            $this->line(sprintf('  %-16s %s', $key, is_bool($value) ? ($value ? 'true' : 'false') : ($value ?? '—')));
+        }
+        $this->line(sprintf('  %-16s %d', 'workspaces', count($report['workspaces'])));
+        foreach ($report['workspaces'] as $workspace) {
+            $this->line(sprintf('    - %s (%s, id %d)', $workspace['name'], $workspace['slug'], $workspace['id']));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Audit/AuditEvent.php
+++ b/app/Domain/Audit/AuditEvent.php
@@ -43,5 +43,10 @@ enum AuditEvent: string
     case NOTE_REVIEW_CHANGES_REQUESTED = 'note.review_changes_requested';
     case NOTE_REVIEW_INVALIDATED = 'note.review_invalidated';
 
+    case TENANT_PLAN_CHANGED = 'tenant.plan_changed';
+    case TENANT_TRIAL_EXPIRED = 'tenant.trial_expired';
+    case PLAN_WRITE_BLOCKED = 'plan.write_blocked';
+    case PLAN_SEAT_LIMIT_REACHED = 'plan.seat_limit_reached';
+
     case SYSTEM_AUDIT_PRUNED = 'system.audit_pruned';
 }

--- a/app/Domain/Plan/PlanStatus.php
+++ b/app/Domain/Plan/PlanStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Domain\Plan;
+
+use Carbon\CarbonInterface;
+
+enum PlanStatus: string
+{
+    case SELF_HOSTED = 'self_hosted';
+    case TRIAL = 'trial';
+    case ACTIVE = 'active';
+    case PAST_DUE = 'past_due';
+    case READ_ONLY = 'read_only';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $status): string => $status->value, self::cases());
+    }
+
+    /**
+     * Whether a tenant in this status may write, given its trial deadline.
+     * `self_hosted` never restricts anything; a trial writes until it ends.
+     */
+    public function allowsWrites(?CarbonInterface $trialEndsAt, CarbonInterface $now): bool
+    {
+        return match ($this) {
+            self::SELF_HOSTED, self::ACTIVE => true,
+            self::TRIAL => $trialEndsAt === null || $trialEndsAt->greaterThan($now),
+            self::PAST_DUE, self::READ_ONLY => false,
+        };
+    }
+}

--- a/app/Domain/Plan/TenantPlan.php
+++ b/app/Domain/Plan/TenantPlan.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Domain\Plan;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Models\Membership;
+use App\Models\Tenant;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Hosted-mode plan rules. With the default `self_hosted` status every method is
+ * a no-op, so a self-hosted installation never observes this class. Billing is
+ * external: the operator changes state with `tenant:plan`; nothing here charges.
+ */
+final class TenantPlan
+{
+    public function __construct(
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+    ) {}
+
+    public function status(Tenant $tenant): PlanStatus
+    {
+        return PlanStatus::tryFrom((string) $tenant->plan_status) ?? PlanStatus::SELF_HOSTED;
+    }
+
+    public function allowsWrites(Tenant $tenant): bool
+    {
+        return $this->status($tenant)->allowsWrites($tenant->trial_ends_at, CarbonImmutable::now());
+    }
+
+    public function isSelfHosted(Tenant $tenant): bool
+    {
+        return $this->status($tenant) === PlanStatus::SELF_HOSTED;
+    }
+
+    /**
+     * Whole days left in an active trial; null outside a dated trial.
+     */
+    public function trialDaysLeft(Tenant $tenant): ?int
+    {
+        if ($this->status($tenant) !== PlanStatus::TRIAL || $tenant->trial_ends_at === null) {
+            return null;
+        }
+
+        $now = CarbonImmutable::now();
+
+        return $tenant->trial_ends_at->greaterThan($now)
+            ? (int) ceil($now->diffInSeconds($tenant->trial_ends_at) / 86400)
+            : 0;
+    }
+
+    /**
+     * Distinct subjects holding at least one membership in the tenant.
+     */
+    public function seatsUsed(Tenant $tenant): int
+    {
+        return Membership::query()
+            ->where('tenant_id', $tenant->id)
+            ->distinct()
+            ->count('subject_id');
+    }
+
+    /**
+     * Whether granting membership to $subjectId would exceed `plan_seats`.
+     * Subjects that already hold a membership never consume a new seat.
+     */
+    public function seatLimitReached(Tenant $tenant, string $subjectId): bool
+    {
+        $seats = $tenant->plan_seats;
+        if ($seats === null || $this->isSelfHosted($tenant)) {
+            return false;
+        }
+
+        $alreadyMember = Membership::query()
+            ->where('tenant_id', $tenant->id)
+            ->where('subject_id', $subjectId)
+            ->exists();
+        if ($alreadyMember) {
+            return false;
+        }
+
+        return $this->seatsUsed($tenant) >= (int) $seats;
+    }
+
+    /**
+     * Payload exposed to the SPA (trial banner, read-only notice).
+     *
+     * @return array{status: string, name: ?string, seats: ?int, trial_ends_at: ?string, trial_days_left: ?int, read_only: bool}
+     */
+    public function payload(Tenant $tenant): array
+    {
+        return [
+            'status' => $this->status($tenant)->value,
+            'name' => $tenant->plan_name,
+            'seats' => $tenant->plan_seats,
+            'trial_ends_at' => $tenant->trial_ends_at?->toIso8601String(),
+            'trial_days_left' => $this->trialDaysLeft($tenant),
+            'read_only' => ! $this->allowsWrites($tenant),
+        ];
+    }
+
+    /**
+     * 402 response for a blocked write, recorded in the audit log.
+     */
+    public function denyWrite(Tenant $tenant, Request $request, ?int $workspaceId, ?string $actorId): JsonResponse
+    {
+        $this->auditRecorder->record(
+            event: AuditEvent::PLAN_WRITE_BLOCKED,
+            tenantId: $tenant->id,
+            workspaceId: $workspaceId,
+            actorId: $actorId,
+            metadata: [
+                'plan_status' => $this->status($tenant)->value,
+                'path' => $request->path(),
+                'method' => $request->method(),
+            ],
+        );
+
+        return response()->json([
+            'message' => __('messages.plan_read_only'),
+            'plan_status' => $this->status($tenant)->value,
+        ], 402);
+    }
+
+    /**
+     * 402 response for a membership beyond `plan_seats`, recorded in the audit log.
+     */
+    public function denySeat(Tenant $tenant, ?int $workspaceId, ?string $actorId, string $targetSubjectId): JsonResponse
+    {
+        $this->auditRecorder->record(
+            event: AuditEvent::PLAN_SEAT_LIMIT_REACHED,
+            tenantId: $tenant->id,
+            workspaceId: $workspaceId,
+            actorId: $actorId,
+            metadata: [
+                'plan_seats' => $tenant->plan_seats,
+                'seats_used' => $this->seatsUsed($tenant),
+                'target_subject_id' => $targetSubjectId,
+            ],
+        );
+
+        return response()->json([
+            'message' => __('messages.plan_seat_limit_reached', ['seats' => (int) $tenant->plan_seats]),
+            'plan_status' => $this->status($tenant)->value,
+            'plan_seats' => $tenant->plan_seats,
+        ], 402);
+    }
+
+    /**
+     * Moves every trial whose deadline passed to `read_only`, one audit row each.
+     *
+     * @return list<string> slugs that were expired
+     */
+    public function expireTrials(): array
+    {
+        $expired = [];
+        $now = CarbonImmutable::now();
+
+        Tenant::query()
+            ->where('plan_status', PlanStatus::TRIAL->value)
+            ->whereNotNull('trial_ends_at')
+            ->where('trial_ends_at', '<=', $now)
+            ->orderBy('id')
+            ->each(function (Tenant $tenant) use (&$expired, $now): void {
+                $tenant->forceFill(['plan_status' => PlanStatus::READ_ONLY->value])->save();
+
+                $this->auditRecorder->record(
+                    event: AuditEvent::TENANT_TRIAL_EXPIRED,
+                    tenantId: $tenant->id,
+                    metadata: [
+                        'tenant_slug' => $tenant->slug,
+                        'trial_ends_at' => $tenant->trial_ends_at?->toIso8601String(),
+                        'expired_at' => $now->toIso8601String(),
+                        'from' => PlanStatus::TRIAL->value,
+                        'to' => PlanStatus::READ_ONLY->value,
+                    ],
+                );
+
+                $expired[] = $tenant->slug;
+            });
+
+        return $expired;
+    }
+}

--- a/app/Http/Controllers/AdminMembershipController.php
+++ b/app/Http/Controllers/AdminMembershipController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
 use App\Domain\Auth\AuthenticatedSubject;
+use App\Domain\Plan\TenantPlan;
 use App\Models\Membership;
 use App\Models\Workspace;
 use Illuminate\Http\JsonResponse;
@@ -17,6 +18,7 @@ final class AdminMembershipController extends Controller
 
     public function __construct(
         private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+        private readonly TenantPlan $tenantPlan = new TenantPlan,
     ) {}
 
     public function index(Request $request, Workspace $workspace): JsonResponse
@@ -43,6 +45,17 @@ final class AdminMembershipController extends Controller
             'subject_id' => ['required', 'string', 'max:191'],
             'role' => ['required', 'string', Rule::in(self::ALLOWED_ROLES)],
         ]);
+
+        // Hosted mode: a new subject beyond `plan_seats` is refused with 402.
+        $tenant = $workspace->tenant;
+        if ($tenant !== null && $this->tenantPlan->seatLimitReached($tenant, $validated['subject_id'])) {
+            return $this->tenantPlan->denySeat(
+                $tenant,
+                $workspace->id,
+                $this->currentSubject($request)?->subjectId,
+                $validated['subject_id'],
+            );
+        }
 
         // Cross-tenant check: ensure workspace belongs to requested tenant context
         $membership = Membership::query()->updateOrCreate(

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Domain\Vault\ExternalEmbedPolicy;
+use App\Support\Branding;
 use App\Support\ReleaseVersion;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -75,6 +76,7 @@ final class AuthController extends Controller
                 'sso_login_url' => $ssoLoginUrl,
                 'version' => ReleaseVersion::current(),
                 'external_embed_domains' => ExternalEmbedPolicy::configured()->allowedHosts(),
+                'brand' => Branding::configured()->toArray(),
             ],
         ]);
     }

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Domain\Plan\TenantPlan;
 use App\Models\Tenant;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -10,14 +11,17 @@ use Illuminate\Http\Request;
 class TenantController extends Controller
 {
     public function __construct(
-        private readonly IdentityProvider $identityProvider
+        private readonly IdentityProvider $identityProvider,
+        private readonly TenantPlan $tenantPlan,
     ) {}
 
     public function index(Request $request): JsonResponse
     {
         $subject = $request->attributes->get('authenticated_subject');
 
-        $query = Tenant::query()->select(['id', 'slug', 'name'])->orderBy('id');
+        $query = Tenant::query()
+            ->select(['id', 'slug', 'name', 'plan_status', 'trial_ends_at', 'plan_name', 'plan_seats'])
+            ->orderBy('id');
 
         $accessibleIds = $this->identityProvider->accessibleTenantIds($subject);
 
@@ -25,6 +29,13 @@ class TenantController extends Controller
             $query->whereIn('id', $accessibleIds);
         }
 
-        return response()->json(['data' => $query->get()]);
+        $tenants = $query->get()->map(fn (Tenant $tenant): array => [
+            'id' => $tenant->id,
+            'slug' => $tenant->slug,
+            'name' => $tenant->name,
+            'plan' => $this->tenantPlan->payload($tenant),
+        ])->values();
+
+        return response()->json(['data' => $tenants]);
     }
 }

--- a/app/Http/Controllers/WebDavController.php
+++ b/app/Http/Controllers/WebDavController.php
@@ -6,11 +6,12 @@ use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Domain\Auth\NoteAccess;
+use App\Domain\Plan\TenantPlan;
 use App\Domain\Vault\Exceptions\PathTraversalRejected;
 use App\Domain\Vault\VaultPathGuard;
 use App\Domain\Vault\VaultStorage;
-use App\Models\Workspace;
 use App\Models\Note;
+use App\Models\Workspace;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -23,6 +24,7 @@ final class WebDavController extends Controller
         private readonly VaultStorage $storage,
         private readonly NoteAccess $noteAccess,
         private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+        private readonly TenantPlan $tenantPlan = new TenantPlan,
     ) {}
 
     public function handle(Request $request, int $workspaceId, ?string $path = null): Response|JsonResponse
@@ -57,6 +59,12 @@ final class WebDavController extends Controller
             );
 
             return response()->json(['message' => __('messages.forbidden')], 403);
+        }
+
+        if (in_array($method, ['PUT', 'MKCOL', 'DELETE'], true)
+            && $workspace->tenant !== null
+            && ! $this->tenantPlan->allowsWrites($workspace->tenant)) {
+            return $this->tenantPlan->denyWrite($workspace->tenant, $request, $workspace->id, $subject->subjectId);
         }
 
         $targetPath = trim($path ?? '', '/');

--- a/app/Http/Middleware/AuthorizeWorkspaceWrite.php
+++ b/app/Http/Middleware/AuthorizeWorkspaceWrite.php
@@ -6,6 +6,7 @@ use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
 use App\Domain\Auth\AuthenticatedSubject;
 use App\Domain\Auth\Contracts\IdentityProvider;
+use App\Domain\Plan\TenantPlan;
 use App\Models\Workspace;
 use Closure;
 use Illuminate\Http\Request;
@@ -16,6 +17,7 @@ final class AuthorizeWorkspaceWrite
     public function __construct(
         private readonly IdentityProvider $identityProvider,
         private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+        private readonly TenantPlan $tenantPlan = new TenantPlan,
     ) {}
 
     /**
@@ -31,8 +33,10 @@ final class AuthorizeWorkspaceWrite
         $workspaceParam = $request->route('workspace');
         $workspaceId = null;
         $tenantId = null;
+        $workspace = null;
 
         if ($workspaceParam instanceof Workspace) {
+            $workspace = $workspaceParam;
             $workspaceId = $workspaceParam->id;
             $tenantId = $workspaceParam->tenant_id;
         } elseif (is_numeric($workspaceParam)) {
@@ -57,6 +61,14 @@ final class AuthorizeWorkspaceWrite
             );
 
             return response()->json(['message' => __('messages.forbidden')], 403);
+        }
+
+        // Hosted mode: an expired trial, past-due, or read-only tenant keeps reading
+        // but every write behind this middleware answers 402. `self_hosted` never
+        // reaches denyWrite().
+        $tenant = $workspace?->tenant;
+        if ($tenant !== null && ! $this->tenantPlan->allowsWrites($tenant)) {
+            return $this->tenantPlan->denyWrite($tenant, $request, $workspaceId, $subject->subjectId);
         }
 
         return $next($request);

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -10,6 +10,15 @@ class Tenant extends Model
     protected $fillable = [
         'slug',
         'name',
+        'plan_status',
+        'trial_ends_at',
+        'plan_name',
+        'plan_seats',
+    ];
+
+    protected $casts = [
+        'trial_ends_at' => 'immutable_datetime',
+        'plan_seats' => 'integer',
     ];
 
     public function workspaces(): HasMany

--- a/app/Support/Branding.php
+++ b/app/Support/Branding.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Operator-facing branding for one installation. Every value has a default that
+ * leaves a self-hosted Jotter exactly as before; a hosted operator overrides them
+ * through environment variables only — never by forking the engine.
+ */
+final class Branding
+{
+    public const REPOSITORY_URL = 'https://github.com/suporterfid/jotter';
+
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $logoUrl,
+        public readonly ?string $supportUrl,
+        public readonly ?string $termsUrl,
+        public readonly ?string $privacyUrl,
+        public readonly bool $poweredBy,
+    ) {}
+
+    public static function configured(): self
+    {
+        $brand = (array) config('jotter.brand', []);
+
+        return new self(
+            name: self::stringOrNull($brand['name'] ?? null) ?? (string) config('app.name', 'Jotter'),
+            logoUrl: self::stringOrNull($brand['logo_url'] ?? null),
+            supportUrl: self::stringOrNull($brand['support_url'] ?? null),
+            termsUrl: self::stringOrNull($brand['terms_url'] ?? null),
+            privacyUrl: self::stringOrNull($brand['privacy_url'] ?? null),
+            poweredBy: (bool) ($brand['powered_by'] ?? true),
+        );
+    }
+
+    /**
+     * @return array{name: string, logo_url: ?string, support_url: ?string, terms_url: ?string, privacy_url: ?string, powered_by: bool, powered_by_url: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'logo_url' => $this->logoUrl,
+            'support_url' => $this->supportUrl,
+            'terms_url' => $this->termsUrl,
+            'privacy_url' => $this->privacyUrl,
+            'powered_by' => $this->poweredBy,
+            'powered_by_url' => self::REPOSITORY_URL,
+        ];
+    }
+
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/config/jotter.php
+++ b/config/jotter.php
@@ -4,6 +4,17 @@ return [
     // Identifies one installation when several share a host (logs, doctor, support).
     'instance_slug' => env('APP_INSTANCE_SLUG'),
 
+    // Branding. Defaults reproduce the stock Jotter UI; a hosted operator (e.g.
+    // "Cadernia") overrides them by environment only. Empty strings mean unset.
+    'brand' => [
+        'name' => env('JOTTER_BRAND_NAME') ?: env('APP_NAME', 'Jotter'),
+        'logo_url' => env('JOTTER_BRAND_LOGO_URL') ?: null,
+        'support_url' => env('JOTTER_BRAND_SUPPORT_URL') ?: null,
+        'terms_url' => env('JOTTER_BRAND_TERMS_URL') ?: null,
+        'privacy_url' => env('JOTTER_BRAND_PRIVACY_URL') ?: null,
+        'powered_by' => (bool) env('JOTTER_BRAND_POWERED_BY', true),
+    ],
+
     'seed' => [
         'tenant_name' => env('JOTTER_TENANT_NAME', 'Jotter'),
         'tenant_slug' => env('JOTTER_TENANT_SLUG', 'default'),

--- a/database/migrations/2026_08_31_000001_add_plan_columns_to_tenants_table.php
+++ b/database/migrations/2026_08_31_000001_add_plan_columns_to_tenants_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table): void {
+            // `self_hosted` is the default and changes nothing; the other states
+            // exist only for hosted operators and are set with `tenant:plan`.
+            $table->enum('plan_status', ['self_hosted', 'trial', 'active', 'past_due', 'read_only'])
+                ->default('self_hosted')
+                ->after('name');
+            $table->timestamp('trial_ends_at')->nullable()->after('plan_status');
+            $table->string('plan_name')->nullable()->after('trial_ends_at');
+            $table->unsignedInteger('plan_seats')->nullable()->after('plan_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table): void {
+            $table->dropColumn(['plan_status', 'trial_ends_at', 'plan_name', 'plan_seats']);
+        });
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,41 @@ PR4 adds the MySQL FULLTEXT index and read-only search endpoint only. It does no
 
 For AI assistant integration, Jotter provides a Model Context Protocol server over HTTP JSON-RPC 2.0 (`POST /api/mcp`). Read-only tools (`list_notes`, `read_note`, `search_notes`, `get_backlinks`) are implemented with per-workspace authorization. Write tools are intentionally deferred and gated per security policy §8 S2 & S5. See [docs/mcp.md](mcp.md) for details.
 
+## Hosted mode
+
+Jotter (MIT) is one engine. Offering it as a hosted service — for example under
+the "Cadernia" brand — is configuration of that engine, never a fork
+(`docs/decisions.md`, "Single engine; hosting is configuration"). Every hosted
+feature has a default that leaves a self-hosted installation byte-for-byte
+unchanged, and none of it involves payment code: billing is external and the
+operator reflects it with an Artisan command.
+
+**Branding** (`config/jotter.php` → `brand`, env `JOTTER_BRAND_*`): name
+(defaults to `APP_NAME`), logo URL (empty = bundled mark from `assets/brand/`),
+support/terms/privacy URLs, and a `powered_by` flag (default `true`). The values
+are served by `GET /api/auth/config` (`data.brand`) and consumed by the SPA
+(tab title, sidebar header, login screen, footer links, "Powered by Jotter"), by
+the Laravel shell (`app.blade.php` title/OG tags), and by published static pages
+(`publish/page.blade.php` footer).
+
+**Plan** (`tenants.plan_status`, `trial_ends_at`, `plan_name`, `plan_seats`):
+`self_hosted` (default) disables every rule. `trial` writes until
+`trial_ends_at`; the SPA shows a discreet "Trial ends in N days" banner
+(`GET /api/tenants` → `plan`). An expired `trial`, `past_due`, or `read_only`
+tenant keeps login, reading, search, and ZIP/JSON/PDF export, while writes
+behind `workspace.write`, WebDAV `PUT`/`MKCOL`/`DELETE`, and import answer
+`402 Payment Required` with a localized message (`App\Domain\Plan\TenantPlan`).
+`plan_seats` refuses a membership for a new subject beyond the limit with 402;
+existing members can still change role. Group, ACL, review, and notification
+writes are metadata and stay outside the gate (see `BACKLOG.md`).
+
+**Operations**: `tenant:plan {slug} --status= --trial-days= --seats= --name=`
+and `tenant:show {slug}` (both `--json`) are the only way plan state changes;
+each change is an `audit_log` row (`tenant.plan_changed`). The scheduled
+`tenant:expire-trials` (daily, via the single `schedule:run` cron) moves overdue
+trials to `read_only` and records `tenant.trial_expired`. Blocked writes and
+refused seats are audited as `plan.write_blocked` / `plan.seat_limit_reached`.
+
 ## Visual Identity
 
 The user interface follows the shared visual identity specification, documented in [docs/visual-identity.md](visual-identity.md) and asset inventory in `assets/brand/`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -169,3 +169,26 @@ This boundary preserves the Markdown-on-disk source of truth and shared-hosting 
 This decision resolves the semantics required before implementing #359. A future decision may add publication gating or a stronger deployment-level lock, but that would supersede this entry and require a separate issue.
 
 ---
+
+## Decision — Single engine; hosting is configuration, not a fork (feat/brand-and-plan)
+
+**Decided 2026-08-31:** Jotter is offered both as MIT self-hosted software and as a hosted service ("Cadernia"). Both run the same engine from the same repository. Branding and commercial plan state are configuration and data of that engine, with defaults that leave a self-hosted installation unchanged.
+
+### Selected contract
+
+- Branding is environment configuration (`JOTTER_BRAND_NAME`, `JOTTER_BRAND_LOGO_URL`, `JOTTER_BRAND_SUPPORT_URL`, `JOTTER_BRAND_TERMS_URL`, `JOTTER_BRAND_PRIVACY_URL`, `JOTTER_BRAND_POWERED_BY`) exposed through `GET /api/auth/config`. Defaults reproduce the stock identity; `powered_by` defaults to `true` and links to the repository.
+- Plan state lives on `tenants` (`plan_status`, `trial_ends_at`, `plan_name`, `plan_seats`) with `self_hosted` as the default that disables every rule. Restrictions are read-only gates (402) on writes; reading, search, export, and login are never restricted.
+- Plan state changes only through operator commands (`tenant:plan`, `tenant:show`) and one scheduled transition (`tenant:expire-trials`). Every change is audited.
+- No payment, checkout, invoice, or billing-provider code enters the repository. Billing is external; the operator mirrors its outcome with `tenant:plan`.
+- No hosted-only branch, build flag, or fork. Any hosted feature must ship with a default that keeps self-hosting identical and must be usable by any self-hoster who wants it.
+
+### Options considered
+
+- Fork or private downstream branch for the hosted product: rejected — divergence tax, duplicated security fixes, and the MIT engine would stop being the product actually run.
+- Build-time white-label (compile-time constants): rejected — one artifact must install for both audiences (`jt release` is shared), and per-client configuration is already the deployment model.
+- Payment integration inside the engine: rejected — it would force billing-provider dependencies and secrets on every self-hoster; a status field the operator sets is sufficient and auditable.
+- Runtime configuration with `self_hosted` default: selected.
+
+This entry governs future hosted-mode work; a decision that introduces billing code or a hosted-only fork would have to supersede it explicitly.
+
+---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -135,10 +135,12 @@ runs are prevented with cache locks (`CACHE_STORE=database`).
 | `vault:purge-trash` | daily 02:00 | Permanently deletes notes past the trash retention period. |
 | `vault:prune-revisions --days=30` | daily 02:15 | Prunes derived revision snapshots (Markdown files are never touched). |
 | `audit:prune --days=90` | daily 02:30 | Enforces audit-log retention. |
+| `tenant:expire-trials` | daily 03:00 | Hosted mode only: moves trials past `trial_ends_at` to `read_only` and audits it. No-op for self-hosted tenants. |
 
-Trial expiry is not scheduled because the product has no trial concept; add it to
-this table and to `routes/console.php` if one is introduced. The individual
-commands below remain available for one-off runs with different options.
+The individual commands below remain available for one-off runs with different
+options. Hosted-mode plan state is changed with `php artisan tenant:plan <slug>`
+and inspected with `php artisan tenant:show <slug>` (see `docs/architecture.md`,
+"Hosted mode").
 
 ## External content embeds
 

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -1,4 +1,4 @@
-import { mount, flushPromises } from '@vue/test-utils'
+import { config, mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App.vue'
 import { createNote, getWorkspaces, getAuthConfig, getTenants, getNotes, getNote, deleteNote, getNotifications, getTrash, restoreTrashNote, permanentlyDeleteTrashNote, queueWorkspacePdfExport, getWorkspacePdfExport, downloadWorkspacePdfExport } from './services/api'
@@ -59,6 +59,12 @@ vi.mock('./services/api', () => ({
   getWorkspacePdfExport: vi.fn().mockResolvedValue({ id: 'export-1', status: 'ready', scope: 'workspace' }),
   downloadWorkspacePdfExport: vi.fn(),
 }))
+
+// The real Milkdown editor arms 3s readiness timers that can fire after the
+// jsdom environment is torn down ("removeEventListener is not defined" as an
+// unhandled error under load). Nothing here interacts with the WYSIWYG surface,
+// so stub it; NoteEditor (the textarea surface) stays real.
+config.global.stubs = { ...config.global.stubs, NoteEditorWysiwyg: true }
 
 beforeEach(() => {
   localStorage.clear()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -76,6 +76,7 @@
 
     <!-- Main Content Area -->
     <main class="main-content">
+      <PlanBanner :plan="activeTenantPlan" />
       <!-- Graph View Mode -->
       <GraphView
         v-if="isGraphViewActive"
@@ -405,6 +406,8 @@ import { APP_VERSION } from './version'
 import { resolveWikilinkTarget } from './services/wikilinks'
 import { useSplitPanes, type PaneId } from './composables/useSplitPanes'
 import { setExternalEmbedAllowedHosts } from './services/externalEmbeds'
+import { brand, setBrand } from './services/brand'
+import PlanBanner from './components/PlanBanner.vue'
 
 const { t } = useI18n()
 
@@ -412,6 +415,7 @@ const workspaces = ref<Workspace[]>([])
 const activeWorkspaceId = ref<number>(1)
 const tenants = ref<Tenant[]>([])
 const activeTenantId = ref<number | null>(null)
+const activeTenantPlan = computed(() => tenants.value.find((tenant) => tenant.id === activeTenantId.value)?.plan ?? null)
 const notes = ref<NoteMeta[]>([])
 const folderPositions = ref<FolderPosition[]>([])
 const { layout: splitLayout, loadLayout, saveLayout, openNote, closeNote, splitWithNote, mergeSecondary } = useSplitPanes()
@@ -610,9 +614,12 @@ onMounted(async () => {
     backendVersion.value = config.version
     authProvider.value = config.provider
     setExternalEmbedAllowedHosts(config.external_embed_domains ?? [])
+    setBrand(config.brand)
   } catch {
     setExternalEmbedAllowedHosts([])
+    setBrand(null)
   }
+  if (typeof document !== 'undefined') document.title = brand.name
 
   await initWorkspace()
   openNotificationPreferencesFromUrl()

--- a/frontend/src/Brand.spec.ts
+++ b/frontend/src/Brand.spec.ts
@@ -1,0 +1,86 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Sidebar from './components/Sidebar.vue'
+import LoginModal from './components/LoginModal.vue'
+import BrandFooter from './components/BrandFooter.vue'
+import { getAuthConfig } from './services/api'
+import { resetBrand, setBrand } from './services/brand'
+
+vi.mock('./services/api', () => ({
+  getAuthConfig: vi.fn(),
+  login: vi.fn(),
+  moveNote: vi.fn(),
+  reorderNoteTree: vi.fn(),
+}))
+
+const CADERNIA = {
+  name: 'Cadernia',
+  logo_url: 'https://cdn.example.com/cadernia.svg',
+  support_url: 'https://cadernia.example.com/support',
+  terms_url: 'https://cadernia.example.com/terms',
+  privacy_url: 'https://cadernia.example.com/privacy',
+  powered_by: true,
+  powered_by_url: 'https://github.com/suporterfid/jotter',
+}
+
+function mountSidebar() {
+  return mount(Sidebar, {
+    props: { notes: [], selectedNoteId: null, workspaceId: 1, folderPositions: [], workspaces: [], frontendVersion: 'dev' },
+  })
+}
+
+describe('Branding', () => {
+  beforeEach(() => {
+    resetBrand()
+    vi.mocked(getAuthConfig).mockReset()
+  })
+
+  it('renders the stock Jotter identity by default', () => {
+    const wrapper = mountSidebar()
+
+    expect(wrapper.find('[data-testid="brand-title"]').text()).toBe('Jotter')
+    expect(wrapper.find('[data-testid="brand-mark"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="brand-logo"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="brand-powered-by"]').attributes('href')).toBe('https://github.com/suporterfid/jotter')
+    expect(wrapper.find('[data-testid="brand-link-terms"]').exists()).toBe(false)
+  })
+
+  it('shows the operator name, logo, and footer links in the sidebar', () => {
+    setBrand(CADERNIA)
+    const wrapper = mountSidebar()
+
+    expect(wrapper.find('[data-testid="brand-title"]').text()).toBe('Cadernia')
+    expect(wrapper.find('[data-testid="brand-logo"]').attributes('src')).toBe(CADERNIA.logo_url)
+    expect(wrapper.find('[data-testid="brand-logo"]').attributes('alt')).toBe('Cadernia')
+    expect(wrapper.find('[data-testid="brand-mark"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="brand-link-terms"]').attributes('href')).toBe(CADERNIA.terms_url)
+    expect(wrapper.find('[data-testid="brand-link-privacy"]').attributes('href')).toBe(CADERNIA.privacy_url)
+    expect(wrapper.find('[data-testid="brand-link-support"]').attributes('href')).toBe(CADERNIA.support_url)
+    expect(wrapper.find('[data-testid="brand-powered-by"]').text()).toBe('Powered by Jotter')
+  })
+
+  it('hides the powered-by link when disabled and the footer when nothing remains', () => {
+    setBrand({ ...CADERNIA, powered_by: false })
+    expect(mount(BrandFooter).find('[data-testid="brand-powered-by"]').exists()).toBe(false)
+
+    setBrand({ powered_by: false })
+    expect(mount(BrandFooter).find('[data-testid="brand-footer"]').exists()).toBe(false)
+  })
+
+  it('applies the brand from the auth config on the login screen', async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({ provider: 'local', sso_login_url: null, version: null, brand: CADERNIA })
+
+    const wrapper = mount(LoginModal, { props: { show: true } })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="login-heading"]').text()).toBe('Cadernia Sign In')
+    expect(wrapper.find('[data-testid="brand-logo"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="brand-link-terms"]').attributes('href')).toBe(CADERNIA.terms_url)
+    expect(wrapper.find('[data-testid="brand-powered-by"]').exists()).toBe(true)
+  })
+
+  it('falls back to Jotter when the brand name is blank', () => {
+    setBrand({ name: '   ' })
+    expect(mountSidebar().find('[data-testid="brand-title"]').text()).toBe('Jotter')
+  })
+})

--- a/frontend/src/PlanBanner.spec.ts
+++ b/frontend/src/PlanBanner.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import PlanBanner from './components/PlanBanner.vue'
+import i18n from './i18n'
+import { resetBrand, setBrand } from './services/brand'
+import type { TenantPlan } from './services/types'
+
+function plan(overrides: Partial<TenantPlan>): TenantPlan {
+  return { status: 'self_hosted', name: null, seats: null, trial_ends_at: null, trial_days_left: null, read_only: false, ...overrides }
+}
+
+describe('PlanBanner', () => {
+  beforeEach(() => {
+    resetBrand()
+    i18n.global.locale.value = 'en'
+  })
+
+  it('renders nothing for self-hosted or active plans', () => {
+    expect(mount(PlanBanner, { props: { plan: plan({}) } }).find('[data-testid="plan-banner"]').exists()).toBe(false)
+    expect(mount(PlanBanner, { props: { plan: plan({ status: 'active' }) } }).find('[data-testid="plan-banner"]').exists()).toBe(false)
+    expect(mount(PlanBanner, { props: { plan: null } }).find('[data-testid="plan-banner"]').exists()).toBe(false)
+  })
+
+  it('shows the remaining trial days in English and Portuguese', () => {
+    const trial = plan({ status: 'trial', trial_days_left: 5 })
+
+    expect(mount(PlanBanner, { props: { plan: trial } }).text()).toBe('Trial ends in 5 days')
+
+    i18n.global.locale.value = 'pt-BR'
+    expect(mount(PlanBanner, { props: { plan: trial } }).text()).toBe('O período de teste termina em 5 dias')
+  })
+
+  it('shows a read-only notice with a support link when configured', () => {
+    setBrand({ support_url: 'https://cadernia.example.com/support' })
+    const wrapper = mount(PlanBanner, { props: { plan: plan({ status: 'read_only', read_only: true }) } })
+
+    expect(wrapper.find('[data-testid="plan-banner"]').classes()).toContain('plan-banner--read-only')
+    expect(wrapper.text()).toContain('This account is read-only')
+    expect(wrapper.find('[data-testid="plan-banner-support"]').attributes('href')).toBe('https://cadernia.example.com/support')
+  })
+
+  it('treats an expired trial and past_due as read-only', () => {
+    expect(mount(PlanBanner, { props: { plan: plan({ status: 'trial', trial_days_left: 0, read_only: true }) } }).text()).toContain('read-only')
+    expect(mount(PlanBanner, { props: { plan: plan({ status: 'past_due', read_only: true }) } }).text()).toContain('read-only')
+  })
+})

--- a/frontend/src/components/BrandFooter.vue
+++ b/frontend/src/components/BrandFooter.vue
@@ -1,0 +1,56 @@
+<template>
+  <nav v-if="links.length > 0 || brand.powered_by" class="brand-footer" data-testid="brand-footer" :aria-label="t('brand.footerLabel')">
+    <a
+      v-for="link in links"
+      :key="link.key"
+      :href="link.href"
+      target="_blank"
+      rel="noopener"
+      class="brand-footer-link"
+      :data-testid="`brand-link-${link.key}`"
+    >
+      {{ t(`brand.${link.key}`) }}
+    </a>
+    <a
+      v-if="brand.powered_by"
+      :href="brand.powered_by_url"
+      target="_blank"
+      rel="noopener"
+      class="brand-footer-link brand-powered-by"
+      data-testid="brand-powered-by"
+    >
+      {{ t('brand.poweredBy') }}
+    </a>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { brand, brandLinks } from '../services/brand'
+
+const { t } = useI18n()
+const links = computed(() => brandLinks(brand))
+</script>
+
+<style scoped>
+.brand-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-1) var(--space-3);
+  padding: 0 var(--space-4) var(--space-2);
+  font-size: 0.75rem;
+}
+
+.brand-footer-link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.brand-footer-link:hover,
+.brand-footer-link:focus-visible {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+</style>

--- a/frontend/src/components/BrandMark.vue
+++ b/frontend/src/components/BrandMark.vue
@@ -1,0 +1,46 @@
+<template>
+  <img
+    v-if="brand.logo_url"
+    :src="brand.logo_url"
+    :alt="brand.name"
+    class="brand-logo"
+    :width="size"
+    :height="size"
+    data-testid="brand-logo"
+  />
+  <svg
+    v-else
+    class="brand-icon"
+    viewBox="0 0 24 24"
+    :width="size"
+    :height="size"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    aria-hidden="true"
+    data-testid="brand-mark"
+  >
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+    <polyline points="14 2 14 8 20 8"></polyline>
+    <line x1="16" y1="13" x2="8" y2="13"></line>
+    <line x1="16" y1="17" x2="8" y2="17"></line>
+    <polyline points="10 9 9 9 8 9"></polyline>
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { brand } from '../services/brand'
+
+withDefaults(defineProps<{ size?: number }>(), { size: 22 })
+</script>
+
+<style scoped>
+.brand-logo {
+  display: block;
+  object-fit: contain;
+}
+
+.brand-icon {
+  color: var(--color-action);
+}
+</style>

--- a/frontend/src/components/LoginModal.vue
+++ b/frontend/src/components/LoginModal.vue
@@ -3,14 +3,8 @@
     <div class="login-card">
       <div class="login-header">
         <div class="login-brand">
-          <svg class="brand-icon" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-            <polyline points="14 2 14 8 20 8"></polyline>
-            <line x1="16" y1="13" x2="8" y2="13"></line>
-            <line x1="16" y1="17" x2="8" y2="17"></line>
-            <polyline points="10 9 9 9 8 9"></polyline>
-          </svg>
-          <h2>{{ t('login.heading') }}</h2>
+          <BrandMark :size="28" />
+          <h2 data-testid="login-heading">{{ t('login.heading', { name: brand.name }) }}</h2>
         </div>
         <p class="login-subtitle">{{ t('login.subtitle') }}</p>
       </div>
@@ -63,6 +57,7 @@
           <span v-else>{{ t('login.signIn') }}</span>
         </button>
       </form>
+      <BrandFooter />
     </div>
   </div>
 </template>
@@ -71,6 +66,9 @@
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { login, getAuthConfig } from '../services/api'
+import { brand, setBrand } from '../services/brand'
+import BrandMark from './BrandMark.vue'
+import BrandFooter from './BrandFooter.vue'
 import type { AuthConfig } from '../services/api'
 import type { AuthUser } from '../services/types'
 
@@ -99,6 +97,7 @@ watch(
       const config = await getAuthConfig()
       ssoLoginUrl.value = config.sso_login_url
       authProvider.value = config.provider
+      if (config.brand) setBrand(config.brand)
     } catch (err) {
       console.error('Failed to load auth config:', err)
     }

--- a/frontend/src/components/PlanBanner.vue
+++ b/frontend/src/components/PlanBanner.vue
@@ -1,0 +1,69 @@
+<template>
+  <div
+    v-if="message"
+    class="plan-banner"
+    :class="{ 'plan-banner--read-only': readOnly }"
+    role="status"
+    data-testid="plan-banner"
+  >
+    <span>{{ message }}</span>
+    <a
+      v-if="readOnly && brand.support_url"
+      :href="brand.support_url"
+      target="_blank"
+      rel="noopener"
+      class="plan-banner-link"
+      data-testid="plan-banner-support"
+    >
+      {{ t('brand.support') }}
+    </a>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { brand } from '../services/brand'
+import type { TenantPlan } from '../services/types'
+
+const { t } = useI18n()
+
+const props = defineProps<{ plan?: TenantPlan | null }>()
+
+const readOnly = computed(() => !!props.plan && props.plan.status !== 'self_hosted' && props.plan.read_only)
+
+const message = computed<string | null>(() => {
+  const plan = props.plan
+  if (!plan || plan.status === 'self_hosted') return null
+  if (plan.read_only) return t('plan.readOnly')
+  if (plan.status === 'trial' && plan.trial_days_left !== null) {
+    return plan.trial_days_left <= 1 ? t('plan.trialEndsToday') : t('plan.trialEndsIn', { days: plan.trial_days_left })
+  }
+  return null
+})
+</script>
+
+<style scoped>
+.plan-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-4);
+  font-size: 0.8125rem;
+  color: var(--color-warning-fg);
+  background: var(--color-warning-bg);
+  border-bottom: 1px solid var(--color-warning-border);
+}
+
+.plan-banner--read-only {
+  color: var(--color-text);
+  background: var(--color-bg-surface);
+  border-bottom-color: var(--color-status-danger);
+}
+
+.plan-banner-link {
+  color: inherit;
+  text-decoration: underline;
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -19,14 +19,8 @@
     <!-- Header -->
     <div class="sidebar-header">
       <div class="brand">
-        <svg class="brand-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-          <polyline points="14 2 14 8 20 8"></polyline>
-          <line x1="16" y1="13" x2="8" y2="13"></line>
-          <line x1="16" y1="17" x2="8" y2="17"></line>
-          <polyline points="10 9 9 9 8 9"></polyline>
-        </svg>
-        <span class="brand-title">Jotter</span>
+        <BrandMark :size="22" />
+        <span class="brand-title" data-testid="brand-title">{{ brand.name }}</span>
       </div>
       <TenantSwitcher
         v-if="(props.tenants ?? []).length > 1"
@@ -500,6 +494,7 @@
         (backend: {{ props.backendVersion }})
       </span>
     </div>
+    <BrandFooter />
   </aside>
 </template>
 
@@ -515,6 +510,9 @@ import ThemeToggle from './ThemeToggle.vue'
 import LocaleToggle from './LocaleToggle.vue'
 import WorkspaceSwitcher from './WorkspaceSwitcher.vue'
 import TenantSwitcher from './TenantSwitcher.vue'
+import BrandMark from './BrandMark.vue'
+import BrandFooter from './BrandFooter.vue'
+import { brand } from '../services/brand'
 import { moveNote, reorderNoteTree } from '../services/api'
 import { createNoteTreeSortable, type NoteTreeSortableHandle } from '../composables/useNoteTreeSortable'
 import { useCollapsiblePanel } from '../composables/useCollapsiblePanel'
@@ -937,10 +935,6 @@ function handleImportSubmit() {
   color: var(--color-text);
   font-weight: 700;
   font-size: 1.125rem;
-}
-
-.brand-icon {
-  color: var(--color-action);
 }
 
 .header-actions {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,9 +1,21 @@
 export default {
+  brand: {
+    footerLabel: 'About this service',
+    terms: 'Terms',
+    privacy: 'Privacy',
+    support: 'Support',
+    poweredBy: 'Powered by Jotter',
+  },
+  plan: {
+    trialEndsIn: 'Trial ends in {days} days',
+    trialEndsToday: 'Trial ends today',
+    readOnly: 'This account is read-only. You can keep reading, searching, and exporting, but changes are paused.',
+  },
   nav: {
     settings: 'Settings',
   },
   login: {
-    heading: 'Jotter Sign In',
+    heading: '{name} Sign In',
     subtitle: 'Enter your administrator credentials to access your notes vault.',
     ssoButton: 'Sign in with GrandpaSSOn',
     ssoGenericButton: 'Sign in with SSO',

--- a/frontend/src/i18n/locales/pt-BR.ts
+++ b/frontend/src/i18n/locales/pt-BR.ts
@@ -1,9 +1,21 @@
 export default {
+  brand: {
+    footerLabel: 'Sobre este serviço',
+    terms: 'Termos',
+    privacy: 'Privacidade',
+    support: 'Suporte',
+    poweredBy: 'Powered by Jotter',
+  },
+  plan: {
+    trialEndsIn: 'O período de teste termina em {days} dias',
+    trialEndsToday: 'O período de teste termina hoje',
+    readOnly: 'Esta conta está somente leitura. Você pode continuar lendo, buscando e exportando, mas as alterações estão pausadas.',
+  },
   nav: {
     settings: 'Configurações',
   },
   login: {
-    heading: 'Entrar no Jotter',
+    heading: 'Entrar no {name}',
     subtitle: 'Digite suas credenciais de administrador para acessar seu cofre de notas.',
     ssoButton: 'Entrar com GrandpaSSOn',
     ssoGenericButton: 'Entrar com SSO',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,3 +1,4 @@
+import type { BrandConfig } from './brand'
 import axios from 'axios'
 import type { Workspace, Tenant, NoteMeta, TrashNoteMeta, NoteDetail, SearchResult, AuthUser, AttachmentItem, SearchFilters, NoteRevisionMeta, NoteRevisionDetail, NoteRevisionComparison, NoteProperty, NoteComment, AuditLogEntry, LinkReport, NotificationItem, CollectionPage, UnlinkedMention, OutgoingLink, FolderPosition, SortItem, Board, NoteChecklistItem, NoteActivityEntry, NoteAccessPayload, NoteAclEntry, WorkspaceGroup, NoteShareState, WorkspaceAnalytics, NoteReviewSummary } from './types'
 
@@ -73,6 +74,7 @@ export interface AuthConfig {
   sso_login_url: string | null
   version: string | null
   external_embed_domains?: string[]
+  brand?: BrandConfig
 }
 
 export async function getAuthConfig(): Promise<AuthConfig> {

--- a/frontend/src/services/brand.ts
+++ b/frontend/src/services/brand.ts
@@ -1,0 +1,49 @@
+import { reactive, readonly } from 'vue'
+
+/**
+ * Operator branding delivered by GET /api/auth/config. Defaults reproduce the
+ * stock Jotter identity so a self-hosted install renders exactly as before the
+ * config request resolves (or if it fails).
+ */
+export interface BrandConfig {
+  name: string
+  logo_url: string | null
+  support_url: string | null
+  terms_url: string | null
+  privacy_url: string | null
+  powered_by: boolean
+  powered_by_url: string
+}
+
+export const DEFAULT_BRAND: BrandConfig = {
+  name: 'Jotter',
+  logo_url: null,
+  support_url: null,
+  terms_url: null,
+  privacy_url: null,
+  powered_by: true,
+  powered_by_url: 'https://github.com/suporterfid/jotter',
+}
+
+const state = reactive<BrandConfig>({ ...DEFAULT_BRAND })
+
+export const brand = readonly(state)
+
+export function setBrand(config: Partial<BrandConfig> | null | undefined): void {
+  Object.assign(state, DEFAULT_BRAND, config ?? {})
+  if (!state.name || !state.name.trim()) state.name = DEFAULT_BRAND.name
+}
+
+export function resetBrand(): void {
+  setBrand(null)
+}
+
+/** Links shown in footers: only the configured ones, in a stable order. */
+export function brandLinks(config: BrandConfig = state): Array<{ key: 'terms' | 'privacy' | 'support'; href: string }> {
+  const entries: Array<{ key: 'terms' | 'privacy' | 'support'; href: string | null }> = [
+    { key: 'terms', href: config.terms_url },
+    { key: 'privacy', href: config.privacy_url },
+    { key: 'support', href: config.support_url },
+  ]
+  return entries.filter((entry): entry is { key: 'terms' | 'privacy' | 'support'; href: string } => !!entry.href)
+}

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -5,10 +5,22 @@ export interface Workspace {
   name: string
 }
 
+export type PlanStatus = 'self_hosted' | 'trial' | 'active' | 'past_due' | 'read_only'
+
+export interface TenantPlan {
+  status: PlanStatus
+  name: string | null
+  seats: number | null
+  trial_ends_at: string | null
+  trial_days_left: number | null
+  read_only: boolean
+}
+
 export interface Tenant {
   id: number
   slug: string
   name: string
+  plan?: TenantPlan
 }
 
 export interface NoteMeta {

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -49,4 +49,6 @@ return [
     'notification_email_unsubscribe' => 'Change or unsubscribe from these notifications',
     'notification_email_preferences' => 'Manage notification preferences',
     'notification_type_unsupported' => 'Unsupported notification type.',
+    'plan_read_only' => 'This workspace is read-only: the plan for this account does not allow changes right now. Reading, search, and exports remain available.',
+    'plan_seat_limit_reached' => 'Seat limit reached: this plan allows :seats member(s). Remove a member or upgrade the plan.',
 ];

--- a/lang/pt-BR/messages.php
+++ b/lang/pt-BR/messages.php
@@ -49,4 +49,6 @@ return [
     'notification_email_unsubscribe' => 'Alterar ou cancelar estas notificações',
     'notification_email_preferences' => 'Gerenciar preferências de notificações',
     'notification_type_unsupported' => 'Tipo de notificação não suportado.',
+    'plan_read_only' => 'Este espaço está somente leitura: o plano desta conta não permite alterações no momento. Leitura, busca e exportações continuam disponíveis.',
+    'plan_seat_limit_reached' => 'Limite de assentos atingido: este plano permite :seats membro(s). Remova um membro ou atualize o plano.',
 ];

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -15,6 +15,12 @@
     $entry = $manifest['src/main.ts']
         ?? $manifest['index.html']
         ?? null;
+
+    // Operator branding (JOTTER_BRAND_*); defaults reproduce the stock Jotter shell.
+    $brand = \App\Support\Branding::configured();
+    $brandDescription = $brand->name === 'Jotter'
+        ? 'A fast, local-first Markdown knowledge base and note-taking application.'
+        : $brand->name.' — Markdown knowledge base and notes.';
 @endphp
 <!doctype html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
@@ -37,18 +43,18 @@
         if (themeColor) themeColor.setAttribute('content', theme === 'dark' ? '#191919' : '#FFFFFF');
       })();
     </script>
-    <meta name="description" content="A fast, local-first Markdown knowledge base and note-taking application.">
+    <meta name="description" content="{{ $brandDescription }}">
 
-    <title>Jotter</title>
+    <title>{{ $brand->name }}</title>
 
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-    <meta property="og:title" content="Jotter">
-    <meta property="og:description" content="A fast, local-first Markdown knowledge base and note-taking application.">
-    <meta property="og:image" content="{{ url('social-card.png') }}">
+    <meta property="og:title" content="{{ $brand->name }}">
+    <meta property="og:description" content="{{ $brandDescription }}">
+    <meta property="og:image" content="{{ $brand->logoUrl ?? url('social-card.png') }}">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">
 

--- a/resources/views/publish/page.blade.php
+++ b/resources/views/publish/page.blade.php
@@ -1,3 +1,12 @@
+@php
+    $brand = \App\Support\Branding::configured();
+    $brandLinks = array_filter([
+        'terms' => $brand->termsUrl,
+        'privacy' => $brand->privacyUrl,
+        'support' => $brand->supportUrl,
+    ]);
+    $brandLinkLabels = $brandLinkLabels ?? ['terms' => 'Terms', 'privacy' => 'Privacy', 'support' => 'Support'];
+@endphp
 <!DOCTYPE html>
 <html lang="{{ $locale }}" dir="{{ $direction }}">
 <head>
@@ -26,5 +35,15 @@
             {!! $html !!}
         </article>
     </main>
+    @if ($brandLinks !== [] || $brand->poweredBy)
+    <footer class="publish-footer" data-brand="{{ $brand->name }}">
+        @foreach ($brandLinks as $key => $href)
+            <a href="{{ $href }}" rel="noopener">{{ $brandLinkLabels[$key] ?? ucfirst($key) }}</a>
+        @endforeach
+        @if ($brand->poweredBy)
+            <a class="publish-powered-by" href="{{ \App\Support\Branding::REPOSITORY_URL }}" rel="noopener">Powered by Jotter</a>
+        @endif
+    </footer>
+    @endif
 </body>
 </html>

--- a/resources/views/publish/publish.css
+++ b/resources/views/publish/publish.css
@@ -29,3 +29,5 @@ pre code { padding: 0; background: transparent; }
 .publish-index { padding-inline-start: 1.25rem; }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 1ms !important; transition-duration: 1ms !important; scroll-behavior: auto !important; } }
 @media (forced-colors: active) { :focus-visible { outline-color: CanvasText; } }
+.publish-footer { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; max-inline-size: 1200px; margin-inline: auto; margin-block-start: 3rem; padding-block-start: 1rem; border-block-start: 1px solid var(--color-border-default); color: var(--color-text-secondary); font-size: .875rem; }
+.publish-footer a { color: var(--color-text-secondary); }

--- a/routes/console.php
+++ b/routes/console.php
@@ -42,3 +42,7 @@ Schedule::command('vault:reindex', ['--all'])->hourly()->withoutOverlapping(55);
 Schedule::command('vault:purge-trash')->dailyAt('02:00')->withoutOverlapping(60);
 Schedule::command('vault:prune-revisions', ['--days=30'])->dailyAt('02:15')->withoutOverlapping(60);
 Schedule::command('audit:prune', ['--days=90'])->dailyAt('02:30')->withoutOverlapping(60);
+
+// Hosted mode only: trials past their deadline become read_only (audited). A
+// self-hosted installation has no trial tenants, so this is a no-op there.
+Schedule::command('tenant:expire-trials')->dailyAt('03:00')->withoutOverlapping(60);

--- a/tests/Feature/BrandingTest.php
+++ b/tests/Feature/BrandingTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class BrandingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_auth_config_exposes_default_branding(): void
+    {
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJsonPath('data.brand', [
+                'name' => config('app.name'),
+                'logo_url' => null,
+                'support_url' => null,
+                'terms_url' => null,
+                'privacy_url' => null,
+                'powered_by' => true,
+                'powered_by_url' => 'https://github.com/suporterfid/jotter',
+            ]);
+    }
+
+    public function test_auth_config_exposes_operator_branding(): void
+    {
+        config(['jotter.brand' => [
+            'name' => 'Cadernia',
+            'logo_url' => 'https://cdn.example.com/cadernia.svg',
+            'support_url' => 'https://cadernia.example.com/support',
+            'terms_url' => 'https://cadernia.example.com/terms',
+            'privacy_url' => 'https://cadernia.example.com/privacy',
+            'powered_by' => false,
+        ]]);
+
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJsonPath('data.brand.name', 'Cadernia')
+            ->assertJsonPath('data.brand.logo_url', 'https://cdn.example.com/cadernia.svg')
+            ->assertJsonPath('data.brand.terms_url', 'https://cadernia.example.com/terms')
+            ->assertJsonPath('data.brand.privacy_url', 'https://cadernia.example.com/privacy')
+            ->assertJsonPath('data.brand.support_url', 'https://cadernia.example.com/support')
+            ->assertJsonPath('data.brand.powered_by', false);
+    }
+
+    public function test_empty_brand_values_fall_back_to_defaults(): void
+    {
+        config(['jotter.brand' => ['name' => '   ', 'logo_url' => '', 'powered_by' => true]]);
+
+        $this->getJson('/api/auth/config')
+            ->assertOk()
+            ->assertJsonPath('data.brand.name', config('app.name'))
+            ->assertJsonPath('data.brand.logo_url', null);
+    }
+
+    public function test_app_shell_uses_the_brand_name_in_title_and_open_graph(): void
+    {
+        config(['jotter.brand' => ['name' => 'Cadernia', 'logo_url' => 'https://cdn.example.com/c.png']]);
+
+        $html = $this->get('/')->assertOk()->getContent();
+
+        $this->assertStringContainsString('<title>Cadernia</title>', $html);
+        $this->assertStringContainsString('<meta property="og:title" content="Cadernia">', $html);
+        $this->assertStringContainsString('<meta property="og:image" content="https://cdn.example.com/c.png">', $html);
+    }
+
+    public function test_app_shell_defaults_to_jotter(): void
+    {
+        $html = $this->get('/')->assertOk()->getContent();
+
+        $this->assertStringContainsString('<title>'.config('app.name').'</title>', $html);
+        $this->assertStringContainsString('social-card.png', $html);
+    }
+
+    public function test_published_pages_carry_brand_links_and_powered_by(): void
+    {
+        config(['jotter.brand' => [
+            'name' => 'Cadernia',
+            'terms_url' => 'https://cadernia.example.com/terms',
+            'privacy_url' => 'https://cadernia.example.com/privacy',
+            'support_url' => null,
+            'powered_by' => true,
+        ]]);
+
+        $html = view('publish.page', [
+            'locale' => 'en',
+            'direction' => 'ltr',
+            'assetPrefix' => '',
+            'title' => 'Hello',
+            'html' => '<p>Body</p>',
+            'themeLabels' => ['preference' => 'Theme', 'system' => 'System', 'light' => 'Light', 'dark' => 'Dark'],
+        ])->render();
+
+        $this->assertStringContainsString('class="publish-footer" data-brand="Cadernia"', $html);
+        $this->assertStringContainsString('href="https://cadernia.example.com/terms"', $html);
+        $this->assertStringContainsString('href="https://cadernia.example.com/privacy"', $html);
+        $this->assertStringNotContainsString('>Support<', $html);
+        $this->assertStringContainsString('Powered by Jotter', $html);
+    }
+
+    public function test_published_pages_omit_the_footer_when_nothing_is_configured_and_powered_by_is_off(): void
+    {
+        config(['jotter.brand' => ['powered_by' => false]]);
+
+        $html = view('publish.page', [
+            'locale' => 'en',
+            'direction' => 'ltr',
+            'assetPrefix' => '',
+            'title' => 'Hello',
+            'html' => '<p>Body</p>',
+            'themeLabels' => ['preference' => 'Theme', 'system' => 'System', 'light' => 'Light', 'dark' => 'Dark'],
+        ])->render();
+
+        $this->assertStringNotContainsString('publish-footer', $html);
+    }
+}

--- a/tests/Feature/SchedulerRegistrationTest.php
+++ b/tests/Feature/SchedulerRegistrationTest.php
@@ -42,6 +42,7 @@ final class SchedulerRegistrationTest extends TestCase
             'vault:purge-trash',
             'vault:prune-revisions',
             'audit:prune',
+            'tenant:expire-trials',
             'jotter:scheduler-heartbeat',
         ] as $expected) {
             $this->assertStringContainsString($expected, $commands, "{$expected} is not scheduled");

--- a/tests/Feature/TenantPlanCommandsTest.php
+++ b/tests/Feature/TenantPlanCommandsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\Tenant;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class TenantPlanCommandsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tenant_plan_starts_a_trial_and_records_an_audit_row(): void
+    {
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+
+        $this->artisan('tenant:plan acme --trial-days=14 --seats=5 --name=Starter')
+            ->expectsOutputToContain('Tenant acme (Acme) updated.')
+            ->assertSuccessful();
+
+        $tenant->refresh();
+        $this->assertSame('trial', $tenant->plan_status);
+        $this->assertSame(5, $tenant->plan_seats);
+        $this->assertSame('Starter', $tenant->plan_name);
+        $this->assertTrue($tenant->trial_ends_at->between(now()->addDays(13), now()->addDays(15)));
+        $this->assertSame(1, AuditLog::query()->where('event', 'tenant.plan_changed')->where('tenant_id', $tenant->id)->count());
+    }
+
+    public function test_tenant_plan_moves_through_every_status_and_clears_the_trial_deadline(): void
+    {
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme', 'plan_status' => 'trial', 'trial_ends_at' => now()->addDay()]);
+
+        foreach (['active', 'past_due', 'read_only', 'self_hosted'] as $status) {
+            $this->artisan("tenant:plan acme --status={$status}")->assertSuccessful();
+            $this->assertSame($status, $tenant->fresh()->plan_status);
+            $this->assertNull($tenant->fresh()->trial_ends_at);
+        }
+
+        $this->artisan('tenant:plan acme --status=trial --trial-days=3')->assertSuccessful();
+        $this->assertSame('trial', $tenant->fresh()->plan_status);
+        $this->assertNotNull($tenant->fresh()->trial_ends_at);
+    }
+
+    public function test_tenant_plan_rejects_invalid_input(): void
+    {
+        Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+
+        $this->artisan('tenant:plan acme --status=platinum')->assertFailed();
+        $this->artisan('tenant:plan acme --trial-days=0')->assertFailed();
+        $this->artisan('tenant:plan acme')->assertFailed();
+        $this->artisan('tenant:plan missing --status=active')->assertFailed();
+    }
+
+    public function test_tenant_plan_and_tenant_show_emit_json(): void
+    {
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+        $tenant->workspaces()->create(['slug' => 'docs', 'name' => 'Docs', 'vault_path' => storage_path('app/vaults/acme-docs')]);
+
+        // The JSON report is one write, so decode the captured output instead of
+        // chaining expectsOutputToContain (which expects separate writes).
+        $this->assertSame(0, Artisan::call('tenant:plan', ['slug' => 'acme', '--status' => 'active', '--seats' => '3', '--json' => true]));
+        $plan = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('acme', $plan['slug']);
+        $this->assertSame('active', $plan['plan']['status']);
+        $this->assertSame(3, $plan['plan']['seats']);
+        $this->assertFalse($plan['plan']['read_only']);
+
+        $this->assertSame(0, Artisan::call('tenant:show', ['slug' => 'acme', '--json' => true]));
+        $show = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('acme', $show['slug']);
+        $this->assertSame(0, $show['plan']['seats_used']);
+        $this->assertSame(3, $show['plan']['seats']);
+        $this->assertSame('docs', $show['workspaces'][0]['slug']);
+
+        $this->artisan('tenant:show acme')
+            ->expectsOutputToContain('Tenant acme — Acme')
+            ->expectsOutputToContain('active')
+            ->assertSuccessful();
+
+        $this->artisan('tenant:show missing')->assertFailed();
+    }
+
+    public function test_expire_trials_moves_only_overdue_trials_to_read_only(): void
+    {
+        $expired = Tenant::create(['slug' => 'expired', 'name' => 'Expired', 'plan_status' => 'trial', 'trial_ends_at' => now()->subMinute()]);
+        $running = Tenant::create(['slug' => 'running', 'name' => 'Running', 'plan_status' => 'trial', 'trial_ends_at' => now()->addDay()]);
+        $active = Tenant::create(['slug' => 'active', 'name' => 'Active', 'plan_status' => 'active']);
+        $selfHosted = Tenant::create(['slug' => 'self', 'name' => 'Self']);
+
+        $this->artisan('tenant:expire-trials')
+            ->expectsOutputToContain('Expired 1 trial(s): expired.')
+            ->assertSuccessful();
+
+        $this->assertSame('read_only', $expired->fresh()->plan_status);
+        $this->assertSame('trial', $running->fresh()->plan_status);
+        $this->assertSame('active', $active->fresh()->plan_status);
+        $this->assertSame('self_hosted', $selfHosted->fresh()->plan_status);
+        $this->assertSame(1, AuditLog::query()->where('event', 'tenant.trial_expired')->where('tenant_id', $expired->id)->count());
+
+        // Idempotent: a second run finds nothing.
+        $this->artisan('tenant:expire-trials')->expectsOutputToContain('Expired 0 trial(s).')->assertSuccessful();
+    }
+}

--- a/tests/Feature/TenantPlanEnforcementTest.php
+++ b/tests/Feature/TenantPlanEnforcementTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\AuditLog;
+use App\Models\Membership;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Hosted-mode plan gate. `self_hosted` (the default) must change nothing; an
+ * expired trial, past_due, or read_only tenant keeps reading, searching,
+ * exporting, and logging in while writes answer 402.
+ */
+final class TenantPlanEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['is_admin' => true]);
+        $this->actingAs($this->admin);
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array{0: Tenant, 1: Workspace, 2: Note}
+     */
+    private function fixture(array $plan = []): array
+    {
+        $tenant = Tenant::create(array_merge(['slug' => 'plan-'.uniqid(), 'name' => 'Plan'], $plan));
+        $vaultPath = storage_path('app/vaults/plan_'.uniqid());
+        @mkdir($vaultPath, 0755, true);
+        $workspace = Workspace::create([
+            'tenant_id' => $tenant->id,
+            'slug' => 'plan-'.uniqid(),
+            'name' => 'Plan workspace',
+            'vault_path' => $vaultPath,
+        ]);
+        $note = app(VaultStorage::class)->write($workspace, 'readme.md', "# Readme\n");
+
+        return [$tenant, $workspace, $note];
+    }
+
+    public function test_default_tenant_is_self_hosted_and_writes_are_unaffected(): void
+    {
+        [$tenant, $workspace, $note] = $this->fixture();
+
+        $this->assertSame('self_hosted', $tenant->fresh()->plan_status);
+        $this->putJson("/api/workspaces/{$workspace->id}/notes/{$note->id}", ['content' => '# Changed'])->assertOk();
+        $this->getJson('/api/tenants')->assertOk()->assertJsonPath('data.0.plan.status', 'self_hosted')->assertJsonPath('data.0.plan.read_only', false);
+        $this->assertSame(0, AuditLog::query()->where('event', 'plan.write_blocked')->count());
+    }
+
+    public function test_active_trial_allows_writes_and_reports_days_left(): void
+    {
+        [, $workspace, $note] = $this->fixture(['plan_status' => 'trial', 'trial_ends_at' => now()->addDays(7)->addMinute()]);
+
+        $this->putJson("/api/workspaces/{$workspace->id}/notes/{$note->id}", ['content' => '# Trial'])->assertOk();
+
+        $plan = $this->getJson('/api/tenants')->assertOk()->json('data.0.plan');
+        $this->assertSame('trial', $plan['status']);
+        $this->assertSame(8, $plan['trial_days_left']);
+        $this->assertFalse($plan['read_only']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function blockedPlans(): iterable
+    {
+        yield 'expired trial' => [['plan_status' => 'trial', 'trial_ends_at' => '2026-01-01 00:00:00']];
+        yield 'read_only' => [['plan_status' => 'read_only']];
+        yield 'past_due' => [['plan_status' => 'past_due']];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     */
+    #[DataProvider('blockedPlans')]
+    public function test_blocked_plan_rejects_writes_with_402_but_keeps_reads(array $plan): void
+    {
+        [$tenant, $workspace, $note] = $this->fixture($plan);
+
+        // API writes behind workspace.write
+        $this->putJson("/api/workspaces/{$workspace->id}/notes/{$note->id}", ['content' => '# Nope'])
+            ->assertStatus(402)
+            ->assertJsonPath('plan_status', $plan['plan_status'])
+            ->assertJsonPath('message', __('messages.plan_read_only'));
+        $this->postJson("/api/workspaces/{$workspace->id}/notes", ['path' => 'new.md', 'content' => '# New'])->assertStatus(402);
+        $this->deleteJson("/api/workspaces/{$workspace->id}/notes/{$note->id}")->assertStatus(402);
+
+        // Import (workspace.write) and WebDAV write methods
+        $this->postJson("/api/workspaces/{$workspace->id}/import")->assertStatus(402);
+        $this->call('PUT', "/api/webdav/{$workspace->id}/blocked.md", [], [], [], [], "# Blocked\n")->assertStatus(402);
+        $this->call('MKCOL', "/api/webdav/{$workspace->id}/folder")->assertStatus(402);
+        $this->call('DELETE', "/api/webdav/{$workspace->id}/readme.md")->assertStatus(402);
+
+        // Reads, search, export, WebDAV reads, and the plan payload stay available
+        $this->getJson("/api/workspaces/{$workspace->id}/notes")->assertOk();
+        $this->getJson("/api/workspaces/{$workspace->id}/notes/{$note->id}")->assertOk();
+        $this->getJson("/api/workspaces/{$workspace->id}/search?q=Readme")->assertOk();
+        $this->get("/api/workspaces/{$workspace->id}/export")->assertOk();
+        $this->postJson("/api/workspaces/{$workspace->id}/pdf-exports")->assertStatus(202);
+        $this->call('PROPFIND', "/api/webdav/{$workspace->id}/readme.md")->assertStatus(207);
+        $this->getJson('/api/tenants')->assertOk()->assertJsonPath('data.0.plan.read_only', true);
+        $this->getJson('/api/auth/me')->assertOk();
+
+        $this->assertSame("# Readme\n", file_get_contents($workspace->vault_path.'/readme.md'));
+        $this->assertGreaterThanOrEqual(1, AuditLog::query()->where('event', 'plan.write_blocked')->where('tenant_id', $tenant->id)->count());
+    }
+
+    public function test_login_still_works_for_a_read_only_tenant(): void
+    {
+        $this->fixture(['plan_status' => 'read_only']);
+        $user = User::factory()->create(['password' => bcrypt('password12345')]);
+
+        $this->postJson('/api/auth/login', ['email' => $user->email, 'password' => 'password12345'])->assertOk();
+    }
+
+    public function test_seat_limit_blocks_new_members_but_not_existing_ones(): void
+    {
+        [$tenant, $workspace] = $this->fixture(['plan_status' => 'active', 'plan_seats' => 2]);
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => 'u1', 'role' => 'owner']);
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => 'u2', 'role' => 'editor']);
+
+        $this->postJson("/api/admin/workspaces/{$workspace->id}/members", ['subject_id' => 'u3', 'role' => 'viewer'])
+            ->assertStatus(402)
+            ->assertJsonPath('plan_seats', 2)
+            ->assertJsonPath('message', __('messages.plan_seat_limit_reached', ['seats' => 2]));
+
+        // Changing the role of an existing subject does not consume a seat.
+        $this->postJson("/api/admin/workspaces/{$workspace->id}/members", ['subject_id' => 'u2', 'role' => 'viewer'])->assertCreated();
+
+        $this->assertSame(1, AuditLog::query()->where('event', 'plan.seat_limit_reached')->count());
+    }
+
+    public function test_seat_limit_is_ignored_for_self_hosted_tenants(): void
+    {
+        [$tenant, $workspace] = $this->fixture(['plan_seats' => 1]);
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => 'u1', 'role' => 'owner']);
+
+        $this->postJson("/api/admin/workspaces/{$workspace->id}/members", ['subject_id' => 'u2', 'role' => 'editor'])->assertCreated();
+    }
+}


### PR DESCRIPTION
## Summary

Jotter (MIT) will also be offered as the hosted service **Cadernia**. Nothing here is a fork: branding and plan state are configuration of the single engine, with defaults that leave a self-hosted installation unchanged, and **no payment code** (billing is external; the operator runs `tenant:plan`). Decision recorded in `docs/decisions.md` — "Single engine; hosting is configuration, not a fork".

### Part A — Branding
- `JOTTER_BRAND_NAME` (default `APP_NAME`), `JOTTER_BRAND_LOGO_URL` (empty = bundled mark), `JOTTER_BRAND_SUPPORT_URL`, `JOTTER_BRAND_TERMS_URL`, `JOTTER_BRAND_PRIVACY_URL`, `JOTTER_BRAND_POWERED_BY` (bool, default `true`) in `.env.example` and `config/jotter.php` (`brand`), resolved by `App\Support\Branding`.
- `GET /api/auth/config` → `data.brand`. SPA: tab title (`document.title`), sidebar header (`BrandMark` — logo URL or bundled SVG), login heading (`{name} Sign In` / `Entrar no {name}`), footer links terms/privacy/support and "Powered by Jotter" → repository (`BrandFooter`, in sidebar and login card). `app.blade.php`: `<title>`, `og:title/description/image`. `publish/page.blade.php`: footer with links + powered-by (omitted when nothing is configured and powered-by is off).
- Tests: `BrandingTest` (defaults, operator values, blank fallbacks, shell title/OG, published footer); Vitest `Brand.spec.ts` (sidebar header/footer, login). New components use semantic tokens only — `scripts/check-design-tokens.sh` reports no issue for them (its two failures are pre-existing on `main`: `NoteReviewPanel.vue:243`, `NotificationPreferences.vue:117`; noted in `BACKLOG.md`).

### Part B — Plan and trial
- Migration: `tenants.plan_status` enum (`self_hosted` default, `trial`, `active`, `past_due`, `read_only`), `trial_ends_at`, `plan_name`, `plan_seats`.
- `App\Domain\Plan\TenantPlan`: `self_hosted` changes nothing. Trial in term: `GET /api/tenants` carries `plan` (`trial_days_left`), SPA shows "Trial ends in N days" (en/pt-BR). Expired trial / `read_only` / `past_due`: writes behind `workspace.write`, WebDAV `PUT`/`MKCOL`/`DELETE`, and import answer **402** with `messages.plan_read_only` (en/pt-BR); reading, search, ZIP/JSON/PDF export, WebDAV reads, and login keep working. `plan_seats`: a membership for a new subject beyond the limit → 402 `messages.plan_seat_limit_reached`; existing subjects can change role. Audited as `plan.write_blocked` / `plan.seat_limit_reached`.
- Commands: `tenant:plan {slug} --status= --trial-days= --seats= --name= [--json]` (audit `tenant.plan_changed`; leaving trial clears the deadline; `--trial-days` implies `--status=trial`), `tenant:show {slug} [--json]`.
- Scheduler: `tenant:expire-trials` daily 03:00 via the single `schedule:run` cron → overdue trials become `read_only` with `tenant.trial_expired` audit rows. No queue worker. Registered in `routes/console.php`, listed in `docs/deployment.md`, asserted by `SchedulerRegistrationTest`.
- Tests: `TenantPlanEnforcementTest` (self-hosted unchanged; active trial; expired trial/read_only/past_due data provider covering API, import, WebDAV, reads, search, export, PDF, login; seat limit; seats ignored when self-hosted), `TenantPlanCommandsTest` (trial start, every status transition, invalid input, JSON, expiry idempotence); Vitest `PlanBanner.spec.ts` (en + pt-BR, read-only notice with support link).

### Docs
`docs/architecture.md` "Hosted mode", `docs/decisions.md`, `CHANGELOG.md`, `STATUS.md`, `BACKLOG.md` (follow-ups: gate does not cover group/ACL/review metadata writes by design; token-guard debt), `docs/deployment.md`.

### Test-hygiene note
`App.spec.ts` now stubs `NoteEditorWysiwyg`: the real Milkdown editor arms 3 s readiness timers that fired after the jsdom teardown under the larger suite (`ReferenceError: removeEventListener is not defined`, flaky). No App.spec assertion touches the WYSIWYG surface.

## Verification
- `./scripts/jt.sh test` — 398 PHP tests passed (1745 assertions); 77 Vitest files passed, no unhandled errors (`npm run build` type-checks in bootstrap).
- Dev smoke: `tenant:plan default --status=active --seats=3 --json` produced the expected payload; reset to `self_hosted` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
