### PR TITLE
CLI provisioning + transactional e-mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,14 +105,20 @@ JOTTER_OIDC_POST_LOGIN_REDIRECT_URI=${APP_URL}
 JOTTER_OIDC_ALLOW_INSECURE_HTTP=false
 JOTTER_OIDC_TRUSTED_EMAIL_CLAIM=false
 
-# [PROD REQUIRED] A real transport (e.g. `smtp`) if notification e-mails should be
-# delivered; with `log` they are recorded as skipped and never sent.
+# [PROD REQUIRED] Transactional e-mail (welcome, password reset, notifications,
+# trial reminders). Sent synchronously from the request or the scheduler; no
+# queue worker is needed. Use `smtp` with any provider, for example:
+#   Resend:   MAIL_HOST=smtp.resend.com      MAIL_PORT=465 MAIL_SCHEME=smtps MAIL_USERNAME=resend         MAIL_PASSWORD=<API key>
+#   Postmark: MAIL_HOST=smtp.postmarkapp.com MAIL_PORT=587 MAIL_SCHEME=smtp  MAIL_USERNAME=<server token> MAIL_PASSWORD=<server token>
+# MAIL_SCHEME: `smtps` = implicit TLS (port 465); `smtp` = STARTTLS negotiated (587).
+# With `log` (the default) messages are written to storage/logs and never delivered.
 MAIL_MAILER=log
 MAIL_HOST=
 MAIL_PORT=
+MAIL_SCHEME=
 MAIL_USERNAME=
 MAIL_PASSWORD=
-MAIL_ENCRYPTION=
+# [PROD REQUIRED] A sender address verified with your provider's domain.
 MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME="${APP_NAME}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Jotter will be documented here. Decision records live in `docs/decisions.md`; security-audit findings live in `docs/security-audit-2026.md`; visual-identity rollout tracking lives in `docs/visual-identity.md`. Split from a single overloaded `BACKLOG.md` in #208.
 
+## v1 (post-v0) — 2026-08-31: CLI provisioning and transactional e-mail
+
+A new hosted customer is ready with one SSH command, and e-mail leaves for real (`feat/provisioning-and-mail`). Runbook: `docs/hosted-operations.md`.
+
+- **`tenant:provision`** — tenant, workspace with vault at `VAULT_BASE_PATH/<workspace-slug>`, owner admin with a random 20-character password (created through `platform:bootstrap-admin`), owner membership, trial plan (`--trial-days=14 --seats=5`), starter templates in `--locale`, welcome e-mail; prints URLs and the password once (`--json` too). Exit 2 when the tenant exists; existing users are reused without touching their password. The password is never logged or audited (`tenant.provisioned`).
+- **Transactional e-mail** — shared `x-mail-layout` shell with operator branding; `WelcomeEmail` (login, WebDAV, MCP guide, trial length), `PasswordResetEmail` (sent by `AdminUserController::resetPassword`, no password inside), `TrialReminderEmail` (3 days before) and `TrialEndedEmail` (on expiry), both driven by the daily `tenant:expire-trials` task and sent at most once per tenant (`trial_reminder_sent_at`, `trial_ended_notified_at`). Notification e-mails reuse the layout. i18n in `lang/{en,pt-BR}/emails.php`. Sending is synchronous; if `QUEUE_CONNECTION=database` is used, the scheduler drains it with `queue:work --stop-when-empty`. `.env.example` documents SMTP (Resend / Postmark).
+- **`tenant:export {slug} --to=`** — one ZIP with every vault file, the JSON backup (`WorkspaceJsonBackup`, now shared with the API export), and `tenant.json` (plan, workspaces, memberships, users) for LGPD portability; refuses the document root; audited as `tenant.exported`.
+- **Starter templates** — `resources/templates/{en,pt-BR}/_templates/` (ADR, meeting notes, daily, runbook, PRD) using TemplateEngine placeholders; `templates:pack` builds a ZIP the import endpoint accepts.
+- **Tests** — `TenantProvisionCommandTest`, `TenantExportCommandTest`, `TemplatePackTest`, `TransactionalEmailTest` (all with `Mail::fake()`).
+
 ## v1 (post-v0) — 2026-08-31: Branding by environment and hosted-mode plan/trial
 
 Jotter (MIT) is also offered as the hosted service "Cadernia". Both are the same engine: branding and plan state are configuration with self-hosting-neutral defaults (`docs/decisions.md`, "Single engine; hosting is configuration"). Zero change with defaults; no payment code (`feat/brand-and-plan`).

--- a/STATUS.md
+++ b/STATUS.md
@@ -117,6 +117,13 @@ This file previously ended at the 2026-08-05 formatting toolbar while 65 commits
 
 ---
 
+## 1.4 Delivered 2026-08-31 — CLI provisioning + transactional e-mail
+
+- **`tenant:provision`** one-shot customer setup (tenant, workspace/vault, owner admin via `platform:bootstrap-admin`, membership, trial, starter templates, welcome e-mail; password shown once, never logged). **`tenant:export`** full portable ZIP (vault + JSON backup + manifest). **`templates:pack`** importable starter templates (en/pt-BR).
+- **E-mail** — branded layout, welcome / password reset / trial reminder / trial ended mailables (en/pt-BR), SMTP documented for Resend/Postmark, synchronous sending, optional cron-driven `queue:work --stop-when-empty`. Runbook in `docs/hosted-operations.md`.
+
+---
+
 ## 2. Position against the product roadmap
 
 `docs/20260727-jotter-roadmap-ai-agent.md` ranks twelve near-term priorities. **Five of its top six already ship here** — search, nested folders, tags, backlinks, and attachments. Its gap analysis says otherwise because its baseline describes a different product (offline-first, Material You, realtime collaboration); spec §14.1 records this and §14.3 carries the authoritative delivered-state table.

