### PR TITLE
Fix design-token guard: replace raw color fallbacks with semantic tokens

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,7 +33,7 @@ The roadmap's historical Phase 1 gaps are already delivered in this repository: 
 - **Plan gate coverage.** The 402 gate covers `workspace.write` routes, WebDAV `PUT`/`MKCOL`/`DELETE`, and import, per the issue's scope. Group, ACL, review-workflow, watch, and notification-state writes are metadata and remain allowed for read-only tenants; extend the gate if operators need a stricter freeze.
 - **Trial expiry job.** Delivered as `tenant:expire-trials` (daily). Remove the placeholder from the 2026-08-31 operations follow-ups above.
 - **Hosted-mode UX.** The SPA surfaces 402 responses through the existing error paths (message text from the API). A dedicated upgrade/contact call-to-action would need the operator's `JOTTER_BRAND_SUPPORT_URL` and is not built.
-- **Design-token guard debt.** `scripts/check-design-tokens.sh` fails on `main` for pre-existing raw color fallbacks in `NoteReviewPanel.vue:243` and `NotificationPreferences.vue:117`; new components in this branch are token-only.
+- ~~**Design-token guard debt.**~~ Fixed in `fix/design-token-guard`: `NoteReviewPanel.vue` and `NotificationPreferences.vue` now use `--color-status-danger` / `--color-border`; `scripts/check-design-tokens.sh` passes on `main`.
 
 ## Completed follow-up
 

--- a/frontend/src/components/NoteReviewPanel.vue
+++ b/frontend/src/components/NoteReviewPanel.vue
@@ -240,7 +240,7 @@ watch(() => props.review, (value) => {
 .note-review-stale,
 .note-review-error {
   margin: 0;
-  color: var(--color-danger, #b42318);
+  color: var(--color-status-danger);
   font-size: 0.8125rem;
 }
 

--- a/frontend/src/components/NotificationPreferences.vue
+++ b/frontend/src/components/NotificationPreferences.vue
@@ -114,7 +114,7 @@ async function handleUnsubscribeRequest(): Promise<void> {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.75rem;
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--color-border);
   border-radius: 0.6rem;
 }
 


### PR DESCRIPTION
## Summary

`scripts/check-design-tokens.sh` failed on `main` for two pre-existing raw color literals:

- `frontend/src/components/NoteReviewPanel.vue:243` — `var(--color-danger, #b42318)`: `--color-danger` does not exist, so the hex literal always applied. Now `var(--color-status-danger)`.
- `frontend/src/components/NotificationPreferences.vue:117` — `var(--border-color, rgba(255, 255, 255, 0.12))`: `--border-color` does not exist either. Now `var(--color-border)`.

Both tokens exist in `frontend/src/styles/tokens.css` for light and dark themes, so the elements now follow the theme instead of a fixed color. `BACKLOG.md` follow-up closed.

## Verification

- `bash scripts/check-design-tokens.sh` → `✅ All Visual Identity CI Guards PASSED.`
- `./scripts/jt.sh npm test -- src/components/NoteReviewPanel.spec.ts src/NotificationPreferences.spec.ts` → 2 files, 5 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)