### PR TITLE
Record the v0.10.0 release in STATUS and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Jotter will be documented here. Decision records live in `docs/decisions.md`; security-audit findings live in `docs/security-audit-2026.md`; visual-identity rollout tracking lives in `docs/visual-identity.md`. Split from a single overloaded `BACKLOG.md` in #208.
 
+## v0.10.0 — 2026-08-31
+
+Tagged release: [v0.10.0](https://github.com/suporterfid/jotter/releases/tag/v0.10.0), built with `jt release` as `jotter-release-v0.10.0.zip` (+ `.sha256`, attached to the GitHub Release; `VERSION` inside the artifact reads `v0.10.0`). Packages the four 2026-08-31 deliveries below — multi-instance release + installation doctor (#391), branding by environment + hosted-mode plan/trial (#392), CLI provisioning + transactional e-mail (#394), and the MCP client path with migration guides and the demo vault (#395) — plus the design-token guard fix (#393).
+
 ## v1 (post-v0) — 2026-08-31: MCP client guides, migration guides, demo vault, README
 
 Connecting Claude Code, Cursor, and Claude Desktop to a vault is now a documented, tested five-minute path (`docs/mcp-clients`).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Jotter — Project Status
 
-- **Current Version:** v0.9.0 (v0 spec contracts complete; v1 work in progress)
-- **Last Updated:** 2026-08-20 (#388 revision comparison delivered; #51 version history remains complete; no open Confluence-parity issues remain)
+- **Current Version:** [v0.10.0](https://github.com/suporterfid/jotter/releases/tag/v0.10.0) (tagged 2026-08-31; release ZIP + checksum attached to the GitHub Release)
+- **Last Updated:** 2026-08-31 (v0.10.0 released: #391 doctor/health, #392 branding + plan/trial, #394 provisioning + mail, #395 MCP client path + migrations + demo, #393 token-guard fix — see §1.2–§1.5 and CHANGELOG.md)
 - **Repo:** https://github.com/suporterfid/jotter
 - **Production Site:** https://hub.taskconnect.com.br/
 - **#388 — Revision comparison:** delivered an ACL-protected revision/current line-diff endpoint, bounded in-memory diffing, HistoryPanel source/target selectors, semantic added/removed/context rows, and regression coverage. Restore remains an independent write action.


### PR DESCRIPTION
Doc-only: CHANGELOG gains a `v0.10.0 — 2026-08-31` section tying the tag/GitHub Release to the four 2026-08-31 deliveries (#391, #392, #394, #395, plus #393); STATUS.md header bumps Current Version to v0.10.0 and refreshes Last Updated. `main` is branch-protected, so even doc updates go through a PR with a green `test` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)