--- a/app/Console/Commands/TemplatePackCommand.php
+++ b/app/Console/Commands/TemplatePackCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Provisioning\TemplatePack;
+use Illuminate\Console\Command;
+
+/**
+ * Builds the starter-template ZIP so it can be uploaded through the workspace
+ * import endpoint (or handed to a customer).
+ */
+final class TemplatePackCommand extends Command
+{
+    protected $signature = 'templates:pack {--locale=en : en or pt-BR} {--to= : Output ZIP path}';
+
+    protected $description = 'Write the starter template pack (_templates/*.md) as an importable ZIP.';
+
+    public function handle(TemplatePack $pack): int
+    {
+        $locale = TemplatePack::normalizeLocale((string) $this->option('locale'));
+        $to = (string) ($this->option('to') ?: storage_path('app/private/exports/templates-'.$locale.'.zip'));
+        $path = $pack->writeZip($locale, $to);
+
+        $this->info(sprintf('Template pack (%s, %d files) written to %s', $locale, count($pack->files($locale)), $path));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/TenantExpireTrialsCommand.php
+++ b/app/Console/Commands/TenantExpireTrialsCommand.php
@@ -3,23 +3,31 @@
 namespace App\Console\Commands;
 
 use App\Domain\Plan\TenantPlan;
+use App\Domain\Plan\TrialNotifier;
+use App\Models\Tenant;
 use Illuminate\Console\Command;
 
 /**
- * Scheduled daily. Moves trials past their deadline to read_only and writes one
- * audit row per tenant. Idempotent: already read-only tenants are not touched.
+ * Scheduled daily. Reminds owners REMINDER_DAYS before a trial ends, moves trials
+ * past their deadline to read_only (one audit row per tenant), and e-mails the
+ * owners once. Idempotent: markers on the tenant prevent repeats.
  */
 final class TenantExpireTrialsCommand extends Command
 {
     protected $signature = 'tenant:expire-trials';
 
-    protected $description = 'Move expired hosted-mode trials to read_only (scheduler task).';
+    protected $description = 'Remind about ending trials and move expired hosted-mode trials to read_only (scheduler task).';
 
-    public function handle(TenantPlan $tenantPlan): int
+    public function handle(TenantPlan $tenantPlan, TrialNotifier $notifier): int
     {
+        $reminded = $notifier->sendReminders();
         $expired = $tenantPlan->expireTrials();
+        $notified = $notifier->sendEnded($expired);
+        $slugs = array_map(static fn (Tenant $tenant): string => $tenant->slug, $expired);
 
-        $this->info(sprintf('Expired %d trial(s)%s.', count($expired), $expired === [] ? '' : ': '.implode(', ', $expired)));
+        $this->info(sprintf('Reminded %d trial(s)%s.', count($reminded), $reminded === [] ? '' : ': '.implode(', ', $reminded)));
+        $this->info(sprintf('Expired %d trial(s)%s.', count($slugs), $slugs === [] ? '' : ': '.implode(', ', $slugs)));
+        $this->info(sprintf('Notified %d trial(s) ended.', count($notified)));
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/TenantExportCommand.php
+++ b/app/Console/Commands/TenantExportCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Provisioning\TenantExporter;
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+
+final class TenantExportCommand extends Command
+{
+    protected $signature = 'tenant:export {slug : Tenant slug} {--to= : Output ZIP path (default: storage/app/private/exports/<slug>-<timestamp>.zip)} {--json : Emit JSON}';
+
+    protected $description = 'Export a whole tenant (vault files, JSON backups, manifest) as one portable ZIP.';
+
+    public function handle(TenantExporter $exporter): int
+    {
+        $tenant = Tenant::query()->where('slug', $this->argument('slug'))->first();
+        if ($tenant === null) {
+            $this->error(sprintf('Tenant [%s] was not found.', $this->argument('slug')));
+
+            return self::FAILURE;
+        }
+
+        $to = (string) ($this->option('to') ?: storage_path('app/private/exports/'.$tenant->slug.'-'.now()->format('Ymd-His').'.zip'));
+        if (str_starts_with($to, public_path())) {
+            $this->error('Refusing to write the export under the document root.');
+
+            return self::FAILURE;
+        }
+
+        $summary = $exporter->export($tenant, $to);
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode(['tenant' => $tenant->slug] + $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Exported tenant %s: %d workspace(s), %d file(s), %s.', $tenant->slug, $summary['workspaces'], $summary['files'], $this->humanBytes($summary['bytes'])));
+        $this->line('  '.$summary['path']);
+
+        return self::SUCCESS;
+    }
+
+    private function humanBytes(int $bytes): string
+    {
+        $units = ['B', 'KiB', 'MiB', 'GiB'];
+        $value = (float) $bytes;
+        $unit = 0;
+        while ($value >= 1024 && $unit < count($units) - 1) {
+            $value /= 1024;
+            $unit++;
+        }
+
+        return sprintf($unit === 0 ? '%d %s' : '%.1f %s', $value, $units[$unit]);
+    }
+}

--- a/app/Console/Commands/TenantProvisionCommand.php
+++ b/app/Console/Commands/TenantProvisionCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Provisioning\ProvisioningRequest;
+use App\Domain\Provisioning\ProvisioningResult;
+use App\Domain\Provisioning\TenantAlreadyExists;
+use App\Domain\Provisioning\TenantProvisioner;
+use Illuminate\Console\Command;
+
+/**
+ * One command per new customer, run over SSH with the host's PHP CLI. Prints
+ * the generated password exactly once; it is never logged or audited.
+ */
+final class TenantProvisionCommand extends Command
+{
+    public const EXIT_ALREADY_EXISTS = 2;
+
+    protected $signature = 'tenant:provision
+                            {--tenant-name= : Display name of the customer}
+                            {--tenant-slug= : URL-safe tenant identifier}
+                            {--workspace-name= : Display name of the first workspace}
+                            {--workspace-slug= : Slug of the first workspace; also the vault folder under VAULT_BASE_PATH}
+                            {--admin-email= : E-mail of the owner administrator}
+                            {--admin-name= : Name of the owner administrator}
+                            {--trial-days=14 : Trial length in days (0 = active plan, no trial)}
+                            {--seats=5 : Seat limit (0 = unlimited)}
+                            {--locale=pt-BR : Locale of the admin and the starter templates (en, pt-BR)}
+                            {--no-welcome-email : Skip the welcome e-mail}
+                            {--json : Emit the result as JSON (includes the one-time password)}';
+
+    protected $description = 'Provision a new customer: tenant, workspace + vault, owner admin, trial plan, starter templates, welcome e-mail.';
+
+    public function handle(TenantProvisioner $provisioner): int
+    {
+        foreach (['tenant-name', 'tenant-slug', 'workspace-name', 'workspace-slug', 'admin-email', 'admin-name'] as $required) {
+            if (trim((string) $this->option($required)) === '') {
+                $this->error("--{$required} is required.");
+
+                return self::FAILURE;
+            }
+        }
+
+        $seats = (int) $this->option('seats');
+        $request = new ProvisioningRequest(
+            tenantName: trim((string) $this->option('tenant-name')),
+            tenantSlug: (string) $this->option('tenant-slug'),
+            workspaceName: trim((string) $this->option('workspace-name')),
+            workspaceSlug: (string) $this->option('workspace-slug'),
+            adminEmail: (string) $this->option('admin-email'),
+            adminName: trim((string) $this->option('admin-name')),
+            trialDays: (int) $this->option('trial-days'),
+            seats: $seats > 0 ? $seats : null,
+            locale: (string) $this->option('locale'),
+            sendWelcomeEmail: ! $this->option('no-welcome-email'),
+        );
+
+        try {
+            $result = $provisioner->provision($request);
+        } catch (TenantAlreadyExists $exception) {
+            $this->error($exception->getMessage());
+
+            return self::EXIT_ALREADY_EXISTS;
+        } catch (\InvalidArgumentException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($this->report($result), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Tenant %s (%s) provisioned.', $result->tenant->slug, $result->tenant->name));
+        $this->line(sprintf('  %-16s %s (id %d) — vault %s', 'workspace', $result->workspace->slug, $result->workspace->id, $result->workspace->vault_path));
+        $this->line(sprintf('  %-16s %s / %s', 'plan', $result->tenant->plan_status, $result->tenant->trial_ends_at?->toDateString() ?? 'no trial deadline'));
+        $this->line(sprintf('  %-16s %s', 'seats', $result->tenant->plan_seats ?? 'unlimited'));
+        $this->line(sprintf('  %-16s %d installed', 'templates', count($result->templatesInstalled)));
+        foreach ($result->urls() as $key => $url) {
+            $this->line(sprintf('  %-16s %s', $key, $url));
+        }
+        $this->newLine();
+        $this->line(sprintf('  %-16s %s (%s)', 'admin', $result->admin->email, $result->adminCreated ? 'created' : 'existing user, password unchanged'));
+        if ($result->password !== null) {
+            $this->line(sprintf('  %-16s %s', 'password', $result->password));
+            $this->comment('  Shown once. It is not stored in clear text, logged, or audited. Hand it over securely.');
+        }
+        if ($result->welcomeEmailSent) {
+            $this->line(sprintf('  %-16s sent to %s', 'welcome e-mail', $result->admin->email));
+        } elseif ($result->welcomeEmailError !== null) {
+            $this->warn('  welcome e-mail failed: '.$result->welcomeEmailError);
+        } else {
+            $this->line(sprintf('  %-16s skipped', 'welcome e-mail'));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function report(ProvisioningResult $result): array
+    {
+        return [
+            'tenant' => ['id' => $result->tenant->id, 'slug' => $result->tenant->slug, 'name' => $result->tenant->name],
+            'plan' => [
+                'status' => $result->tenant->plan_status,
+                'trial_ends_at' => $result->tenant->trial_ends_at?->toIso8601String(),
+                'seats' => $result->tenant->plan_seats,
+            ],
+            'workspace' => ['id' => $result->workspace->id, 'slug' => $result->workspace->slug, 'name' => $result->workspace->name, 'vault_path' => $result->workspace->vault_path],
+            'admin' => ['id' => $result->admin->id, 'email' => $result->admin->email, 'name' => $result->admin->name, 'created' => $result->adminCreated, 'password' => $result->password],
+            'templates_installed' => $result->templatesInstalled,
+            'urls' => $result->urls(),
+            'welcome_email' => ['sent' => $result->welcomeEmailSent, 'error' => $result->welcomeEmailError],
+        ];
+    }
+}

--- a/app/Domain/Audit/AuditEvent.php
+++ b/app/Domain/Audit/AuditEvent.php
@@ -43,7 +43,10 @@ enum AuditEvent: string
     case NOTE_REVIEW_CHANGES_REQUESTED = 'note.review_changes_requested';
     case NOTE_REVIEW_INVALIDATED = 'note.review_invalidated';
 
+    case TENANT_PROVISIONED = 'tenant.provisioned';
+    case TENANT_EXPORTED = 'tenant.exported';
     case TENANT_PLAN_CHANGED = 'tenant.plan_changed';
+    case TENANT_TRIAL_REMINDER_SENT = 'tenant.trial_reminder_sent';
     case TENANT_TRIAL_EXPIRED = 'tenant.trial_expired';
     case PLAN_WRITE_BLOCKED = 'plan.write_blocked';
     case PLAN_SEAT_LIMIT_REACHED = 'plan.seat_limit_reached';

--- a/app/Domain/Export/WorkspaceJsonBackup.php
+++ b/app/Domain/Export/WorkspaceJsonBackup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Domain\Export;
+
+use App\Domain\Vault\VaultPathGuard;
+use App\Models\Note;
+use App\Models\Workspace;
+
+/**
+ * The JSON backup document (`GET /api/workspaces/{id}/export?format=json`) as a
+ * reusable builder so CLI exports produce byte-compatible files.
+ */
+final class WorkspaceJsonBackup
+{
+    public const VERSION = '1.0';
+
+    public function __construct(
+        private readonly VaultPathGuard $pathGuard = new VaultPathGuard,
+    ) {}
+
+    /**
+     * @param  iterable<Note>  $notes
+     * @return array{version: string, workspace_slug: string, exported_at: string, notes: list<array{path: string, content: string}>}
+     */
+    public function build(Workspace $workspace, iterable $notes): array
+    {
+        $exported = [];
+        foreach ($notes as $note) {
+            try {
+                $fullPath = $this->pathGuard->resolve($workspace, $note->path, mustExist: true, mustBeMarkdown: false);
+                $exported[] = ['path' => $note->path, 'content' => (string) file_get_contents($fullPath)];
+            } catch (\Throwable) {
+                // File missing on disk: the projection is rebuildable, skip it.
+            }
+        }
+
+        return [
+            'version' => self::VERSION,
+            'workspace_slug' => $workspace->slug,
+            'exported_at' => now()->toIso8601String(),
+            'notes' => $exported,
+        ];
+    }
+}

--- a/app/Domain/Health/InstanceDoctor.php
+++ b/app/Domain/Health/InstanceDoctor.php
@@ -78,6 +78,7 @@ final class InstanceDoctor
             $databaseCheck,
             $this->checkPendingMigrations($databaseCheck->passed),
             $this->checkMailer(),
+            $this->checkMailFrom(),
             $this->checkScheduler(),
         ];
 
@@ -324,6 +325,18 @@ final class InstanceDoctor
         return $mailer !== 'log'
             ? DoctorCheck::pass('mail_mailer', 'MAIL_MAILER', false, $mailer, ['mailer' => $mailer])
             : DoctorCheck::fail('mail_mailer', 'MAIL_MAILER', false, 'MAIL_MAILER=log: notification emails are recorded as skipped and never delivered.', ['mailer' => $mailer]);
+    }
+
+    private function checkMailFrom(): DoctorCheck
+    {
+        $address = trim((string) config('mail.from.address'));
+        $details = ['address' => $address];
+
+        if ($address === '' || str_ends_with($address, '@example.com')) {
+            return DoctorCheck::fail('mail_from', 'MAIL_FROM_ADDRESS', false, 'Not set (or a placeholder): transactional e-mails cannot be sent without a verified sender.', $details);
+        }
+
+        return DoctorCheck::pass('mail_from', 'MAIL_FROM_ADDRESS', false, $address, $details);
     }
 
     private function checkScheduler(): DoctorCheck

--- a/app/Domain/Plan/TenantPlan.php
+++ b/app/Domain/Plan/TenantPlan.php
@@ -152,7 +152,7 @@ final class TenantPlan
     /**
      * Moves every trial whose deadline passed to `read_only`, one audit row each.
      *
-     * @return list<string> slugs that were expired
+     * @return list<Tenant> tenants that were expired
      */
     public function expireTrials(): array
     {
@@ -179,7 +179,7 @@ final class TenantPlan
                     ],
                 );
 
-                $expired[] = $tenant->slug;
+                $expired[] = $tenant;
             });
 
         return $expired;

--- a/app/Domain/Plan/TrialNotifier.php
+++ b/app/Domain/Plan/TrialNotifier.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Domain\Plan;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Mail\TrialEndedEmail;
+use App\Mail\TrialReminderEmail;
+use App\Models\Membership;
+use App\Models\Tenant;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Scheduler-driven trial e-mails, sent synchronously from the CLI (no queue
+ * worker on shared hosting). Each tenant receives every message at most once,
+ * tracked by `trial_reminder_sent_at` / `trial_ended_notified_at`.
+ */
+final class TrialNotifier
+{
+    public const REMINDER_DAYS = 3;
+
+    public function __construct(
+        private readonly TenantPlan $tenantPlan,
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+    ) {}
+
+    /**
+     * Reminds owners of trials ending within REMINDER_DAYS.
+     *
+     * @return list<string> slugs reminded
+     */
+    public function sendReminders(): array
+    {
+        $now = CarbonImmutable::now();
+        $reminded = [];
+
+        Tenant::query()
+            ->where('plan_status', PlanStatus::TRIAL->value)
+            ->whereNull('trial_reminder_sent_at')
+            ->whereNotNull('trial_ends_at')
+            ->where('trial_ends_at', '>', $now)
+            ->where('trial_ends_at', '<=', $now->addDays(self::REMINDER_DAYS))
+            ->orderBy('id')
+            ->each(function (Tenant $tenant) use (&$reminded): void {
+                $daysLeft = max(1, (int) $this->tenantPlan->trialDaysLeft($tenant));
+                $recipients = $this->recipients($tenant);
+                foreach ($recipients as $user) {
+                    $this->deliver($user, new TrialReminderEmail($user, $tenant, $daysLeft));
+                }
+
+                $tenant->forceFill(['trial_reminder_sent_at' => CarbonImmutable::now()])->save();
+                $this->auditRecorder->record(
+                    event: AuditEvent::TENANT_TRIAL_REMINDER_SENT,
+                    tenantId: $tenant->id,
+                    metadata: ['tenant_slug' => $tenant->slug, 'days_left' => $daysLeft, 'recipients' => $recipients->count()],
+                );
+                $reminded[] = $tenant->slug;
+            });
+
+        return $reminded;
+    }
+
+    /**
+     * Tells owners that a trial ended (tenant already moved to read_only).
+     *
+     * @param  iterable<Tenant>  $tenants
+     * @return list<string> slugs notified
+     */
+    public function sendEnded(iterable $tenants): array
+    {
+        $notified = [];
+        foreach ($tenants as $tenant) {
+            if ($tenant->trial_ended_notified_at !== null) {
+                continue;
+            }
+            foreach ($this->recipients($tenant) as $user) {
+                $this->deliver($user, new TrialEndedEmail($user, $tenant));
+            }
+            $tenant->forceFill(['trial_ended_notified_at' => CarbonImmutable::now()])->save();
+            $notified[] = $tenant->slug;
+        }
+
+        return $notified;
+    }
+
+    /**
+     * Owners and admins of any workspace in the tenant (local users only).
+     *
+     * @return Collection<int, User>
+     */
+    public function recipients(Tenant $tenant): Collection
+    {
+        $ids = Membership::query()
+            ->where('tenant_id', $tenant->id)
+            ->whereIn('role', ['owner', 'admin'])
+            ->pluck('subject_id')
+            ->filter(static fn ($id): bool => ctype_digit((string) $id))
+            ->map(static fn ($id): int => (int) $id)
+            ->unique()
+            ->values();
+
+        return User::query()->whereIn('id', $ids)->where('is_active', true)->orderBy('id')->get();
+    }
+
+    private function deliver(User $user, TrialReminderEmail|TrialEndedEmail $mailable): void
+    {
+        try {
+            Mail::to($user->email)->send($mailable);
+        } catch (\Throwable $exception) {
+            Log::error('trial_email_failed', ['user_id' => $user->id, 'mailable' => $mailable::class, 'exception' => $exception]);
+        }
+    }
+}

--- a/app/Domain/Provisioning/ProvisioningRequest.php
+++ b/app/Domain/Provisioning/ProvisioningRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+final class ProvisioningRequest
+{
+    public readonly string $tenantSlug;
+
+    public readonly string $workspaceSlug;
+
+    public readonly string $adminEmail;
+
+    public readonly string $locale;
+
+    public function __construct(
+        public readonly string $tenantName,
+        string $tenantSlug,
+        public readonly string $workspaceName,
+        string $workspaceSlug,
+        string $adminEmail,
+        public readonly string $adminName,
+        public readonly int $trialDays = 14,
+        public readonly ?int $seats = 5,
+        string $locale = 'pt-BR',
+        public readonly bool $sendWelcomeEmail = true,
+    ) {
+        $this->tenantSlug = Str::slug($tenantSlug);
+        $this->workspaceSlug = Str::slug($workspaceSlug);
+        $this->adminEmail = Str::lower(trim($adminEmail));
+        $this->locale = TemplatePack::normalizeLocale($locale);
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function validate(): void
+    {
+        $validator = Validator::make([
+            'tenant_name' => $this->tenantName,
+            'tenant_slug' => $this->tenantSlug,
+            'workspace_name' => $this->workspaceName,
+            'workspace_slug' => $this->workspaceSlug,
+            'admin_email' => $this->adminEmail,
+            'admin_name' => $this->adminName,
+            'trial_days' => $this->trialDays,
+            'seats' => $this->seats,
+        ], [
+            'tenant_name' => ['required', 'string', 'max:191'],
+            'tenant_slug' => ['required', 'string', 'max:191', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/'],
+            'workspace_name' => ['required', 'string', 'max:191'],
+            'workspace_slug' => ['required', 'string', 'max:191', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', 'not_in:_templates'],
+            'admin_email' => ['required', 'email:rfc', 'max:255'],
+            'admin_name' => ['required', 'string', 'max:191'],
+            'trial_days' => ['integer', 'min:0', 'max:365'],
+            'seats' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        if ($validator->fails()) {
+            throw new \InvalidArgumentException(implode(' ', $validator->errors()->all()));
+        }
+    }
+}

--- a/app/Domain/Provisioning/ProvisioningResult.php
+++ b/app/Domain/Provisioning/ProvisioningResult.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+
+final class ProvisioningResult
+{
+    public bool $welcomeEmailSent = false;
+
+    public ?string $welcomeEmailError = null;
+
+    /**
+     * @param  list<string>  $templatesInstalled
+     * @param  ?string  $password  Set only when the admin user was created; shown once, never stored or logged.
+     */
+    public function __construct(
+        public readonly Tenant $tenant,
+        public readonly Workspace $workspace,
+        public readonly User $admin,
+        public readonly bool $adminCreated,
+        public readonly array $templatesInstalled,
+        public readonly ?string $password,
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function urls(): array
+    {
+        $base = rtrim((string) config('app.url'), '/');
+
+        return [
+            'app' => $base.'/',
+            'login' => $base.'/',
+            'webdav' => $base.'/api/webdav/'.$this->workspace->id,
+            'mcp' => $base.'/api/mcp',
+            'health' => $base.'/api/health',
+        ];
+    }
+}

--- a/app/Domain/Provisioning/TemplatePack.php
+++ b/app/Domain/Provisioning/TemplatePack.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\Workspace;
+use ZipArchive;
+
+/**
+ * Starter templates shipped with the engine (`resources/templates/<locale>/_templates`).
+ * They are plain Markdown using the TemplateEngine placeholders, installed into a
+ * workspace vault as `_templates/<name>.md` or packaged as a ZIP the import
+ * endpoint accepts.
+ */
+final class TemplatePack
+{
+    public const LOCALES = ['en', 'pt-BR'];
+
+    public const FOLDER = '_templates';
+
+    public function __construct(
+        private readonly VaultStorage $storage,
+    ) {}
+
+    public static function normalizeLocale(?string $locale): string
+    {
+        return in_array($locale, self::LOCALES, true) ? $locale : 'en';
+    }
+
+    /**
+     * @return array<string, string> relative vault path => Markdown contents
+     */
+    public function files(string $locale): array
+    {
+        $dir = resource_path('templates/'.self::normalizeLocale($locale).'/'.self::FOLDER);
+        $files = [];
+        foreach (glob($dir.'/*.md') ?: [] as $path) {
+            $files[self::FOLDER.'/'.basename($path)] = (string) file_get_contents($path);
+        }
+        ksort($files);
+
+        return $files;
+    }
+
+    /**
+     * Writes every template into the workspace (projecting notes). Existing
+     * templates are left untouched unless $overwrite is true.
+     *
+     * @return list<string> paths written
+     */
+    public function install(Workspace $workspace, string $locale, bool $overwrite = false, ?string $actorId = null): array
+    {
+        $written = [];
+        foreach ($this->files($locale) as $path => $contents) {
+            if (! $overwrite && $this->storage->exists($workspace, $path)) {
+                continue;
+            }
+            $this->storage->write($workspace, $path, $contents, $actorId);
+            $written[] = $path;
+        }
+
+        return $written;
+    }
+
+    /**
+     * Builds a ZIP with the same layout the import endpoint expects.
+     */
+    public function writeZip(string $locale, string $zipPath): string
+    {
+        @mkdir(dirname($zipPath), 0755, true);
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Unable to create template pack ZIP at {$zipPath}.");
+        }
+        foreach ($this->files($locale) as $path => $contents) {
+            $zip->addFromString($path, $contents);
+        }
+        $zip->close();
+
+        return $zipPath;
+    }
+}

--- a/app/Domain/Provisioning/TenantAlreadyExists.php
+++ b/app/Domain/Provisioning/TenantAlreadyExists.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+final class TenantAlreadyExists extends \RuntimeException
+{
+    public function __construct(public readonly string $slug)
+    {
+        parent::__construct("Tenant [{$slug}] already exists. Provisioning is not repeated; use tenant:plan / tenant:show to manage it.");
+    }
+}

--- a/app/Domain/Provisioning/TenantExporter.php
+++ b/app/Domain/Provisioning/TenantExporter.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Domain\Export\WorkspaceJsonBackup;
+use App\Domain\Plan\TenantPlan;
+use App\Models\Membership;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use ZipArchive;
+
+/**
+ * Full, portable copy of one tenant (LGPD data portability): every workspace
+ * vault file (notes, attachments, templates), the JSON backup the API also
+ * produces, and a manifest of tenant, plan, workspaces, memberships, and users.
+ */
+final class TenantExporter
+{
+    public function __construct(
+        private readonly WorkspaceJsonBackup $jsonBackup,
+        private readonly TenantPlan $tenantPlan,
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+    ) {}
+
+    /**
+     * @return array{path: string, workspaces: int, files: int, bytes: int}
+     */
+    public function export(Tenant $tenant, string $zipPath): array
+    {
+        @mkdir(dirname($zipPath), 0755, true);
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("Unable to create export ZIP at {$zipPath}.");
+        }
+
+        $files = 0;
+        $manifestWorkspaces = [];
+
+        foreach ($tenant->workspaces()->orderBy('id')->get() as $workspace) {
+            $prefix = 'workspaces/'.$workspace->slug.'/';
+            $files += $this->addVault($zip, $workspace, $prefix.'vault/');
+
+            $notes = Note::withTrashed()->where('workspace_id', $workspace->id)->orderBy('path')->get();
+            $zip->addFromString($prefix.'backup.json', (string) json_encode(
+                $this->jsonBackup->build($workspace, $notes),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ));
+            $files++;
+
+            $manifestWorkspaces[] = [
+                'id' => $workspace->id,
+                'slug' => $workspace->slug,
+                'name' => $workspace->name,
+                'notes' => $notes->count(),
+            ];
+        }
+
+        $zip->addFromString('tenant.json', (string) json_encode($this->manifest($tenant, $manifestWorkspaces), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $files++;
+        $zip->close();
+
+        $this->auditRecorder->record(
+            event: AuditEvent::TENANT_EXPORTED,
+            tenantId: $tenant->id,
+            actorId: 'cli:tenant:export',
+            metadata: ['tenant_slug' => $tenant->slug, 'workspaces' => count($manifestWorkspaces), 'files' => $files],
+        );
+
+        return [
+            'path' => $zipPath,
+            'workspaces' => count($manifestWorkspaces),
+            'files' => $files,
+            'bytes' => (int) filesize($zipPath),
+        ];
+    }
+
+    private function addVault(ZipArchive $zip, Workspace $workspace, string $prefix): int
+    {
+        $root = realpath($workspace->vault_path);
+        if ($root === false || ! is_dir($root)) {
+            return 0;
+        }
+
+        $count = 0;
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+        /** @var SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $relative = ltrim(str_replace('\\', '/', substr($entry->getPathname(), strlen($root))), '/');
+            if ($entry->isDir()) {
+                $zip->addEmptyDir($prefix.$relative);
+            } elseif ($entry->isFile() && ! $entry->isLink()) {
+                $zip->addFile($entry->getPathname(), $prefix.$relative);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $workspaces
+     * @return array<string, mixed>
+     */
+    private function manifest(Tenant $tenant, array $workspaces): array
+    {
+        $memberships = Membership::query()->where('tenant_id', $tenant->id)->orderBy('id')->get();
+        $userIds = $memberships->pluck('subject_id')->filter(static fn ($id): bool => ctype_digit((string) $id))->map(static fn ($id): int => (int) $id)->unique()->all();
+        $users = User::query()->whereIn('id', $userIds)->orderBy('id')->get(['id', 'name', 'email', 'locale', 'is_admin', 'is_active', 'created_at']);
+
+        return [
+            'format' => 'jotter-tenant-export',
+            'version' => '1.0',
+            'exported_at' => now()->toIso8601String(),
+            'tenant' => [
+                'id' => $tenant->id,
+                'slug' => $tenant->slug,
+                'name' => $tenant->name,
+                'created_at' => $tenant->created_at?->toIso8601String(),
+                'plan' => $this->tenantPlan->payload($tenant),
+            ],
+            'workspaces' => $workspaces,
+            'memberships' => $memberships->map(static fn (Membership $membership): array => [
+                'workspace_id' => $membership->workspace_id,
+                'subject_id' => $membership->subject_id,
+                'role' => $membership->role,
+            ])->all(),
+            'users' => $users->map(static fn (User $user): array => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'locale' => $user->locale,
+                'is_admin' => (bool) $user->is_admin,
+                'is_active' => (bool) $user->is_active,
+                'created_at' => $user->created_at?->toIso8601String(),
+            ])->all(),
+        ];
+    }
+}

--- a/app/Domain/Provisioning/TenantProvisioner.php
+++ b/app/Domain/Provisioning/TenantProvisioner.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Domain\Provisioning;
+
+use App\Domain\Audit\AuditEvent;
+use App\Domain\Audit\AuditRecorder;
+use App\Domain\Plan\PlanStatus;
+use App\Domain\Vault\VaultRootGuard;
+use App\Mail\WelcomeEmail;
+use App\Models\Membership;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+/**
+ * One-shot installation of a customer: tenant, workspace + vault, owner admin,
+ * trial plan, starter templates, welcome e-mail. The generated password is
+ * returned to the caller exactly once and never logged or audited.
+ */
+final class TenantProvisioner
+{
+    public const PASSWORD_LENGTH = 20;
+
+    public function __construct(
+        private readonly VaultRootGuard $rootGuard,
+        private readonly TemplatePack $templatePack,
+        private readonly AuditRecorder $auditRecorder = new AuditRecorder,
+    ) {}
+
+    /**
+     * @throws TenantAlreadyExists when the tenant slug is taken
+     * @throws \InvalidArgumentException for invalid input
+     */
+    public function provision(ProvisioningRequest $request): ProvisioningResult
+    {
+        $request->validate();
+
+        if (Tenant::query()->where('slug', $request->tenantSlug)->exists()) {
+            throw new TenantAlreadyExists($request->tenantSlug);
+        }
+
+        $vaultPath = $this->rootGuard->validate(
+            rtrim((string) config('vault.base_path'), '/').'/'.$request->workspaceSlug,
+        );
+        $createdVault = false;
+        if (! is_dir($vaultPath)) {
+            if (! @mkdir($vaultPath, 0755, true) && ! is_dir($vaultPath)) {
+                throw new \RuntimeException("Unable to create the vault directory [{$vaultPath}].");
+            }
+            $createdVault = true;
+        }
+
+        $password = null;
+
+        try {
+            /** @var ProvisioningResult $result */
+            $result = DB::transaction(function () use ($request, $vaultPath, &$password): ProvisioningResult {
+                $tenant = Tenant::create([
+                    'slug' => $request->tenantSlug,
+                    'name' => $request->tenantName,
+                    'plan_status' => $request->trialDays > 0 ? PlanStatus::TRIAL->value : PlanStatus::ACTIVE->value,
+                    'trial_ends_at' => $request->trialDays > 0 ? CarbonImmutable::now()->addDays($request->trialDays) : null,
+                    'plan_seats' => $request->seats,
+                    'plan_name' => $request->trialDays > 0 ? 'trial' : null,
+                ]);
+
+                $workspace = Workspace::create([
+                    'tenant_id' => $tenant->id,
+                    'slug' => $request->workspaceSlug,
+                    'name' => $request->workspaceName,
+                    'vault_path' => $vaultPath,
+                ]);
+
+                $existing = User::query()->where('email', $request->adminEmail)->first();
+                if ($existing === null) {
+                    // Reuse the platform bootstrap command for the admin user itself.
+                    $password = Str::password(self::PASSWORD_LENGTH);
+                    $exit = Artisan::call('platform:bootstrap-admin', ['email' => $request->adminEmail, 'password' => $password]);
+                    if ($exit !== 0) {
+                        throw new \RuntimeException('platform:bootstrap-admin failed: '.trim(Artisan::output()));
+                    }
+                }
+                $admin = User::query()->where('email', $request->adminEmail)->firstOrFail();
+                $admin->forceFill(array_filter([
+                    'name' => $existing === null ? $request->adminName : null,
+                    'locale' => $request->locale,
+                    'is_active' => true,
+                ], static fn ($value): bool => $value !== null))->save();
+
+                Membership::create([
+                    'tenant_id' => $tenant->id,
+                    'workspace_id' => $workspace->id,
+                    'subject_id' => (string) $admin->id,
+                    'role' => 'owner',
+                ]);
+
+                $templates = $this->templatePack->install($workspace, $request->locale, false, (string) $admin->id);
+
+                $this->auditRecorder->record(
+                    event: AuditEvent::TENANT_PROVISIONED,
+                    tenantId: $tenant->id,
+                    workspaceId: $workspace->id,
+                    actorId: 'cli:tenant:provision',
+                    metadata: [
+                        'tenant_slug' => $tenant->slug,
+                        'workspace_slug' => $workspace->slug,
+                        'admin_user_id' => $admin->id,
+                        'admin_email' => $admin->email,
+                        'admin_created' => $existing === null,
+                        'trial_days' => $request->trialDays,
+                        'seats' => $request->seats,
+                        'locale' => $request->locale,
+                        'templates_installed' => count($templates),
+                    ],
+                );
+
+                return new ProvisioningResult(
+                    tenant: $tenant,
+                    workspace: $workspace,
+                    admin: $admin,
+                    adminCreated: $existing === null,
+                    templatesInstalled: $templates,
+                    password: $password,
+                );
+            });
+        } catch (\Throwable $exception) {
+            if ($createdVault) {
+                $this->removeEmptyVault($vaultPath);
+            }
+            throw $exception;
+        }
+
+        $result->welcomeEmailSent = $this->sendWelcome($result, $request);
+
+        return $result;
+    }
+
+    private function sendWelcome(ProvisioningResult $result, ProvisioningRequest $request): bool
+    {
+        if (! $request->sendWelcomeEmail) {
+            return false;
+        }
+
+        if (trim((string) config('mail.from.address')) === '') {
+            $result->welcomeEmailError = 'MAIL_FROM_ADDRESS is not set; configure the sender and re-send manually.';
+
+            return false;
+        }
+
+        try {
+            Mail::to($result->admin->email)->send(new WelcomeEmail(
+                $result->admin,
+                $result->workspace,
+                $request->trialDays > 0 ? $request->trialDays : null,
+            ));
+
+            return true;
+        } catch (\Throwable $exception) {
+            // Provisioning already succeeded; the caller reports the failure.
+            $result->welcomeEmailError = $exception->getMessage();
+
+            return false;
+        }
+    }
+
+    private function removeEmptyVault(string $vaultPath): void
+    {
+        $entries = @scandir($vaultPath) ?: [];
+        if (count(array_diff($entries, ['.', '..'])) === 0) {
+            @rmdir($vaultPath);
+        }
+    }
+}

--- a/app/Http/Controllers/AdminUserController.php
+++ b/app/Http/Controllers/AdminUserController.php
@@ -5,10 +5,12 @@ namespace App\Http\Controllers;
 use App\Domain\Audit\AuditEvent;
 use App\Domain\Audit\AuditRecorder;
 use App\Domain\Auth\AuthenticatedSubject;
+use App\Mail\PasswordResetEmail;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rules\Password;
 
 final class AdminUserController extends Controller
@@ -130,6 +132,15 @@ final class AdminUserController extends Controller
                 'mode' => 'admin_reset',
             ]
         );
+
+        // Tell the user out of band; the message never contains the password.
+        if (config('mail.default') !== 'log') {
+            try {
+                Mail::to($user->email)->send(new PasswordResetEmail($user));
+            } catch (\Throwable $exception) {
+                report($exception);
+            }
+        }
 
         return response()->json(['message' => __('messages.user_password_reset_successfully')]);
     }

--- a/app/Http/Controllers/WorkspaceExportController.php
+++ b/app/Http/Controllers/WorkspaceExportController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Domain\Auth\Contracts\IdentityProvider;
 use App\Domain\Auth\NoteAccess;
+use App\Domain\Export\WorkspaceJsonBackup;
+use App\Domain\Vault\VaultPathGuard;
 use App\Models\Note;
 use App\Models\Workspace;
 use Illuminate\Http\JsonResponse;
@@ -16,6 +18,7 @@ final class WorkspaceExportController extends Controller
     public function __construct(
         private readonly IdentityProvider $identityProvider,
         private readonly NoteAccess $noteAccess,
+        private readonly WorkspaceJsonBackup $jsonBackup = new WorkspaceJsonBackup,
     ) {}
 
     public function export(Request $request, int $workspaceId): JsonResponse|BinaryFileResponse
@@ -41,31 +44,14 @@ final class WorkspaceExportController extends Controller
 
         if ($request->query('format') === 'json') {
             $notes = $this->noteAccess->scopeVisible(Note::query(), $subject, $workspaceId)->get();
-            $pathGuard = new \App\Domain\Vault\VaultPathGuard();
-            $exportedNotes = [];
-            foreach ($notes as $note) {
-                try {
-                    $fullPath = $pathGuard->resolve($workspace, $note->path, mustExist: true, mustBeMarkdown: false);
-                    $exportedNotes[] = [
-                        'path' => $note->path,
-                        'content' => file_get_contents($fullPath),
-                    ];
-                } catch (\Throwable) {
-                    // file missing
-                }
-            }
-            return response()->json([
-                'version' => '1.0',
-                'workspace_slug' => $workspace->slug,
-                'exported_at' => now()->toIso8601String(),
-                'notes' => $exportedNotes,
-            ]);
+
+            return response()->json($this->jsonBackup->build($workspace, $notes));
         }
 
         $zipPath = "{$exportDir}/export_workspace_{$workspace->id}.zip";
         @unlink($zipPath);
 
-        $zip = new ZipArchive();
+        $zip = new ZipArchive;
         if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
             return response()->json(['message' => __('messages.failed_to_create_export_zip')], 500);
         }
@@ -73,7 +59,7 @@ final class WorkspaceExportController extends Controller
         $notes = $this->noteAccess->scopeVisible(Note::query(), $subject, $workspaceId)->get();
         $hasFiles = false;
 
-        $pathGuard = new \App\Domain\Vault\VaultPathGuard();
+        $pathGuard = new VaultPathGuard;
         foreach ($notes as $note) {
             try {
                 $fullPath = $pathGuard->resolve($workspace, $note->path, mustExist: true, mustBeMarkdown: false);

--- a/app/Mail/BrandedMailable.php
+++ b/app/Mail/BrandedMailable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use App\Support\Branding;
+use Illuminate\Mail\Mailable;
+
+/**
+ * Base for transactional mail: resolves the recipient locale (en / pt-BR) and
+ * the operator branding once so every template shares the same shell.
+ */
+abstract class BrandedMailable extends Mailable
+{
+    public readonly Branding $brand;
+
+    public function __construct(public readonly User $recipient)
+    {
+        $this->brand = Branding::configured();
+        $this->locale = in_array($recipient->locale, ['en', 'pt-BR'], true) ? $recipient->locale : 'en';
+    }
+
+    protected function appUrl(): string
+    {
+        return rtrim((string) config('app.url'), '/');
+    }
+
+    /**
+     * @param  array<string, mixed>  $replace
+     */
+    protected function translate(string $key, array $replace = []): string
+    {
+        return trans($key, $replace + ['brand' => $this->brand->name], $this->locale);
+    }
+
+    /**
+     * @param  array<string, mixed>  $replace
+     */
+    protected function translateChoice(string $key, int $number, array $replace = []): string
+    {
+        return trans_choice($key, $number, $replace + ['brand' => $this->brand->name], $this->locale);
+    }
+}

--- a/app/Mail/PasswordResetEmail.php
+++ b/app/Mail/PasswordResetEmail.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Sent when an administrator resets a user's password. Deliberately contains no
+ * password: the administrator hands it over out of band.
+ */
+final class PasswordResetEmail extends BrandedMailable
+{
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: $this->translate('emails.password_reset.subject'));
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.password-reset', with: [
+            'locale' => $this->locale,
+            'subject' => $this->translate('emails.password_reset.subject'),
+            'brand' => $this->brand,
+            'recipient' => $this->recipient,
+            'loginUrl' => $this->appUrl().'/',
+        ]);
+    }
+}

--- a/app/Mail/TrialEndedEmail.php
+++ b/app/Mail/TrialEndedEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+final class TrialEndedEmail extends BrandedMailable
+{
+    public function __construct(
+        User $recipient,
+        public readonly Tenant $tenant,
+    ) {
+        parent::__construct($recipient);
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: $this->translate('emails.trial_ended.subject'));
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.trial-ended', with: [
+            'locale' => $this->locale,
+            'subject' => $this->translate('emails.trial_ended.subject'),
+            'brand' => $this->brand,
+            'recipient' => $this->recipient,
+            'tenant' => $this->tenant,
+        ]);
+    }
+}

--- a/app/Mail/TrialReminderEmail.php
+++ b/app/Mail/TrialReminderEmail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+final class TrialReminderEmail extends BrandedMailable
+{
+    public function __construct(
+        User $recipient,
+        public readonly Tenant $tenant,
+        public readonly int $daysLeft,
+    ) {
+        parent::__construct($recipient);
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: $this->translateChoice('emails.trial_reminder.subject', $this->daysLeft, ['days' => $this->daysLeft]));
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.trial-reminder', with: [
+            'locale' => $this->locale,
+            'subject' => $this->translateChoice('emails.trial_reminder.subject', $this->daysLeft, ['days' => $this->daysLeft]),
+            'brand' => $this->brand,
+            'recipient' => $this->recipient,
+            'tenant' => $this->tenant,
+            'daysLeft' => $this->daysLeft,
+            'endsAt' => $this->tenant->trial_ends_at?->locale($this->locale)->isoFormat('LL') ?? '',
+        ]);
+    }
+}

--- a/app/Mail/WelcomeEmail.php
+++ b/app/Mail/WelcomeEmail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Sent once by `tenant:provision`. Never carries the password: that is printed
+ * a single time on the operator's terminal.
+ */
+final class WelcomeEmail extends BrandedMailable
+{
+    public const MCP_GUIDE_URL = 'https://github.com/suporterfid/jotter/blob/main/docs/mcp.md';
+
+    public function __construct(
+        User $recipient,
+        public readonly Workspace $workspace,
+        public readonly ?int $trialDays = null,
+    ) {
+        parent::__construct($recipient);
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: $this->translate('emails.welcome.subject'));
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.welcome', with: [
+            'locale' => $this->locale,
+            'subject' => $this->translate('emails.welcome.subject'),
+            'brand' => $this->brand,
+            'recipient' => $this->recipient,
+            'workspace' => $this->workspace,
+            'loginUrl' => $this->appUrl().'/',
+            'webdavUrl' => $this->appUrl().'/api/webdav/'.$this->workspace->id,
+            'mcpGuideUrl' => self::MCP_GUIDE_URL,
+            'trialDays' => $this->trialDays,
+        ]);
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -14,10 +14,14 @@ class Tenant extends Model
         'trial_ends_at',
         'plan_name',
         'plan_seats',
+        'trial_reminder_sent_at',
+        'trial_ended_notified_at',
     ];
 
     protected $casts = [
         'trial_ends_at' => 'immutable_datetime',
+        'trial_reminder_sent_at' => 'immutable_datetime',
+        'trial_ended_notified_at' => 'immutable_datetime',
         'plan_seats' => 'integer',
     ];
 

--- a/app/View/Components/MailLayout.php
+++ b/app/View/Components/MailLayout.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/**
+ * Shared transactional e-mail shell: brand header, body slot, footer links.
+ */
+final class MailLayout extends Component
+{
+    public function __construct(
+        public string $locale = 'en',
+        public ?string $subject = null,
+    ) {}
+
+    public function render(): View
+    {
+        return view('emails.layout');
+    }
+}

--- a/database/migrations/2026_08_31_000002_add_trial_notification_columns_to_tenants_table.php
+++ b/database/migrations/2026_08_31_000002_add_trial_notification_columns_to_tenants_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table): void {
+            // Idempotency markers for the scheduler-driven trial e-mails.
+            $table->timestamp('trial_reminder_sent_at')->nullable()->after('plan_seats');
+            $table->timestamp('trial_ended_notified_at')->nullable()->after('trial_reminder_sent_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table): void {
+            $table->dropColumn(['trial_reminder_sent_at', 'trial_ended_notified_at']);
+        });
+    }
+};

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,7 +96,7 @@ The doctor verifies: PHP version and required extensions, `APP_KEY`, `APP_ENV`,
 `APP_DEBUG=false`, `APP_URL` on HTTPS, `storage/` and `bootstrap/cache` writable,
 `VAULT_BASE_PATH` existing, writable, and outside the document root, free disk
 space for the vault, database connectivity, pending migrations, `MAIL_MAILER`
-different from `log`, `APP_INSTANCE_SLUG`, and the scheduler heartbeat (a
+different from `log`, `MAIL_FROM_ADDRESS` set, `APP_INSTANCE_SLUG`, and the scheduler heartbeat (a
 `schedule:run` within the last 5 minutes). `APP_DEBUG` and the HTTPS check are
 critical when `APP_ENV=production` and warnings otherwise; the mailer, recommended
 extensions, and instance slug are always warnings.
@@ -135,7 +135,8 @@ runs are prevented with cache locks (`CACHE_STORE=database`).
 | `vault:purge-trash` | daily 02:00 | Permanently deletes notes past the trash retention period. |
 | `vault:prune-revisions --days=30` | daily 02:15 | Prunes derived revision snapshots (Markdown files are never touched). |
 | `audit:prune --days=90` | daily 02:30 | Enforces audit-log retention. |
-| `tenant:expire-trials` | daily 03:00 | Hosted mode only: moves trials past `trial_ends_at` to `read_only` and audits it. No-op for self-hosted tenants. |
+| `tenant:expire-trials` | daily 03:00 | Hosted mode only: e-mails owners 3 days before a trial ends, moves trials past `trial_ends_at` to `read_only` (audited), and e-mails them once more. No-op for self-hosted tenants. |
+| `queue:work --stop-when-empty --max-time=50` | every minute, only when `QUEUE_CONNECTION=database` | Drains a database queue without a daemon. Mail is synchronous by default, so this is normally not registered. |
 
 The individual commands below remain available for one-off runs with different
 options. Hosted-mode plan state is changed with `php artisan tenant:plan <slug>`

--- a/docs/hosted-operations.md
+++ b/docs/hosted-operations.md
@@ -1,0 +1,128 @@
+# Hosted operations (SSH + Artisan)
+
+Runbook for operating hosted installations ("Cadernia" or any operator brand)
+on shared PHP hosting. Every step is an Artisan command run over SSH with the
+host's PHP CLI from the installation's Laravel root; there is no admin UI for
+these actions and no queue worker. See `docs/deployment.md` for installing the
+release ZIP and `docs/architecture.md` ("Hosted mode") for the model.
+
+```sh
+ssh user@host
+cd ~/domains/acme.example.com/public_html/acme    # the Laravel root of ONE installation
+php artisan jotter:doctor                          # must be green before anything else
+```
+
+## E-mail
+
+Transactional mail (welcome, password reset, notifications, trial reminder,
+trial ended) is sent synchronously from the request or from the scheduler; no
+worker is needed. Configure SMTP in `.env` (Resend and Postmark examples are in
+`.env.example`), then confirm:
+
+```sh
+php artisan jotter:doctor          # MAIL_MAILER must not be `log`
+php artisan tinker --execute="Mail::raw('smoke', fn(\$m) => \$m->to('you@example.com')->subject('SMTP smoke'));"
+```
+
+If an operator deliberately sets `QUEUE_CONNECTION=database`, the scheduler
+drains it every minute with `queue:work --stop-when-empty --max-time=50`; the
+default stays synchronous.
+
+## Provision a customer
+
+One command creates the tenant, its first workspace and vault directory
+(`VAULT_BASE_PATH/<workspace-slug>`), the owner administrator with a random
+20-character password, the owner membership, a 14-day trial with 5 seats, the
+starter templates (`_templates/`) in the chosen locale, and sends the welcome
+e-mail.
+
+```sh
+php artisan tenant:provision \
+  --tenant-name="Acme Ltda" --tenant-slug=acme \
+  --workspace-name="Acme Docs" --workspace-slug=acme-docs \
+  --admin-email=owner@acme.example --admin-name="Ana Owner" \
+  --trial-days=14 --seats=5 --locale=pt-BR
+```
+
+The password is printed **once** on the terminal (or in the `--json` report).
+It is not stored in clear text, logged, or written to the audit log; hand it to
+the customer through a secure channel. The welcome e-mail never contains it.
+
+- Exit code `0`: provisioned. `1`: invalid input. `2`: the tenant slug already
+  exists — nothing is changed; manage it with `tenant:plan` / `tenant:show`.
+- An existing user with the same e-mail is reused as owner and keeps its
+  password (`"created": false` in the report).
+- `--trial-days=0` creates an `active` tenant without a trial; `--seats=0`
+  means unlimited; `--no-welcome-email` skips the message.
+- Audit: `tenant.provisioned` (no password).
+
+## Change a plan
+
+```sh
+php artisan tenant:show acme                      # current state, seats used, workspaces
+php artisan tenant:plan acme --status=active --name=Team --seats=10
+php artisan tenant:plan acme --trial-days=7       # extend or restart a trial
+php artisan tenant:plan acme --status=past_due    # writes answer 402, reading continues
+php artisan tenant:plan acme --status=read_only
+```
+
+Billing happens outside the engine; these commands mirror its outcome. Every
+change is audited (`tenant.plan_changed`). The daily scheduler task
+`tenant:expire-trials` e-mails owners 3 days before a trial ends and again when
+it ends (moving the tenant to `read_only`), each at most once per tenant.
+
+## Export a tenant (LGPD portability)
+
+```sh
+php artisan tenant:export acme --to=/home/user/exports/acme.zip
+```
+
+The ZIP contains, per workspace, `workspaces/<slug>/vault/` (every file on
+disk: notes, attachments, `_templates`) and `workspaces/<slug>/backup.json`
+(the same JSON document `GET /api/workspaces/{id}/export?format=json`
+produces), plus `tenant.json` (tenant, plan, workspaces, memberships, users
+tied to the tenant). Never write it under the document root; the command
+refuses to. Audit: `tenant.exported`.
+
+## Remove a tenant
+
+There is deliberately no destructive command. To remove a customer:
+
+1. `php artisan tenant:export acme --to=...` and deliver the archive.
+2. `php artisan tenant:plan acme --status=read_only` during the notice period.
+3. After the retention period agreed with the customer, delete the rows and the
+   vault directory manually and record the action out of band. `audit_log`
+   rows reference the tenant with `ON DELETE RESTRICT`, so they must go first
+   (keep the exported archive as the record of what existed):
+
+```sh
+php artisan tinker --execute="
+  \$t = App\\Models\\Tenant::where('slug','acme')->firstOrFail();
+  App\\Models\\AuditLog::where('tenant_id', \$t->id)->delete();
+  \$t->delete();
+"
+rm -rf "$VAULT_BASE_PATH/acme-docs"
+```
+
+Cascading foreign keys then remove workspaces, memberships, notes, and related
+projections; the local user account survives (it may belong to other tenants)
+and can be deactivated from the admin UI.
+
+## Starter templates
+
+`resources/templates/<locale>/_templates/` ships ADR, meeting notes, daily,
+runbook, and PRD templates in `en` and `pt-BR`. `tenant:provision` installs them;
+for an existing workspace build the ZIP and upload it through the SPA import
+dialog (or `POST /api/workspaces/{id}/import`):
+
+```sh
+php artisan templates:pack --locale=pt-BR --to=/tmp/templates-pt-BR.zip
+```
+
+Existing files under `_templates/` are never overwritten by `tenant:provision`.
+
+## Health and diagnostics
+
+- `php artisan jotter:doctor [--json]` — installation self-check.
+- `GET /api/health` — public liveness probe (`status`, `version`, scheduler heartbeat).
+- `php artisan tenant:show <slug> --json` — plan, seats, workspaces.

--- a/lang/en/emails.php
+++ b/lang/en/emails.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'greeting' => 'Hello, :name.',
+    'signoff' => '— The :brand team',
+    'footer' => [
+        'terms' => 'Terms',
+        'privacy' => 'Privacy',
+        'support' => 'Support',
+        'powered_by' => 'Powered by Jotter',
+    ],
+    'welcome' => [
+        'subject' => 'Welcome to :brand',
+        'intro' => 'Your :brand account is ready. Your workspace ":workspace" is waiting for your first note.',
+        'login_button' => 'Sign in',
+        'credentials' => 'Sign in with :email and the password your administrator gave you, then change it from your profile menu.',
+        'webdav' => 'Sync with Obsidian or any WebDAV client:',
+        'mcp' => 'Connect an AI assistant with the Model Context Protocol:',
+        'mcp_guide' => 'MCP guide',
+        'trial' => '{1} Your trial lasts 1 day.|[2,*] Your trial lasts :days days; we will remind you before it ends.',
+    ],
+    'password_reset' => [
+        'subject' => 'Your :brand password was reset',
+        'body' => 'An administrator has reset the password of your :brand account. Use the new password they shared with you to sign in, then choose a password of your own.',
+        'login_button' => 'Sign in',
+        'warning' => 'If you did not expect this change, contact your administrator immediately.',
+    ],
+    'trial_reminder' => [
+        'subject' => '{1} Your :brand trial ends tomorrow|[2,*] Your :brand trial ends in :days days',
+        'body' => '{1} The trial of ":tenant" on :brand ends tomorrow (:date).|[2,*] The trial of ":tenant" on :brand ends in :days days (:date).',
+        'what_happens' => 'After that date the account becomes read-only: notes, search, and exports stay available, but editing pauses until a plan is active.',
+        'contact' => 'Talk to us about a plan',
+    ],
+    'trial_ended' => [
+        'subject' => 'Your :brand trial has ended',
+        'body' => 'The trial of ":tenant" on :brand has ended.',
+        'read_only' => 'The account is now read-only. Everything you wrote is safe and can still be read, searched, and exported. Activate a plan to resume editing.',
+        'contact' => 'Activate a plan',
+    ],
+];

--- a/lang/pt-BR/emails.php
+++ b/lang/pt-BR/emails.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'greeting' => 'Olá, :name.',
+    'signoff' => '— Equipe :brand',
+    'footer' => [
+        'terms' => 'Termos',
+        'privacy' => 'Privacidade',
+        'support' => 'Suporte',
+        'powered_by' => 'Powered by Jotter',
+    ],
+    'welcome' => [
+        'subject' => 'Bem-vindo ao :brand',
+        'intro' => 'Sua conta no :brand está pronta. O espaço ":workspace" está esperando pela sua primeira nota.',
+        'login_button' => 'Entrar',
+        'credentials' => 'Entre com :email e a senha que o administrador lhe passou; depois troque-a no menu do seu perfil.',
+        'webdav' => 'Sincronize com o Obsidian ou qualquer cliente WebDAV:',
+        'mcp' => 'Conecte um assistente de IA pelo Model Context Protocol:',
+        'mcp_guide' => 'Guia do MCP',
+        'trial' => '{1} Seu período de teste dura 1 dia.|[2,*] Seu período de teste dura :days dias; avisaremos antes de terminar.',
+    ],
+    'password_reset' => [
+        'subject' => 'Sua senha do :brand foi redefinida',
+        'body' => 'Um administrador redefiniu a senha da sua conta no :brand. Use a nova senha que ele compartilhou com você para entrar e, em seguida, escolha uma senha sua.',
+        'login_button' => 'Entrar',
+        'warning' => 'Se você não esperava esta alteração, contate o administrador imediatamente.',
+    ],
+    'trial_reminder' => [
+        'subject' => '{1} Seu período de teste no :brand termina amanhã|[2,*] Seu período de teste no :brand termina em :days dias',
+        'body' => '{1} O período de teste de ":tenant" no :brand termina amanhã (:date).|[2,*] O período de teste de ":tenant" no :brand termina em :days dias (:date).',
+        'what_happens' => 'Depois dessa data a conta fica somente leitura: notas, busca e exportações continuam disponíveis, mas a edição pausa até um plano estar ativo.',
+        'contact' => 'Fale conosco sobre um plano',
+    ],
+    'trial_ended' => [
+        'subject' => 'Seu período de teste no :brand terminou',
+        'body' => 'O período de teste de ":tenant" no :brand terminou.',
+        'read_only' => 'A conta agora está somente leitura. Tudo o que você escreveu está seguro e continua podendo ser lido, buscado e exportado. Ative um plano para voltar a editar.',
+        'contact' => 'Ativar um plano',
+    ],
+];

--- a/resources/templates/en/_templates/adr.md
+++ b/resources/templates/en/_templates/adr.md
@@ -1,0 +1,23 @@
+---
+type: adr
+status: proposed
+date: {{date}}
+---
+# ADR: {{title}}
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+## Alternatives considered
+
+- Option A —
+- Option B —

--- a/resources/templates/en/_templates/daily.md
+++ b/resources/templates/en/_templates/daily.md
@@ -1,0 +1,17 @@
+---
+type: daily
+date: {{date}}
+---
+# {{date}}
+
+## Focus
+
+-
+
+## Log
+
+- {{time}} —
+
+## Tomorrow
+
+-

--- a/resources/templates/en/_templates/meeting-notes.md
+++ b/resources/templates/en/_templates/meeting-notes.md
@@ -1,0 +1,25 @@
+---
+type: meeting
+date: {{date}}
+attendees: []
+---
+# Meeting: {{title}}
+
+**Date:** {{date}} {{time}}
+**Attendees:**
+
+## Agenda
+
+1.
+
+## Notes
+
+-
+
+## Decisions
+
+-
+
+## Action items
+
+- [ ] Owner — task — due date

--- a/resources/templates/en/_templates/prd.md
+++ b/resources/templates/en/_templates/prd.md
@@ -1,0 +1,37 @@
+---
+type: prd
+status: draft
+owner:
+created: {{date}}
+---
+# PRD: {{title}}
+
+## Problem
+
+Who has the problem, how often, and what it costs them today.
+
+## Goals
+
+-
+
+## Non-goals
+
+-
+
+## Users and use cases
+
+-
+
+## Requirements
+
+| # | Requirement | Priority |
+|---|-------------|----------|
+| 1 |             | Must     |
+
+## Success metrics
+
+-
+
+## Open questions
+
+-

--- a/resources/templates/en/_templates/runbook.md
+++ b/resources/templates/en/_templates/runbook.md
@@ -1,0 +1,35 @@
+---
+type: runbook
+service:
+owner:
+last_reviewed: {{date}}
+---
+# Runbook: {{title}}
+
+## Purpose
+
+What this runbook covers and when to use it.
+
+## Prerequisites
+
+- Access required
+- Tools required
+
+## Steps
+
+1.
+2.
+3.
+
+## Verification
+
+How to confirm the procedure worked.
+
+## Rollback
+
+How to undo the change if something goes wrong.
+
+## Contacts
+
+- Primary on-call —
+- Escalation —

--- a/resources/templates/pt-BR/_templates/adr.md
+++ b/resources/templates/pt-BR/_templates/adr.md
@@ -1,0 +1,23 @@
+---
+type: adr
+status: proposto
+date: {{date}}
+---
+# ADR: {{title}}
+
+## Contexto
+
+Qual problema estamos vendo que motiva esta decisão ou mudança?
+
+## Decisão
+
+Qual mudança estamos propondo e/ou fazendo?
+
+## Consequências
+
+O que fica mais fácil ou mais difícil por causa desta mudança?
+
+## Alternativas consideradas
+
+- Opção A —
+- Opção B —

--- a/resources/templates/pt-BR/_templates/daily.md
+++ b/resources/templates/pt-BR/_templates/daily.md
@@ -1,0 +1,17 @@
+---
+type: daily
+date: {{date}}
+---
+# {{date}}
+
+## Foco
+
+-
+
+## Registro
+
+- {{time}} —
+
+## Amanhã
+
+-

--- a/resources/templates/pt-BR/_templates/meeting-notes.md
+++ b/resources/templates/pt-BR/_templates/meeting-notes.md
@@ -1,0 +1,25 @@
+---
+type: meeting
+date: {{date}}
+attendees: []
+---
+# Reunião: {{title}}
+
+**Data:** {{date}} {{time}}
+**Participantes:**
+
+## Pauta
+
+1.
+
+## Anotações
+
+-
+
+## Decisões
+
+-
+
+## Ações
+
+- [ ] Responsável — tarefa — prazo

--- a/resources/templates/pt-BR/_templates/prd.md
+++ b/resources/templates/pt-BR/_templates/prd.md
@@ -1,0 +1,37 @@
+---
+type: prd
+status: rascunho
+owner:
+created: {{date}}
+---
+# PRD: {{title}}
+
+## Problema
+
+Quem tem o problema, com que frequência e quanto isso custa hoje.
+
+## Objetivos
+
+-
+
+## Fora de escopo
+
+-
+
+## Usuários e casos de uso
+
+-
+
+## Requisitos
+
+| # | Requisito | Prioridade |
+|---|-----------|------------|
+| 1 |           | Obrigatório |
+
+## Métricas de sucesso
+
+-
+
+## Questões abertas
+
+-

--- a/resources/templates/pt-BR/_templates/runbook.md
+++ b/resources/templates/pt-BR/_templates/runbook.md
@@ -1,0 +1,35 @@
+---
+type: runbook
+service:
+owner:
+last_reviewed: {{date}}
+---
+# Runbook: {{title}}
+
+## Objetivo
+
+O que este runbook cobre e quando usá-lo.
+
+## Pré-requisitos
+
+- Acessos necessários
+- Ferramentas necessárias
+
+## Passos
+
+1.
+2.
+3.
+
+## Verificação
+
+Como confirmar que o procedimento funcionou.
+
+## Reversão
+
+Como desfazer a mudança se algo der errado.
+
+## Contatos
+
+- Plantão principal —
+- Escalonamento —

--- a/resources/views/emails/layout.blade.php
+++ b/resources/views/emails/layout.blade.php
@@ -1,0 +1,52 @@
+@php
+    $brand = \App\Support\Branding::configured();
+    $appUrl = rtrim((string) config('app.url'), '/');
+    $footerLinks = array_filter([
+        trans('emails.footer.terms', [], $locale) => $brand->termsUrl,
+        trans('emails.footer.privacy', [], $locale) => $brand->privacyUrl,
+        trans('emails.footer.support', [], $locale) => $brand->supportUrl,
+    ]);
+@endphp
+<!doctype html>
+<html lang="{{ $locale }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $subject ?? $brand->name }}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f2;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#252525;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f2;padding:24px 0;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;background:#ffffff;border:1px solid #d9d7d3;border-radius:8px;">
+                    <tr>
+                        <td style="padding:20px 28px;border-bottom:1px solid #eeecea;font-weight:700;font-size:18px;">
+                            @if ($brand->logoUrl)
+                                <img src="{{ $brand->logoUrl }}" alt="{{ $brand->name }}" height="28" style="height:28px;vertical-align:middle;">
+                            @else
+                                {{ $brand->name }}
+                            @endif
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px 28px;font-size:15px;line-height:1.55;">
+                            {{ $slot }}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 28px;border-top:1px solid #eeecea;font-size:12px;line-height:1.6;color:#5f5f5f;">
+                            <a href="{{ $appUrl }}" style="color:#5f5f5f;">{{ $appUrl }}</a>
+                            @foreach ($footerLinks as $label => $href)
+                                &nbsp;·&nbsp;<a href="{{ $href }}" style="color:#5f5f5f;">{{ $label }}</a>
+                            @endforeach
+                            @if ($brand->poweredBy)
+                                <br><a href="{{ \App\Support\Branding::REPOSITORY_URL }}" style="color:#5f5f5f;">{{ trans('emails.footer.powered_by', [], $locale) }}</a>
+                            @endif
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/notifications/digest.blade.php
+++ b/resources/views/emails/notifications/digest.blade.php
@@ -1,13 +1,10 @@
-<!doctype html>
-<html lang="{{ $recipient->locale }}">
-<body>
+<x-mail-layout :locale="$recipient->locale ?? 'en'" :subject="trans('messages.notification_digest_subject', [], $recipient->locale)">
     <p>{{ trans('messages.notification_email_greeting', ['name' => $recipient->name], $recipient->locale) }}</p>
-    <h1>{{ trans('messages.notification_digest_heading', [], $recipient->locale) }}</h1>
+    <h1 style="font-size:18px;margin:0 0 12px;">{{ trans('messages.notification_digest_heading', [], $recipient->locale) }}</h1>
     <ul>
         @foreach ($notifications as $notification)
             <li>{{ $notification->title }}</li>
         @endforeach
     </ul>
     <p><a href="{{ rtrim((string) config('app.url'), '/') }}/?notification-preferences=1">{{ trans('messages.notification_email_preferences', [], $recipient->locale) }}</a></p>
-</body>
-</html>
+</x-mail-layout>

--- a/resources/views/emails/notifications/event.blade.php
+++ b/resources/views/emails/notifications/event.blade.php
@@ -1,12 +1,9 @@
-<!doctype html>
-<html lang="{{ $notification->user?->locale ?? 'en' }}">
-<body>
+<x-mail-layout :locale="$recipient->locale ?? 'en'" :subject="trans('messages.notification_email_subject', ['title' => $notification->title], $recipient->locale)">
     <p>{{ trans('messages.notification_email_greeting', ['name' => $recipient->name], $recipient->locale) }}</p>
     <p>{{ $notification->title }}</p>
     @if (!empty($notification->data['comment_snippet']))
-        <blockquote>{{ $notification->data['comment_snippet'] }}</blockquote>
+        <blockquote style="margin:0 0 16px;padding:8px 14px;border-left:3px solid #d9d7d3;color:#5f5f5f;">{{ $notification->data['comment_snippet'] }}</blockquote>
     @endif
     <p><a href="{{ rtrim((string) config('app.url'), '/') }}">{{ trans('messages.notification_email_open', [], $recipient->locale) }}</a></p>
     <p><a href="{{ $unsubscribeUrl }}">{{ trans('messages.notification_email_unsubscribe', [], $recipient->locale) }}</a></p>
-</body>
-</html>
+</x-mail-layout>

--- a/resources/views/emails/password-reset.blade.php
+++ b/resources/views/emails/password-reset.blade.php
@@ -1,0 +1,9 @@
+<x-mail-layout :locale="$locale" :subject="$subject">
+    <p>{{ trans('emails.greeting', ['name' => $recipient->name], $locale) }}</p>
+    <p>{{ trans('emails.password_reset.body', ['brand' => $brand->name], $locale) }}</p>
+    <p>
+        <a href="{{ $loginUrl }}" style="display:inline-block;padding:10px 18px;background:#1a6dc1;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">{{ trans('emails.password_reset.login_button', [], $locale) }}</a>
+    </p>
+    <p>{{ trans('emails.password_reset.warning', [], $locale) }}</p>
+    <p>{{ trans('emails.signoff', ['brand' => $brand->name], $locale) }}</p>
+</x-mail-layout>

--- a/resources/views/emails/trial-ended.blade.php
+++ b/resources/views/emails/trial-ended.blade.php
@@ -1,0 +1,9 @@
+<x-mail-layout :locale="$locale" :subject="$subject">
+    <p>{{ trans('emails.greeting', ['name' => $recipient->name], $locale) }}</p>
+    <p>{{ trans('emails.trial_ended.body', ['brand' => $brand->name, 'tenant' => $tenant->name], $locale) }}</p>
+    <p>{{ trans('emails.trial_ended.read_only', [], $locale) }}</p>
+    @if ($brand->supportUrl)
+        <p><a href="{{ $brand->supportUrl }}">{{ trans('emails.trial_ended.contact', [], $locale) }}</a></p>
+    @endif
+    <p>{{ trans('emails.signoff', ['brand' => $brand->name], $locale) }}</p>
+</x-mail-layout>

--- a/resources/views/emails/trial-reminder.blade.php
+++ b/resources/views/emails/trial-reminder.blade.php
@@ -1,0 +1,9 @@
+<x-mail-layout :locale="$locale" :subject="$subject">
+    <p>{{ trans('emails.greeting', ['name' => $recipient->name], $locale) }}</p>
+    <p>{{ trans_choice('emails.trial_reminder.body', $daysLeft, ['brand' => $brand->name, 'tenant' => $tenant->name, 'days' => $daysLeft, 'date' => $endsAt], $locale) }}</p>
+    <p>{{ trans('emails.trial_reminder.what_happens', [], $locale) }}</p>
+    @if ($brand->supportUrl)
+        <p><a href="{{ $brand->supportUrl }}">{{ trans('emails.trial_reminder.contact', [], $locale) }}</a></p>
+    @endif
+    <p>{{ trans('emails.signoff', ['brand' => $brand->name], $locale) }}</p>
+</x-mail-layout>

--- a/resources/views/emails/welcome.blade.php
+++ b/resources/views/emails/welcome.blade.php
@@ -1,0 +1,16 @@
+<x-mail-layout :locale="$locale" :subject="$subject">
+    <p>{{ trans('emails.greeting', ['name' => $recipient->name], $locale) }}</p>
+    <p>{{ trans('emails.welcome.intro', ['brand' => $brand->name, 'workspace' => $workspace->name], $locale) }}</p>
+    <p>
+        <a href="{{ $loginUrl }}" style="display:inline-block;padding:10px 18px;background:#1a6dc1;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">{{ trans('emails.welcome.login_button', [], $locale) }}</a>
+    </p>
+    <p>{{ trans('emails.welcome.credentials', ['email' => $recipient->email], $locale) }}</p>
+    <ul>
+        <li>{{ trans('emails.welcome.webdav', [], $locale) }} <a href="{{ $webdavUrl }}">{{ $webdavUrl }}</a></li>
+        <li>{{ trans('emails.welcome.mcp', [], $locale) }} <a href="{{ $mcpGuideUrl }}">{{ trans('emails.welcome.mcp_guide', [], $locale) }}</a></li>
+    </ul>
+    @if ($trialDays !== null)
+        <p>{{ trans_choice('emails.welcome.trial', $trialDays, ['days' => $trialDays], $locale) }}</p>
+    @endif
+    <p>{{ trans('emails.signoff', ['brand' => $brand->name], $locale) }}</p>
+</x-mail-layout>

--- a/routes/console.php
+++ b/routes/console.php
@@ -43,6 +43,15 @@ Schedule::command('vault:purge-trash')->dailyAt('02:00')->withoutOverlapping(60)
 Schedule::command('vault:prune-revisions', ['--days=30'])->dailyAt('02:15')->withoutOverlapping(60);
 Schedule::command('audit:prune', ['--days=90'])->dailyAt('02:30')->withoutOverlapping(60);
 
-// Hosted mode only: trials past their deadline become read_only (audited). A
+// Hosted mode only: trial reminders (3 days before), then trials past their
+// deadline become read_only (audited) and owners are e-mailed once. A
 // self-hosted installation has no trial tenants, so this is a no-op there.
 Schedule::command('tenant:expire-trials')->dailyAt('03:00')->withoutOverlapping(60);
+
+// Mail is sent synchronously. If an operator opts into QUEUE_CONNECTION=database
+// anyway, drain it from cron: no daemon, exits as soon as the queue is empty.
+if (config('queue.default') === 'database') {
+    Schedule::command('queue:work', ['--stop-when-empty', '--max-time=50', '--tries=3'])
+        ->everyMinute()
+        ->withoutOverlapping(5);
+}

--- a/tests/Feature/JotterDoctorCommandTest.php
+++ b/tests/Feature/JotterDoctorCommandTest.php
@@ -38,6 +38,7 @@ final class JotterDoctorCommandTest extends TestCase
             'app.key' => 'base64:'.base64_encode(random_bytes(32)),
             'app.url' => 'https://client-a.example.com',
             'mail.default' => 'smtp',
+            'mail.from.address' => 'no-reply@client-a.example.com',
             'vault.base_path' => $this->vault,
             'jotter.instance_slug' => 'client-a',
         ]);
@@ -117,6 +118,8 @@ final class JotterDoctorCommandTest extends TestCase
         $byId = array_column($report['checks'], null, 'id');
 
         $this->assertSame('warn', $byId['mail_mailer']['status']);
+        config(['mail.from.address' => 'hello@example.com']);
+        $this->assertSame('warn', array_column(app(InstanceDoctor::class)->run()->toArray()['checks'], null, 'id')['mail_from']['status']);
         $this->assertSame('fail', $byId['scheduler']['status']);
         $this->assertSame('fail', $report['status']);
     }

--- a/tests/Feature/TemplatePackTest.php
+++ b/tests/Feature/TemplatePackTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Provisioning\TemplatePack;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class TemplatePackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $scratch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->scratch = storage_path('framework/testing/templates-'.uniqid());
+        File::ensureDirectoryExists($this->scratch.'/vault');
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->scratch);
+
+        parent::tearDown();
+    }
+
+    public function test_pack_ships_the_five_templates_in_both_locales(): void
+    {
+        $pack = app(TemplatePack::class);
+
+        foreach (['en', 'pt-BR'] as $locale) {
+            $files = $pack->files($locale);
+            $this->assertSame(
+                ['_templates/adr.md', '_templates/daily.md', '_templates/meeting-notes.md', '_templates/prd.md', '_templates/runbook.md'],
+                array_keys($files),
+                $locale,
+            );
+            foreach ($files as $contents) {
+                $this->assertStringContainsString('{{date}}', $contents);
+            }
+        }
+        $this->assertStringContainsString('# Runbook:', $pack->files('en')['_templates/runbook.md']);
+        $this->assertStringContainsString('## Objetivo', $pack->files('pt-BR')['_templates/runbook.md']);
+        $this->assertSame('en', TemplatePack::normalizeLocale('fr'));
+    }
+
+    public function test_pack_zip_is_importable_through_the_workspace_import_endpoint(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+        $workspace = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'docs', 'name' => 'Docs', 'vault_path' => $this->scratch.'/vault']);
+
+        $this->artisan('templates:pack', ['--locale' => 'pt-BR', '--to' => $this->scratch.'/templates.zip'])
+            ->expectsOutputToContain('Template pack (pt-BR, 5 files)')
+            ->assertSuccessful();
+
+        $response = $this->actingAs($admin)->post("/api/workspaces/{$workspace->id}/import", [
+            'archive' => new UploadedFile($this->scratch.'/templates.zip', 'templates.zip', 'application/zip', null, true),
+        ]);
+
+        $response->assertOk()->assertJsonPath('extracted_count', 5);
+        $this->assertFileExists($this->scratch.'/vault/_templates/prd.md');
+        $this->assertSame(5, Note::query()->where('workspace_id', $workspace->id)->where('path', 'like', '_templates/%')->count());
+    }
+
+    public function test_install_does_not_overwrite_customized_templates(): void
+    {
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+        $workspace = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'docs', 'name' => 'Docs', 'vault_path' => $this->scratch.'/vault']);
+        $pack = app(TemplatePack::class);
+
+        $this->assertCount(5, $pack->install($workspace, 'en'));
+        file_put_contents($this->scratch.'/vault/_templates/daily.md', "# Mine\n");
+
+        $this->assertSame([], $pack->install($workspace, 'en'));
+        $this->assertSame("# Mine\n", file_get_contents($this->scratch.'/vault/_templates/daily.md'));
+    }
+}

--- a/tests/Feature/TenantExportCommandTest.php
+++ b/tests/Feature/TenantExportCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Vault\VaultStorage;
+use App\Models\AuditLog;
+use App\Models\Membership;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+use ZipArchive;
+
+final class TenantExportCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $scratch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->scratch = storage_path('framework/testing/export-'.uniqid());
+        File::ensureDirectoryExists($this->scratch.'/vault/attachments');
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->scratch);
+
+        parent::tearDown();
+    }
+
+    public function test_export_produces_a_zip_with_vault_files_json_backup_and_manifest(): void
+    {
+        $tenant = Tenant::create(['slug' => 'acme', 'name' => 'Acme', 'plan_status' => 'active', 'plan_seats' => 3]);
+        $workspace = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'docs', 'name' => 'Docs', 'vault_path' => $this->scratch.'/vault']);
+        $owner = User::factory()->create(['email' => 'owner@acme.example']);
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => (string) $owner->id, 'role' => 'owner']);
+        app(VaultStorage::class)->write($workspace, 'readme.md', "# Readme\n");
+        app(VaultStorage::class)->write($workspace, 'guides/setup.md', "# Setup\n");
+        file_put_contents($this->scratch.'/vault/attachments/logo.png', 'png-bytes');
+
+        $to = $this->scratch.'/out/acme.zip';
+        $this->assertSame(0, Artisan::call('tenant:export', ['slug' => 'acme', '--to' => $to, '--json' => true]));
+        $summary = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('acme', $summary['tenant']);
+        $this->assertSame(1, $summary['workspaces']);
+        $this->assertFileExists($to);
+
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($to));
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $names[] = $zip->getNameIndex($i);
+        }
+        $this->assertContains('workspaces/docs/vault/readme.md', $names);
+        $this->assertContains('workspaces/docs/vault/guides/setup.md', $names);
+        $this->assertContains('workspaces/docs/vault/attachments/logo.png', $names);
+        $this->assertContains('workspaces/docs/backup.json', $names);
+        $this->assertContains('tenant.json', $names);
+
+        $backup = json_decode((string) $zip->getFromName('workspaces/docs/backup.json'), true);
+        $this->assertSame('1.0', $backup['version']);
+        $this->assertSame('docs', $backup['workspace_slug']);
+        $this->assertSame(['guides/setup.md', 'readme.md'], array_column($backup['notes'], 'path'));
+
+        $manifest = json_decode((string) $zip->getFromName('tenant.json'), true);
+        $this->assertSame('acme', $manifest['tenant']['slug']);
+        $this->assertSame('active', $manifest['tenant']['plan']['status']);
+        $this->assertSame('owner@acme.example', $manifest['users'][0]['email']);
+        $this->assertSame('owner', $manifest['memberships'][0]['role']);
+        $zip->close();
+
+        $this->assertSame(1, AuditLog::query()->where('event', 'tenant.exported')->where('tenant_id', $tenant->id)->count());
+    }
+
+    public function test_export_refuses_unknown_tenants_and_the_document_root(): void
+    {
+        $this->artisan('tenant:export', ['slug' => 'missing'])->assertFailed();
+
+        Tenant::create(['slug' => 'acme', 'name' => 'Acme']);
+        $this->artisan('tenant:export', ['slug' => 'acme', '--to' => public_path('acme.zip')])
+            ->expectsOutputToContain('Refusing to write the export under the document root.')
+            ->assertFailed();
+        $this->assertFileDoesNotExist(public_path('acme.zip'));
+    }
+}

--- a/tests/Feature/TenantProvisionCommandTest.php
+++ b/tests/Feature/TenantProvisionCommandTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\WelcomeEmail;
+use App\Models\AuditLog;
+use App\Models\Membership;
+use App\Models\Note;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class TenantProvisionCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $vaultBase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultBase = storage_path('framework/testing/provision-'.uniqid());
+        File::ensureDirectoryExists($this->vaultBase);
+        config(['vault.base_path' => $this->vaultBase, 'mail.default' => 'array', 'mail.from.address' => 'no-reply@acme.example', 'app.url' => 'https://acme.example.com']);
+        Mail::fake();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->vaultBase);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function provisionOptions(array $overrides = []): array
+    {
+        return array_merge([
+            '--tenant-name' => 'Acme Ltda',
+            '--tenant-slug' => 'acme',
+            '--workspace-name' => 'Acme Docs',
+            '--workspace-slug' => 'acme-docs',
+            '--admin-email' => 'Owner@Acme.example',
+            '--admin-name' => 'Ana Owner',
+            '--trial-days' => '14',
+            '--seats' => '5',
+            '--locale' => 'pt-BR',
+            '--json' => true,
+        ], $overrides);
+    }
+
+    /**
+     * The provisioner calls `platform:bootstrap-admin` through Artisan, which
+     * replaces Artisan::output()'s buffer; capture the outer output explicitly.
+     *
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private function runProvision(array $options): array
+    {
+        $output = new BufferedOutput;
+        $this->assertSame(0, Artisan::call('tenant:provision', $options, $output));
+
+        return json_decode($output->fetch(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function test_provision_creates_everything_and_prints_the_password_once(): void
+    {
+        $report = $this->runProvision($this->provisionOptions());
+
+        $tenant = Tenant::query()->where('slug', 'acme')->firstOrFail();
+        $this->assertSame('trial', $tenant->plan_status);
+        $this->assertSame(5, $tenant->plan_seats);
+        $this->assertTrue($tenant->trial_ends_at->between(now()->addDays(13), now()->addDays(15)));
+
+        $workspace = Workspace::query()->where('tenant_id', $tenant->id)->firstOrFail();
+        $this->assertSame('acme-docs', $workspace->slug);
+        $this->assertSame(realpath($this->vaultBase.'/acme-docs'), realpath($workspace->vault_path));
+        $this->assertDirectoryExists($this->vaultBase.'/acme-docs/_templates');
+
+        $admin = User::query()->where('email', 'owner@acme.example')->firstOrFail();
+        $this->assertTrue($admin->is_admin);
+        $this->assertSame('Ana Owner', $admin->name);
+        $this->assertSame('pt-BR', $admin->locale);
+        $this->assertTrue(Membership::query()->where('tenant_id', $tenant->id)->where('subject_id', (string) $admin->id)->where('role', 'owner')->exists());
+
+        // Templates installed in the requested locale and projected as notes.
+        $this->assertCount(5, $report['templates_installed']);
+        $this->assertContains('_templates/adr.md', $report['templates_installed']);
+        $this->assertSame(5, Note::query()->where('workspace_id', $workspace->id)->where('path', 'like', '_templates/%')->count());
+        $this->assertStringContainsString('## Contexto', (string) file_get_contents($workspace->vault_path.'/_templates/adr.md'));
+
+        // Password: strong, valid, present in the report, absent from audit and logs.
+        $password = $report['admin']['password'];
+        $this->assertIsString($password);
+        $this->assertGreaterThanOrEqual(20, strlen($password));
+        $this->assertTrue(Hash::check($password, $admin->fresh()->password));
+        $this->assertSame(1, AuditLog::query()->where('event', 'tenant.provisioned')->count());
+        $this->assertStringNotContainsString($password, json_encode(AuditLog::query()->get()->toArray()));
+
+        $this->assertSame('https://acme.example.com/api/webdav/'.$workspace->id, $report['urls']['webdav']);
+        $this->assertTrue($report['welcome_email']['sent']);
+        Mail::assertSent(WelcomeEmail::class, function (WelcomeEmail $mail) use ($password): bool {
+            $html = $mail->render();
+
+            return $mail->hasTo('owner@acme.example')
+                && $mail->locale === 'pt-BR'
+                && str_contains($html, 'Bem-vindo')
+                && str_contains($html, 'Guia do MCP')
+                && ! str_contains($html, $password);
+        });
+    }
+
+    public function test_provision_is_not_repeated_for_an_existing_tenant(): void
+    {
+        Tenant::create(['slug' => 'acme', 'name' => 'Existing']);
+
+        $this->artisan('tenant:provision', $this->provisionOptions(['--json' => false]))
+            ->expectsOutputToContain('Tenant [acme] already exists.')
+            ->assertExitCode(2);
+
+        $this->assertSame(0, Workspace::query()->count());
+        $this->assertSame(0, User::query()->count());
+        $this->assertDirectoryDoesNotExist($this->vaultBase.'/acme-docs');
+        Mail::assertNothingSent();
+    }
+
+    public function test_provision_reuses_an_existing_admin_without_touching_the_password(): void
+    {
+        $existing = User::factory()->create(['email' => 'owner@acme.example', 'password' => Hash::make('keep-this-password'), 'locale' => 'en']);
+
+        $report = $this->runProvision($this->provisionOptions(['--locale' => 'en']));
+
+        $this->assertFalse($report['admin']['created']);
+        $this->assertNull($report['admin']['password']);
+        $this->assertTrue(Hash::check('keep-this-password', $existing->fresh()->password));
+        $this->assertTrue(Membership::query()->where('subject_id', (string) $existing->id)->where('role', 'owner')->exists());
+        $this->assertStringContainsString('## Context', (string) file_get_contents(Workspace::query()->firstOrFail()->vault_path.'/_templates/adr.md'));
+    }
+
+    public function test_provision_validates_input_and_requires_every_identity_option(): void
+    {
+        $this->artisan('tenant:provision', ['--tenant-name' => 'Acme'])->expectsOutputToContain('--tenant-slug is required.')->assertFailed();
+        $this->artisan('tenant:provision', $this->provisionOptions(['--admin-email' => 'not-an-email', '--json' => false]))->assertFailed();
+
+        $this->assertSame(0, Tenant::query()->count());
+    }
+
+    public function test_provision_without_trial_creates_an_active_tenant_and_can_skip_the_welcome_email(): void
+    {
+        $report = $this->runProvision($this->provisionOptions(['--trial-days' => '0', '--seats' => '0', '--no-welcome-email' => true]));
+
+        $this->assertSame('active', $report['plan']['status']);
+        $this->assertNull($report['plan']['trial_ends_at']);
+        $this->assertNull($report['plan']['seats']);
+        $this->assertFalse($report['welcome_email']['sent']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_provision_reports_a_missing_sender_instead_of_failing(): void
+    {
+        config(['mail.from.address' => '']);
+
+        $report = $this->runProvision($this->provisionOptions());
+
+        $this->assertFalse($report['welcome_email']['sent']);
+        $this->assertStringContainsString('MAIL_FROM_ADDRESS is not set', $report['welcome_email']['error']);
+        $this->assertSame(1, Tenant::query()->count());
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Feature/TransactionalEmailTest.php
+++ b/tests/Feature/TransactionalEmailTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\PasswordResetEmail;
+use App\Mail\TrialEndedEmail;
+use App\Mail\TrialReminderEmail;
+use App\Mail\WelcomeEmail;
+use App\Models\Membership;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+final class TransactionalEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['mail.default' => 'array', 'app.url' => 'https://acme.example.com']);
+        Mail::fake();
+    }
+
+    /**
+     * @return array{0: Tenant, 1: Workspace, 2: User}
+     */
+    private function tenantWithOwner(array $plan, string $locale = 'en'): array
+    {
+        $tenant = Tenant::create(array_merge(['slug' => 'acme-'.uniqid(), 'name' => 'Acme'], $plan));
+        $workspace = Workspace::create(['tenant_id' => $tenant->id, 'slug' => 'docs-'.uniqid(), 'name' => 'Docs', 'vault_path' => storage_path('app/vaults/mail-'.uniqid())]);
+        $owner = User::factory()->create(['locale' => $locale]);
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => (string) $owner->id, 'role' => 'owner']);
+        $viewer = User::factory()->create();
+        Membership::create(['tenant_id' => $tenant->id, 'workspace_id' => $workspace->id, 'subject_id' => (string) $viewer->id, 'role' => 'viewer']);
+
+        return [$tenant, $workspace, $owner];
+    }
+
+    public function test_admin_password_reset_emails_the_user_without_the_password(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $user = User::factory()->create(['locale' => 'pt-BR']);
+
+        $this->actingAs($admin)
+            ->postJson("/api/admin/users/{$user->id}/reset-password", ['new_password' => 'Brand-new-secret-99'])
+            ->assertOk();
+
+        Mail::assertSent(PasswordResetEmail::class, function (PasswordResetEmail $mail) use ($user): bool {
+            $html = $mail->render();
+
+            return $mail->hasTo($user->email)
+                && $mail->locale === 'pt-BR'
+                && str_contains($html, 'redefinida')
+                && ! str_contains($html, 'Brand-new-secret-99');
+        });
+    }
+
+    public function test_admin_password_reset_skips_mail_with_the_log_mailer(): void
+    {
+        config(['mail.default' => 'log']);
+        $admin = User::factory()->create(['is_admin' => true]);
+        $user = User::factory()->create();
+
+        $this->actingAs($admin)->postJson("/api/admin/users/{$user->id}/reset-password", ['new_password' => 'Brand-new-secret-99'])->assertOk();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_trial_reminder_goes_to_owners_three_days_before_the_end_only_once(): void
+    {
+        [$tenant, , $owner] = $this->tenantWithOwner(['plan_status' => 'trial', 'trial_ends_at' => now()->addDays(2)->addHour()], 'pt-BR');
+        $this->tenantWithOwner(['plan_status' => 'trial', 'trial_ends_at' => now()->addDays(10)]);
+        $this->tenantWithOwner(['plan_status' => 'active']);
+
+        $this->artisan('tenant:expire-trials')->expectsOutputToContain('Reminded 1 trial(s): '.$tenant->slug)->assertSuccessful();
+
+        Mail::assertSent(TrialReminderEmail::class, 1);
+        Mail::assertSent(TrialReminderEmail::class, function (TrialReminderEmail $mail) use ($owner): bool {
+            $html = $mail->render();
+
+            return $mail->hasTo($owner->email) && $mail->daysLeft === 3 && str_contains($html, 'termina em 3 dias');
+        });
+        $this->assertNotNull($tenant->fresh()->trial_reminder_sent_at);
+
+        $this->artisan('tenant:expire-trials')->expectsOutputToContain('Reminded 0 trial(s).')->assertSuccessful();
+        Mail::assertSent(TrialReminderEmail::class, 1);
+    }
+
+    public function test_trial_end_moves_to_read_only_and_emails_owners_once(): void
+    {
+        [$tenant, , $owner] = $this->tenantWithOwner(['plan_status' => 'trial', 'trial_ends_at' => now()->subMinute()]);
+
+        $this->artisan('tenant:expire-trials')
+            ->expectsOutputToContain('Expired 1 trial(s): '.$tenant->slug)
+            ->expectsOutputToContain('Notified 1 trial(s) ended.')
+            ->assertSuccessful();
+
+        $this->assertSame('read_only', $tenant->fresh()->plan_status);
+        $this->assertNotNull($tenant->fresh()->trial_ended_notified_at);
+        Mail::assertSent(TrialEndedEmail::class, function (TrialEndedEmail $mail) use ($owner): bool {
+            return $mail->hasTo($owner->email) && str_contains($mail->render(), 'read-only');
+        });
+        Mail::assertSent(TrialEndedEmail::class, 1);
+
+        $this->artisan('tenant:expire-trials')->expectsOutputToContain('Notified 0 trial(s) ended.')->assertSuccessful();
+        Mail::assertSent(TrialEndedEmail::class, 1);
+    }
+
+    public function test_mailables_render_with_operator_branding_in_both_locales(): void
+    {
+        config(['jotter.brand' => ['name' => 'Cadernia', 'support_url' => 'https://cadernia.example.com/support', 'powered_by' => true]]);
+        [$tenant, $workspace] = $this->tenantWithOwner(['plan_status' => 'trial', 'trial_ends_at' => now()->addDays(14)]);
+
+        $en = (new WelcomeEmail(User::factory()->create(['locale' => 'en']), $workspace, 14))->render();
+        $this->assertStringContainsString('Welcome to Cadernia', $en);
+        $this->assertStringContainsString('Your trial lasts 14 days', $en);
+        $this->assertStringContainsString(WelcomeEmail::MCP_GUIDE_URL, $en);
+        $this->assertStringContainsString('Powered by Jotter', $en);
+
+        $pt = (new TrialEndedEmail(User::factory()->create(['locale' => 'pt-BR']), $tenant))->render();
+        $this->assertStringContainsString('terminou', $pt);
+        $this->assertStringContainsString('https://cadernia.example.com/support', $pt);
+
+        $fallback = new PasswordResetEmail(User::factory()->create(['locale' => 'de']));
+        $this->assertSame('en', $fallback->locale);
+    }
+}


### PR DESCRIPTION
## Summary

A new hosted installation is customer-ready with one SSH command, and e-mails leave for real — synchronously, with no queue worker. Runbook: `docs/hosted-operations.md`.

1. **`tenant:provision`** `--tenant-name --tenant-slug --workspace-name --workspace-slug --admin-email --admin-name --trial-days=14 --seats=5 --locale=pt-BR [--no-welcome-email] [--json]` — tenant, workspace with vault at `VAULT_BASE_PATH/<workspace-slug>` (validated by `VaultRootGuard`), owner admin created through the existing `platform:bootstrap-admin` with a random 20-char password (`Str::password`), owner membership, trial plan, starter templates, welcome e-mail. Prints URLs (app, login, WebDAV, MCP, health) and the password **once**; the password is never stored in clear text, logged, or audited (`tenant.provisioned` carries only ids/e-mail/flags; the audit redactor also strips `password` keys). Idempotent: existing tenant → clear message, **exit code 2**, nothing created (an empty vault dir created before the failure is removed). Existing user with the same e-mail is reused as owner with its password untouched. DB work runs in a transaction.
2. **E-mail** — `.env.example` documents SMTP for Resend/Postmark (`MAIL_SCHEME` `smtps`/`smtp`, per `config/mail.php`). `x-mail-layout` (brand name/logo, footer links, powered-by) shared by `WelcomeEmail` (login, WebDAV URL, MCP guide link, trial length), `PasswordResetEmail` (wired into `AdminUserController::resetPassword`, no password inside, skipped with the `log` mailer), `TrialReminderEmail` (3 days before) and `TrialEndedEmail` (on expiry) — both sent by the daily `tenant:expire-trials`, at most once per tenant (`trial_reminder_sent_at`, `trial_ended_notified_at`). Existing notification e-mails now use the same layout. i18n en/pt-BR in `lang/*/emails.php`. Synchronous by default; if `QUEUE_CONNECTION=database`, the scheduler registers `queue:work --stop-when-empty --max-time=50` every minute. `jotter:doctor` gained a `MAIL_FROM_ADDRESS` warning.
3. **`tenant:export {slug} --to=<path> [--json]`** — one ZIP: `workspaces/<slug>/vault/**` (notes, attachments, `_templates`), `workspaces/<slug>/backup.json` (same document as `GET /api/workspaces/{id}/export?format=json`, via the new shared `WorkspaceJsonBackup`), and `tenant.json` (tenant, plan, workspaces, memberships, users). Refuses paths under the document root. Audited as `tenant.exported`.
4. **Starter templates** — `resources/templates/{en,pt-BR}/_templates/{adr,meeting-notes,daily,runbook,prd}.md` using `TemplateEngine` placeholders; installed by provisioning (never overwriting customized files) and packaged by `templates:pack --locale --to` as a ZIP the import endpoint accepts (covered by test).
5. **Docs** — `docs/hosted-operations.md` (provision, change plan, export, remove — including the `audit_log` `ON DELETE RESTRICT` caveat found during the smoke run — templates, health), `CHANGELOG.md`, `STATUS.md`, `docs/deployment.md`. No new dependency (`docs/decisions.md` unchanged).

## Verification

- `./scripts/jt.sh test` — 413 PHP tests passed (1867 assertions), 77 Vitest files passed. Tests use `Mail::fake()`; `MAIL_MAILER` is `array`/`log` in tests.
- Smoke run against the dev container (then cleaned up), password redacted here:

```text
$ php artisan tenant:provision --tenant-name="Smoke Ltda" --tenant-slug=smoke --workspace-name="Smoke Docs" --workspace-slug=smoke-docs --admin-email=owner@smoke.example --admin-name="Smoke Owner" --trial-days=14 --seats=5 --locale=pt-BR
Tenant smoke (Smoke Ltda) provisioned.
  workspace        smoke-docs (id 2) — vault /var/www/html/storage/app/vaults/smoke-docs
  plan             trial / 2026-09-14
  seats            5
  templates        5 installed
  app              http://localhost:8080/
  login            http://localhost:8080/
  webdav           http://localhost:8080/api/webdav/2
  mcp              http://localhost:8080/api/mcp
  health           http://localhost:8080/api/health

  admin            owner@smoke.example (created)
  password         <redacted>
  Shown once. It is not stored in clear text, logged, or audited. Hand it over securely.
  welcome e-mail failed: An email must have a "From" or a "Sender" header.

$ php artisan tenant:provision ... (same slug again)
Tenant [smoke] already exists. Provisioning is not repeated; use tenant:plan / tenant:show to manage it.

exit code: 2

$ php artisan tenant:show smoke
Tenant smoke — Smoke Ltda (id 2)
  status           trial
  name             trial
  seats            5
  trial_ends_at    2026-09-14T14:48:42+00:00
  trial_days_left  14
  read_only        false
  seats_used       1
  workspaces       1
    - Smoke Docs (smoke-docs, id 2)

$ php artisan tenant:export smoke --to=storage/app/private/exports/smoke.zip
Exported tenant smoke: 1 workspace(s), 7 file(s), 3.5 KiB.
  storage/app/private/exports/smoke.zip
```

The welcome-e-mail failure in that run is the dev `.env` without `MAIL_FROM_ADDRESS`; it is now reported as a skipped step (`MAIL_FROM_ADDRESS is not set; configure the sender and re-send manually.`) rather than an exception, and the doctor warns about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
